### PR TITLE
asprintf deprecation

### DIFF
--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -592,11 +592,7 @@ pgp_sprint_keydata(pgp_io_t *io, const pgp_keyring_t *keyring,
 	} else
 		expiration_notice[0] = '\0';
 
-	/* Allocate a buffer for UID notices. Currently this is enormous
-	 * and I'm not sure where the original size came from (an RFC I
-	 * hope), so this might be changed in the future. At least it's
-	 * heap allocated now.
-	 */
+	/* XXX: Why 128KiB? */
 	uid_notices = (char *) malloc(KB(128));
 	if (uid_notices == NULL)
 		return -1;
@@ -627,9 +623,12 @@ pgp_sprint_keydata(pgp_io_t *io, const pgp_keyring_t *keyring,
 
 	ptimestr(birthtime, sizeof(birthtime), pubkey->birthtime);
 
-	/* Allocate a stupidly enormous string for the result until the
-	 * expected size can be guestimated.
+	/* XXX: For now we assume that the output string won't exceed 16KiB
+	 *      in length but this is completely arbitrary. What this
+	 *      really needs is some objective facts to base this
+	 *      size on.
 	 */
+
 	total_length = -1;
 	string = (char *) malloc(KB(16));
 	if (string != NULL) {

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -749,7 +749,7 @@ pgp_hkp_sprint_keydata(pgp_io_t *io, const pgp_keyring_t *keyring,
 	unsigned	 	 j;
 	char			 keyid[PGP_KEY_ID_SIZE * 3];
 	char		 	 uidbuf[KB(128)];
-	char		 	 fp[(PGP_FINGERPRINT_SIZE * 3) + 1];
+	char		 	 fingerprint[(PGP_FINGERPRINT_SIZE * 3) + 1];
 	int		 	 n;
 
 	if (key->revoked) {
@@ -792,13 +792,27 @@ pgp_hkp_sprint_keydata(pgp_io_t *io, const pgp_keyring_t *keyring,
 			}
 		}
 	}
-	return pgp_asprintf(buf, "pub:%s:%d:%d:%lld:%lld\n%s",
-		strhexdump(fp, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE, ""),
-		pubkey->alg,
-		numkeybits(pubkey),
-		(long long)pubkey->birthtime,
-		(long long)pubkey->duration,
-		uidbuf);
+
+	strhexdump(fingerprint, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE, "");
+
+	n = -1;
+	{
+		/* XXX: This number is completely arbitrary. */
+		char *buffer = (char *) malloc(KB(16));
+
+		if (buffer != NULL) {
+			n = snprintf(buffer, KB(16),
+					"pub:%s:%d:%d:%lld:%lld\n%s",
+					fingerprint,
+					pubkey->alg,
+					numkeybits(pubkey),
+					(long long) pubkey->birthtime,
+					(long long) pubkey->duration,
+					uidbuf);
+			*buf = buffer;
+		}
+	}
+	return n;
 }
 
 /* print the key data for a pub or sec key */

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -560,8 +560,11 @@ format_uid_notice(
 }
 
 #ifndef KB
-#define KB(x)	((x) * 1024)
+#define KB(x)  ((x) * 1024)
 #endif
+
+/* XXX: Why 128KiB? */
+#define NOTICE_BUFFER_SIZE KB(128)
 
 /* print into a string (malloc'ed) the pubkeydata */
 int
@@ -592,8 +595,7 @@ pgp_sprint_keydata(pgp_io_t *io, const pgp_keyring_t *keyring,
 	} else
 		expiration_notice[0] = '\0';
 
-	/* XXX: Why 128KiB? */
-	uid_notices = (char *) malloc(KB(128));
+	uid_notices = (char *) malloc(NOTICE_BUFFER_SIZE);
 	if (uid_notices == NULL)
 		return -1;
 
@@ -612,7 +614,7 @@ pgp_sprint_keydata(pgp_io_t *io, const pgp_keyring_t *keyring,
 		uid_notices_offset += format_uid_notice(
 				uid_notices + uid_notices_offset,
 				io, keyring, key, i,
-				sizeof(uid_notices) - uid_notices_offset,
+				NOTICE_BUFFER_SIZE - uid_notices_offset,
 				flags);
 	}
 

--- a/src/lib/ssh2pgp.c
+++ b/src/lib/ssh2pgp.c
@@ -320,15 +320,30 @@ pgp_ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hasht
 				(int)strlen(space + 1) - 1,
 				space + 1);
 		}
-		(void) pgp_asprintf((char **)(void *)&userid,
-						"%s (%s) %s",
-						hostname,
-						f,
-						owner);
+
+		/* This function is very large and probably needs to be
+		 * broken up. For the time being we approximate asprintf
+		 * in a little sub-context.
+		 *
+		 * TODO: There was no error handling here. Some must be
+		 *       added to prevent acting on and freeing a NULL
+		 *       pointer.
+		 */
+		{
+			char *buffer = (char *) malloc(4096);
+
+			if (buffer != NULL) {
+				snprintf(buffer, 4096, "%s (%s) %s",
+						hostname, f, owner);
+				userid = (uint8_t *) buffer;
+			}
+		}
 		pgp_keyid(key->sigid, sizeof(key->sigid), pubkey, hashtype);
 		pgp_add_userid(key, userid);
 		pgp_fingerprint(&key->sigfingerprint, pubkey, hashtype);
-		free(userid);
+
+		free((void *) userid);
+
 		if (pgp_get_debug_level(__FILE__)) {
 			/*pgp_print_keydata(io, keyring, key, "pub", pubkey, 0);*/
 			__PGP_USED(io); /* XXX */

--- a/src/lib/ssh2pgp.c
+++ b/src/lib/ssh2pgp.c
@@ -204,76 +204,80 @@ findstr(str_t *array, const char *name)
 int
 pgp_ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hashtype)
 {
-	pgp_pubkey_t	*pubkey;
-	struct stat	 st;
-	bufgap_t	 bg;
-	uint32_t	 len;
-	int64_t		 off;
-	uint8_t		*userid;
-	char		 hostname[256];
-	char		 owner[256];
-	char		*space;
-	char	 	*buf;
-	char	 	*bin;
-	int		 ok;
-	int		 cc;
+	pgp_pubkey_t *pubkey;
+	struct stat   st;
+	bufgap_t      bg;
+	uint32_t      len;
+	int64_t       off;
+	uint8_t      *userid;
+	char          hostname[_POSIX_HOST_NAME_MAX + 1];
+	char          owner[_POSIX_LOGIN_NAME_MAX + sizeof(hostname) + 1];
+	char         *space;
+	char         *buf;
+	char         *bin;
+	int           ok;
+	int           cc;
 
-	(void) memset(&bg, 0x0, sizeof(bg));
-	if (!bufgap_open(&bg, f)) {
-		(void) fprintf(stderr, "pgp_ssh2pubkey: can't open '%s'\n", f);
+	memset(&bg, 0x0, sizeof(bg));
+	if (! bufgap_open(&bg, f)) {
+		fprintf(stderr, "pgp_ssh2pubkey: can't open '%s'\n", f);
 		return 0;
 	}
-	(void)stat(f, &st);
-	if ((buf = calloc(1, (size_t)st.st_size)) == NULL) {
-		(void) fprintf(stderr, "can't calloc %zu bytes for '%s'\n", (size_t)st.st_size, f);
+	stat(f, &st);
+	if ((buf = calloc(1, (size_t) st.st_size)) == NULL) {
+		fprintf(stderr, "can't calloc %zu bytes for '%s'\n",
+				(size_t) st.st_size, f);
 		bufgap_close(&bg);
 		return 0;
 	}
-	if ((bin = calloc(1, (size_t)st.st_size)) == NULL) {
-		(void) fprintf(stderr, "can't calloc %zu bytes for '%s'\n", (size_t)st.st_size, f);
-		(void) free(buf);
+	if ((bin = calloc(1, (size_t) st.st_size)) == NULL) {
+		fprintf(stderr, "can't calloc %zu bytes for '%s'\n",
+				(size_t) st.st_size, f);
+		free((void *) buf);
 		bufgap_close(&bg);
 		return 0;
 	}
 
 	/* move past ascii type of key */
-	while (bufgap_peek(&bg, 0) != ' ') {
+	while (bufgap_peek(&bg, 0) != ' ')
 		bufgap_seek(&bg, 1, BGFromHere, BGByte);
-	}
 	bufgap_seek(&bg, 1, BGFromHere, BGByte);
 	off = bufgap_tell(&bg, BGFromBOF, BGByte);
 
 	if (bufgap_size(&bg, BGByte) - off < 10) {
-		(void) fprintf(stderr, "bad key file '%s'\n", f);
-		(void) free(buf);
+		fprintf(stderr, "bad key file '%s'\n", f);
+		free((void *) buf);
 		bufgap_close(&bg);
 		return 0;
 	}
 
 	/* convert from base64 to binary */
-	cc = bufgap_getbin(&bg, buf, (size_t)bg.bcc);
+	cc = bufgap_getbin(&bg, buf, (size_t) bg.bcc);
 	if ((space = strchr(buf, ' ')) != NULL) {
 		cc = (int)(space - buf);
 	}
 	if (pgp_get_debug_level(__FILE__)) {
-		hexdump(stderr, NULL, (const uint8_t *)(const void *)buf, (size_t)cc);
+		hexdump(stderr, NULL, (const uint8_t *) (const void *) buf,
+				(size_t) cc);
 	}
-	cc = frombase64(bin, buf, (size_t)cc, 0);
+	cc = frombase64(bin, buf, (size_t) cc, 0);
 	if (pgp_get_debug_level(__FILE__)) {
-		hexdump(stderr, "decoded base64:", (const uint8_t *)(const void *)bin, (size_t)cc);
+		hexdump(stderr, "decoded base64:",
+				(const uint8_t *) (const void *) bin,
+				(size_t) cc);
 	}
-	bufgap_delete(&bg, (uint64_t)bufgap_tell(&bg, BGFromEOF, BGByte));
+	bufgap_delete(&bg, (uint64_t) bufgap_tell(&bg, BGFromEOF, BGByte));
 	bufgap_insert(&bg, bin, cc);
 	bufgap_seek(&bg, off, BGFromBOF, BGByte);
 
 	/* get the type of key */
-	(void) bufgap_getbin(&bg, &len, sizeof(len));
+	bufgap_getbin(&bg, &len, sizeof(len));
 	len = ntohl(len);
-	(void) bufgap_seek(&bg, sizeof(len), BGFromHere, BGByte);
-	(void) bufgap_getbin(&bg, buf, len);
-	(void) bufgap_seek(&bg, len, BGFromHere, BGByte);
+	bufgap_seek(&bg, sizeof(len), BGFromHere, BGByte);
+	bufgap_getbin(&bg, buf, len);
+	bufgap_seek(&bg, len, BGFromHere, BGByte);
 
-	(void) memset(key, 0x0, sizeof(*key));
+	memset(key, 0x0, sizeof(*key));
 	pubkey = &key->key.seckey.pubkey;
 	pubkey->version = PGP_V4;
 	pubkey->birthtime = 0;
@@ -297,7 +301,7 @@ pgp_ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hasht
 		pubkey->key.dsa.y = getbignum(&bg, buf, "DSA Y");
 		break;
 	default:
-		(void) fprintf(stderr, "Unrecognised pubkey type %d for '%s'\n",
+		fprintf(stderr, "Unrecognised pubkey type %d for '%s'\n",
 				pubkey->alg, f);
 		ok = 0;
 		break;
@@ -310,33 +314,38 @@ pgp_ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hasht
 		ok = 0;
 	}
 	if (ok) {
-		(void) memset(&userid, 0x0, sizeof(userid));
-		(void) gethostname(hostname, sizeof(hostname));
+		memset(&userid, 0x0, sizeof(userid));
+		gethostname(hostname, sizeof(hostname));
 		if (strlen(space + 1) - 1 == 0) {
-			(void) snprintf(owner, sizeof(owner), "<root@%s>",
+			snprintf(owner, sizeof(owner), "root@%s",
 					hostname);
 		} else {
-			(void) snprintf(owner, sizeof(owner), "<%.*s>",
-				(int)strlen(space + 1) - 1,
-				space + 1);
+			snprintf(owner, sizeof(owner), "%.*s",
+					(int) strlen(space + 1) - 1,
+					space + 1);
 		}
 
-		/* This function is very large and probably needs to be
-		 * broken up. For the time being we approximate asprintf
-		 * in a little sub-context.
-		 *
-		 * TODO: There was no error handling here. Some must be
-		 *       added to prevent acting on and freeing a NULL
-		 *       pointer.
+		/* This overall function needs to be broken up and this
+		 * code brought back out.
 		 */
 		{
-			char *buffer = (char *) malloc(4096);
+			static const size_t buffer_size =
+					sizeof(hostname) + sizeof(owner) +
+					sizeof(f) + 64;
 
-			if (buffer != NULL) {
-				snprintf(buffer, 4096, "%s (%s) %s",
-						hostname, f, owner);
-				userid = (uint8_t *) buffer;
+			char *buffer = (char *) malloc(buffer_size);
+
+			if (buffer == NULL) {
+				fputs("failed to allocate buffer: "
+						"insufficient memory\n", stderr);
+				free((void *) bin);
+				free((void *) buf);
+				bufgap_close(&bg);
+				return 0;
 			}
+			snprintf(buffer, buffer_size, "%s (%s) <%s>",
+					hostname, f, owner);
+			userid = (uint8_t *) buffer;
 		}
 		pgp_keyid(key->sigid, sizeof(key->sigid), pubkey, hashtype);
 		pgp_add_userid(key, userid);
@@ -349,8 +358,8 @@ pgp_ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hasht
 			__PGP_USED(io); /* XXX */
 		}
 	}
-	(void) free(bin);
-	(void) free(buf);
+	free((void *) bin);
+	free((void *) buf);
 	bufgap_close(&bg);
 	return ok;
 }

--- a/src/rnpv/libverify.c
+++ b/src/rnpv/libverify.c
@@ -2485,11 +2485,25 @@ read_ssh_file(pgpv_t *pgp, pgpv_primarykey_t *primary, const char *fmt, ...)
 				space + 1);
 		}
 		calc_keyid(pubkey, "sha1");
-		userid.userid.size = asprintf((char **)(void *)&userid.userid.data,
+
+		/* XXX: There is no error handling for NULL pointers here,
+		 *      this needs addressing.
+		 *
+		 * XXX: What is a reasonable static size?
+		 */
+		{
+			char *buffer;
+
+			buffer = (char *) malloc(4096);
+			if (buffer != NULL) {
+				userid.userid.size = snprintf(
+						buffer, 4096,
 						"%s (%s) %s",
-						hostname,
-						f,
-						owner);
+						hostname, f, owner);
+				userid.userid.data = (uint8_t *) buffer;
+			}
+		}
+
 		ARRAY_APPEND(primary->signed_userids, userid);
 		primary->fmtsize = estimate_primarykey_size(primary) + 1024;
 	}


### PR DESCRIPTION
This contains:

* Replacements for all instances of asprintf as per #9 except the vasprintf() instance at rnpv/obuf_print:227, which I want to formulate a robust solution to.
* A bug fix for a bug that I introduced in my last PR causing 'uid' notices to be truncated - sorry about that.

I'm not happy with memory management in pgp_sprint_keydata and pgp_hkp_sprint_keydata. I'm going to have to familiarise myself better with the RFCs before I can re-work that section to be more predictable. In the meantime I'm going to move on to other pending issues and come back to this after some progress has been made in other areas. 👍 