### PR TITLE
Add some unit tests using cmocka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.loT
 *.o
 
+core.*
+vgcore.*
+
 # These artifacts can be removed by ./remove_artifacts.sh
 .deps
 .libs
@@ -41,6 +44,10 @@ src/rnpv/Makefile
 src/rnpv/Makefile.in
 src/rnpv/config.h
 src/rnpv/rnpv
+src/cmocka/Makefile
+src/cmocka/Makefile.in
+src/cmocka/config.h
+src/cmocka/rnp_tests
 tests/Makefile
 tests/Makefile.in
 tests/atconfig

--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,7 @@ AC_CHECK_TYPES([SHA256_CTX],
 
 # Checks for library functions.
 #
+AC_SEARCH_LIBS([_cmocka_run_group_tests], [cmocka])
 AC_SEARCH_LIBS([gzopen], [z])
 AC_SEARCH_LIBS([BZ2_bzDecompress], [bz2])
 AC_SEARCH_LIBS([RSA_public_encrypt], [crypto])
@@ -132,6 +133,7 @@ AC_CONFIG_FILES([
         src/rnp/Makefile
         src/rnpkeys/Makefile
         src/rnpv/Makefile
+        src/cmocka/Makefile
         tests/Makefile
         tests/atlocal
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,3 @@
 ## $NetBSD: Makefile.am,v 1.7 2014/03/09 00:15:45 agc Exp $
 
-SUBDIRS = libmj lib rnp rnpkeys rnpv
+SUBDIRS = libmj lib rnp rnpkeys rnpv cmocka

--- a/src/cmocka/Makefile.am
+++ b/src/cmocka/Makefile.am
@@ -1,0 +1,10 @@
+
+AM_CFLAGS		= $(WARNCFLAGS)
+
+bin_PROGRAMS		= rnp_tests
+
+rnp_tests_SOURCES		= rnp_tests.c
+
+rnp_tests_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/libmj -I$(top_srcdir)/src/lib
+
+rnp_tests_LDADD		= ../lib/librnp.la ../libmj/libmj.la

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -103,6 +103,45 @@ static void hash_test_success(void **state)
 
 static void cipher_test_success(void **state)
 {
+   const uint8_t key[16] = { 0 };
+   uint8_t iv[16];
+   pgp_symm_alg_t alg = PGP_SA_AES_128;
+   pgp_crypt_t crypt;
+
+   uint8_t block[16] = { 0 };
+
+   assert_int_equal(1, pgp_crypt_any(&crypt, alg));
+
+   pgp_encrypt_init(&crypt);
+
+   memset(iv, 0x42, sizeof(iv));
+
+   crypt.set_crypt_key(&crypt, key);
+   crypt.block_encrypt(&crypt, block, block);
+
+   test_value_equal("AES ECB encrypt",
+                    "66E94BD4EF8A2C3B884CFA59CA342B2E",
+                    block, sizeof(block));
+
+   crypt.block_decrypt(&crypt, block, block);
+
+   test_value_equal("AES ECB decrypt",
+                    "00000000000000000000000000000000",
+                    block, sizeof(block));
+
+   crypt.set_iv(&crypt, iv);
+   crypt.cfb_encrypt(&crypt, block, block, 16);
+
+   test_value_equal("AES CFB encrypt",
+                    "BFDAA57CB812189713A950AD99478879",
+                    block, sizeof(block));
+
+   crypt.set_iv(&crypt, iv);
+   crypt.cfb_decrypt(&crypt, block, block, 16);
+   test_value_equal("AES CFB decrypt",
+                    "00000000000000000000000000000000",
+                    block, sizeof(block));
+
 }
 static void rsa_test_success(void **state)
 {

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -9,6 +9,8 @@
 #include <cmocka.h>
 
 #include <crypto.h>
+#include <keyring.h>
+#include <packet.h>
 #include <mj.h>
 
 // returns new string containing hex value
@@ -145,8 +147,25 @@ static void cipher_test_success(void **state)
 }
 static void rsa_test_success(void **state)
 {
+   #if 0
+   const uint8_t ptext[3] = { 'a', 'b', 'c' };
 
+   uint8_t ctext[1024/8];
+   uint8_t decrypted[1024/8];
+   int ctext_size, decrypted_size;
+   pgp_key_t* pgp_key;
 
+   pgp_key = pgp_rsa_new_key(1024, 65537, "userid", "AES-128");
+
+   ctext_size = pgp_rsa_public_encrypt(ctext, ptext, sizeof(ptext),
+                                       pgp_key->key.seckey.pubkey);
+
+   decrypted_size = pgp_rsa_private_decrypt(decrypted, ctext, ctext_size,
+                                            pgp_key->key.seckey,
+                                            pgp_key->key.seckey.pubkey);
+
+   assert_int_equal(decrypted_size, 1024/8);
+#endif
 
 }
 

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -1,0 +1,121 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <cmocka.h>
+
+#include <crypto.h>
+#include <mj.h>
+
+// returns new string containing hex value
+char* hex_encode(const uint8_t v[], size_t len)
+{
+   char* s;
+   size_t i;
+
+   s = malloc(2*len + 1);
+   if(s == NULL)
+      return NULL;
+
+   char hex_chars[] = "0123456789ABCDEF";
+
+   for (i = 0; i < len; ++i)
+   {
+      uint8_t b0 = 0x0F & (v[i] >> 4);
+      uint8_t b1 = 0x0F & (v[i]);
+      const char c1 = hex_chars[b0];
+      const char c2 = hex_chars[b1];
+      s[2*i] = c1;
+      s[2*i+1] = c2;
+   }
+   s[2*len] = 0;
+
+   return s;
+}
+
+int test_value_equal(const char* what,
+                     const char* expected_value,
+                     const uint8_t v[], size_t v_len)
+{
+   char* produced = hex_encode(v, v_len);
+
+   // fixme - expects expected_value is also uppercase
+   if(strcmp(produced, expected_value) != 0)
+   {
+      fprintf(stderr, "Bad value for %s expected %s got %s\n", what, expected_value, produced);
+      free(produced);
+      return 1;
+   }
+
+   free(produced);
+   return 0;
+}
+
+static void hash_test_success(void **state)
+{
+   pgp_hash_t hash;
+   uint8_t hash_output[PGP_MAX_HASH_SIZE];
+
+   const pgp_hash_alg_t hash_algs[] = {
+      PGP_HASH_MD5,
+      PGP_HASH_SHA1,
+      PGP_HASH_SHA256,
+      PGP_HASH_SHA384,
+      PGP_HASH_SHA512,
+      PGP_HASH_SHA224,
+      PGP_HASH_UNKNOWN
+   };
+
+   const uint8_t test_input[3] = { 'a', 'b', 'c' };
+   const char* hash_alg_expected_outputs[] = {
+      "900150983CD24FB0D6963F7D28E17F72",
+      "A9993E364706816ABA3E25717850C26C9CD0D89D",
+      "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD",
+      "CB00753F45A35E8BB5A03D699AC65007272C32AB0EDED1631A8B605A43FF5BED8086072BA1E7CC2358BAECA134C825A7",
+      "DDAF35A193617ABACC417349AE20413112E6FA4E89A97EA20A9EEEE64B55D39A2192992A274FC1A836BA3C23A3FEEBBD454D4423643CE80E2A9AC94FA54CA49F",
+      "23097D223405D8228642A477BDA255B32AADBCE4BDA0B3F7E36C9DA7"
+   };
+
+   for(int i = 0; hash_algs[i] != PGP_HASH_UNKNOWN; ++i)
+   {
+      unsigned hash_size = pgp_hash_size(hash_algs[i]);
+
+      //printf("Testing hash # %d size %d\n", i+1, hash_size);
+
+      assert_int_equal(hash_size*2, strlen(hash_alg_expected_outputs[i]));
+
+      assert_int_equal(1, pgp_hash_any(&hash, hash_algs[i]));
+
+      hash.init(&hash);
+      hash.add(&hash, test_input, 1);
+      hash.add(&hash, test_input + 1, sizeof(test_input) - 1);
+      hash.finish(&hash, hash_output);
+
+      test_value_equal(hash.name,
+                       hash_alg_expected_outputs[i],
+                       hash_output, hash_size);
+   }
+}
+
+static void cipher_test_success(void **state)
+{
+}
+static void rsa_test_success(void **state)
+{
+
+
+
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(hash_test_success),
+        cmocka_unit_test(cipher_test_success),
+        cmocka_unit_test(rsa_test_success),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Current tests digests, ciphers, RSA keygen and encrypt/decrypt, and ElGamal encrypt/decrypt. Uses the cmocka library https://cmocka.org/

I'm not sure if there is a better way to integrate this into the build. Right now if cmocka is not available the build will fail, probably instead the cmocka subdir should just be skipped in that case.