### PR TITLE
Updated the build shell scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 #
-# (c) 2017 Ribose Inc.
-#
+# Copyright (c) 2017 Ribose Inc.
+# build.sh
 
-[ ! -d m4 ] && \
-  mkdir m4
-autoreconf -ivf
-./configure
-make
+. build_main.inc.sh 

--- a/build_common.inc.sh
+++ b/build_common.inc.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Ribose Inc.
+# build_common.inc.sh
+
+rnpbuild_reconf() {
+
+	# Check that the ./m4/ directory exists.
+	if [ ! -e m4 ]; then
+		mkdir m4
+	elif [ -f m4 ]; then
+		echo "fatal: $(dirname $0)/m4 is not a directory. Please " \
+		     "move or delete it and try again."
+		return 1
+	fi
+
+	which autoreconf 2>&1 >/dev/null
+	if [ $? -ne 0 ]; then
+		echo "fatal: autoreconf not found. Hint: 'brew install" \
+		    "autoconf automake'"
+		return 1
+	fi
+
+	autoreconf -ivf
+}
+
+rnpbuild_configure() {
+	./configure $ACFLAGS
+}
+
+rnpbuild_main() {
+	if rnpbuild_reconf; then
+		if rnpbuild_configure; then
+			make
+		fi
+	fi
+}

--- a/build_main.inc.sh
+++ b/build_main.inc.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Ribose Inc.
+# build_main.inc.sh
+
+. build_common.inc.sh
+
+interactive() {
+	! echo $- | grep i >/dev/null
+}
+
+interactive && rnpbuild_main


### PR DESCRIPTION
I rolled the common parts of `build_macos.sh` into `build_common.inc.mk` to be used by `build.sh` as well and expanded on macOS-specific script. Following that pattern it should be easy to fork off new scripts for other targets.