### PR TITLE
Added exception cases for empty keyrings

### DIFF
--- a/include/netpgp.h
+++ b/include/netpgp.h
@@ -47,6 +47,12 @@ typedef struct netpgp_t {
 	unsigned	  size;		/* size of array */
 	char		**name;		/* key names */
 	char		**value;	/* value information */
+
+/* TODO: We should review whether or not these need to be void. By
+ *       adding some of these types to a public interface documented
+ *       as "private" we get to keep strong type checking.
+ */
+
 	void		 *pubring;	/* public key ring */
 	void		 *secring;	/* s3kr1t key ring */
 	void		 *io;		/* the io struct for results/errs */


### PR DESCRIPTION
The cause of the --homedir bug was empty private keyrings being generated due to a one of the bugs in netpgpkeys, and the loaded keyrings weren't size checked. Added exception cases to lib/netpgp.c:pgp_load_keys_gnupg and some notes regarding the netpgp_t context structure.