### PR TITLE
Elgamal on botan conv

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,7 @@ Install it into the container:
 ```
 
 install_botan_dev() {
-  # TODO: Link to dev version of botan should probably be changed
-  BOTAN_DEV_GIT_REPO=https://github.com/flowher/botan.git
+  BOTAN_DEV_GIT_REPO=https://github.com/randombit/botan.git
   BOTAN_DEV_GIT_BRANCH=rnp_master
 
   t=$(mktemp -d) \

--- a/README.md
+++ b/README.md
@@ -237,6 +237,32 @@ install_botan
 
 ```
 
+### Botan for not yet realeased branches
+
+Development branches may depend on Botan version which is not yet released (i.e. when adding support for new crypto algorithm). Not released branches of rnp should use following instructions to install Botan library.
+
+Install it into the container:
+
+```
+
+install_botan_dev() {
+  # TODO: Link to dev version of botan should probably be changed
+  BOTAN_DEV_GIT_REPO=https://github.com/flowher/botan.git
+  BOTAN_DEV_GIT_BRANCH=rnp_master
+
+  t=$(mktemp -d) \
+  && pushd ${t} \
+  && git clone --single-branch -b ${BOTAN_DEV_GIT_BRANCH} ${BOTAN_DEV_GIT_REPO} \
+  && pushd botan \
+  && ./configure.py --prefix=/usr/local \
+  && make \
+  && make install
+}
+install_botan_dev
+
+```
+
+
 ### Cmocka
 
 CMocka 1.1 is required to build and run tests.

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -212,66 +212,77 @@ static void raw_rsa_test_success(void **state)
 
 static void raw_elg_test_success(void **state)
 {
-   // largest prime under 512 bits
-   const uint8_t p512[64] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFD, 0xC7,
-   };
+  // largest prime under 512 bits
+  const uint8_t p512[64] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFD, 0xC7,
+  };
 
-   pgp_elgamal_pubkey_t pub_elg;
-   pgp_elgamal_seckey_t sec_elg;
-   uint8_t   encm[1024];
-   uint8_t   g_to_k[1024];
-   uint8_t decr[1024];
-   const uint8_t plaintext[5] = { 1, 2, 3, 4, 23 };
-   BN_CTX* ctx = BN_CTX_new();
+  pgp_elgamal_pubkey_t pub_elg;
+  pgp_elgamal_seckey_t sec_elg;
+  uint8_t              encm[64];
+  uint8_t              g_to_k[64];
+  uint8_t              decryption_result[1024];
+  const uint8_t plaintext[] = { 0x01, 0x02, 0x03, 0x04, 0x17 };
+  BN_CTX* ctx = NULL;
 
-   sec_elg.x = BN_new();
-   BN_set_word(sec_elg.x, 0xDEADBEEF);
+  // Allocate needed memory
+  ctx = BN_CTX_new();
+  pub_elg.p = BN_bin2bn(p512, sizeof(p512), NULL);
+  pub_elg.g = BN_new();
+  sec_elg.x = BN_new();
+  pub_elg.y = BN_new();
 
-   pub_elg.g = BN_new();
-   pub_elg.y = BN_new();
+  BN_set_word(pub_elg.g, 3);
+  BN_set_word(sec_elg.x, 0xCAB5432);
+  BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p, ctx);
 
-   pub_elg.p = BN_bin2bn(p512, sizeof(p512), NULL);
-
-   // G = 3
-   BN_set_word(pub_elg.g, 3);
-   BN_set_word(sec_elg.x, 0xCAB5432);
-
-   BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p, ctx);
-
-   BN_CTX_free(ctx);
-
-   pgp_elgamal_public_encrypt(g_to_k, encm, plaintext, sizeof(plaintext), &pub_elg);
-
-   unsigned ctext_size = pgp_elgamal_public_encrypt(g_to_k, encm, plaintext, sizeof(plaintext), &pub_elg);
-
-   assert_int_equal(ctext_size % 2, 0);
-   ctext_size /= 2;
+  // Encrypt
+  unsigned ctext_size
+    = pgp_elgamal_public_encrypt(
+        g_to_k,
+        encm,
+        plaintext,
+        sizeof(plaintext),
+        &pub_elg);
+  assert_int_not_equal(ctext_size, -1);
+  assert_int_equal(ctext_size % 2, 0);
+  ctext_size /= 2;
 
 #if defined(DEBUG_PRINT)
-   printf("P = 0x%s\n", BN_bn2hex(pub_elg.p));
-   printf("G = 0x%s\n", BN_bn2hex(pub_elg.g));
-   printf("Y = 0x%s\n", BN_bn2hex(pub_elg.y));
-   printf("X = 0x%s\n", BN_bn2hex(sec_elg.x));
-   BIGNUM* x = BN_bin2bn(g_to_k, ctext_size, NULL);
-   printf("Gtk = 0x%s\n", BN_bn2hex(x));
-   printf("MM = ");
-   for(size_t i = 0; i != ctext_size; ++i)
-   {
-      printf("%02X", encm[i]);
-   }
-   printf("\n");
+  BIGNUM *tmp = BN_new();
+
+  printf("\tP\t= 0x%s\n",   BN_bn2hex(pub_elg.p));
+  printf("\tG\t= 0x%s\n",   BN_bn2hex(pub_elg.g));
+  printf("\tY\t= 0x%s\n",   BN_bn2hex(pub_elg.y));
+  printf("\tX\t= 0x%s\n",   BN_bn2hex(sec_elg.x));
+
+  BN_bin2bn(g_to_k, ctext_size, tmp);
+  printf("\tGtk\t= 0x%s\n", BN_bn2hex(tmp));
+
+  BN_bin2bn(encm, ctext_size, tmp);
+  printf("\tMM\t= 0x%s\n",  BN_bn2hex(tmp));
+
+  BN_clear_free(tmp);
 #endif
 
-   pgp_elgamal_private_decrypt(decr, g_to_k, encm, ctext_size, &sec_elg, &pub_elg);
+  assert_int_not_equal(
+    pgp_elgamal_private_decrypt(decryption_result, g_to_k, encm, ctext_size, &sec_elg, &pub_elg),
+    -1);
 
-   test_value_equal("ElGamal decrypt", "0102030417", decr, 5);
+  test_value_equal("ElGamal decrypt", "0102030417", decryption_result, sizeof(plaintext));
+
+  // Free heap
+  BN_CTX_free(ctx);
+  BN_clear_free(pub_elg.p);
+  BN_clear_free(pub_elg.g);
+  BN_clear_free(sec_elg.x);
+  BN_clear_free(pub_elg.y);
 }
 
 int main(void) {

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -183,12 +183,12 @@ static void raw_rsa_test_success(void **state)
    sec_rsa = &sec_key->key.rsa;
 
 #if defined(DEBUG_PRINT)
-   printf("PT = 0x%s\n", hex_encode(ptext, sizeof(ptext)));
-   printf("N = 0x%s\n", BN_bn2hex(pub_rsa->n));
-   printf("E = 0x%s\n", BN_bn2hex(pub_rsa->e));
-   printf("P = 0x%s\n", BN_bn2hex(sec_rsa->p));
-   printf("Q = 0x%s\n", BN_bn2hex(sec_rsa->q));
-   printf("D = 0x%s\n", BN_bn2hex(sec_rsa->d));
+   char* tmp = hex_encode(ptext, sizeof(ptext)); printf("PT = 0x%s\n", tmp); free(tmp);
+   printf("N = "); BN_print_fp(stdout, pub_rsa->n); printf("\n");
+   printf("E = "); BN_print_fp(stdout, pub_rsa->e); printf("\n");
+   printf("P = "); BN_print_fp(stdout, sec_rsa->p); printf("\n");
+   printf("Q = "); BN_print_fp(stdout, sec_rsa->q); printf("\n");
+   printf("D = "); BN_print_fp(stdout, sec_rsa->d); printf("\n");
 #endif
 
    ctext_size = pgp_rsa_public_encrypt(ctext, ptext, sizeof(ptext), pub_rsa);
@@ -200,8 +200,8 @@ static void raw_rsa_test_success(void **state)
                                             sec_rsa, pub_rsa);
 
 #if defined(DEBUG_PRINT)
-   printf("C = 0x%s\n", hex_encode(ctext, ctext_size));
-   printf("PD = 0x%s\n", hex_encode(decrypted, decrypted_size));
+   tmp = hex_encode(ctext, ctext_size);         printf("C = 0x%s\n", tmp);  free(tmp);
+   tmp = hex_encode(decrypted, decrypted_size); printf("PD = 0x%s\n", tmp); free(tmp);
 #endif
 
    test_value_equal("RSA 1024 decrypt", "616263", decrypted, 3);
@@ -228,11 +228,10 @@ static void raw_elg_test_success(void **state)
   uint8_t              encm[64];
   uint8_t              g_to_k[64];
   uint8_t              decryption_result[1024];
-  const uint8_t plaintext[] = { 0x01, 0x02, 0x03, 0x04, 0x17 };
-  BN_CTX* ctx = NULL;
+  const uint8_t        plaintext[] = { 0x01, 0x02, 0x03, 0x04, 0x17 };
+  BN_CTX               ctx;
 
   // Allocate needed memory
-  ctx = BN_CTX_new();
   pub_elg.p = BN_bin2bn(p512, sizeof(p512), NULL);
   pub_elg.g = BN_new();
   sec_elg.x = BN_new();
@@ -240,7 +239,7 @@ static void raw_elg_test_success(void **state)
 
   BN_set_word(pub_elg.g, 3);
   BN_set_word(sec_elg.x, 0xCAB5432);
-  BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p, ctx);
+  BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p, &ctx);
 
   // Encrypt
   unsigned ctext_size
@@ -257,16 +256,16 @@ static void raw_elg_test_success(void **state)
 #if defined(DEBUG_PRINT)
   BIGNUM *tmp = BN_new();
 
-  printf("\tP\t= 0x%s\n",   BN_bn2hex(pub_elg.p));
-  printf("\tG\t= 0x%s\n",   BN_bn2hex(pub_elg.g));
-  printf("\tY\t= 0x%s\n",   BN_bn2hex(pub_elg.y));
-  printf("\tX\t= 0x%s\n",   BN_bn2hex(sec_elg.x));
+  printf("\tP\t= "); BN_print_fp(stdout, pub_elg.p); printf("\n");
+  printf("\tG\t= "); BN_print_fp(stdout, pub_elg.g); printf("\n");
+  printf("\tY\t= "); BN_print_fp(stdout, pub_elg.y); printf("\n");
+  printf("\tX\t= "); BN_print_fp(stdout, sec_elg.x); printf("\n");
 
   BN_bin2bn(g_to_k, ctext_size, tmp);
-  printf("\tGtk\t= 0x%s\n", BN_bn2hex(tmp));
+  printf("\tGtk\t= "); BN_print_fp(stdout, tmp); printf("\n");
 
   BN_bin2bn(encm, ctext_size, tmp);
-  printf("\tMM\t= 0x%s\n",  BN_bn2hex(tmp));
+  printf("\tMM\t= "); BN_print_fp(stdout, tmp); printf("\n");
 
   BN_clear_free(tmp);
 #endif
@@ -278,7 +277,6 @@ static void raw_elg_test_success(void **state)
   test_value_equal("ElGamal decrypt", "0102030417", decryption_result, sizeof(plaintext));
 
   // Free heap
-  BN_CTX_free(ctx);
   BN_clear_free(pub_elg.p);
   BN_clear_free(pub_elg.g);
   BN_clear_free(sec_elg.x);

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -128,10 +128,53 @@ int pgp_rsa_private_encrypt(uint8_t *, const uint8_t *, size_t,
 int pgp_rsa_private_decrypt(uint8_t *, const uint8_t *, size_t,
 			const pgp_rsa_seckey_t *, const pgp_rsa_pubkey_t *);
 
-int pgp_elgamal_public_encrypt(uint8_t *, uint8_t *, const uint8_t *, size_t,
-			const pgp_elgamal_pubkey_t *);
-int pgp_elgamal_private_decrypt(uint8_t *, const uint8_t *, const uint8_t *, size_t,
-			const pgp_elgamal_seckey_t *, const pgp_elgamal_pubkey_t *);
+/*
+* Performs ElGamal encryption
+* Result of an encryption is composed of two parts - g2k and encm
+*
+* @param g2k [out] buffer stores first part of encryption (g^k % p)
+* @param encm [out] buffer stores second part of encryption (y^k * in % p)
+* @param in plaintext to be encrypted
+* @param length length of an input
+* @param pubkey public key to be used for encryption
+*
+* @pre g2k size must be at least equal to byte size of prime `p'
+* @pre encm size must be at least equal to byte size of prime `p'
+*
+* @return 	on success - number of bytes written to g2k and encm
+*			on failure -1
+*/
+int pgp_elgamal_public_encrypt(
+        uint8_t *g2k,
+        uint8_t *encm,
+        const uint8_t *in,
+        size_t length,
+		const pgp_elgamal_pubkey_t *pubkey);
+
+/*
+* Performs ElGamal decryption
+*
+* @param out [out] decrypted plaintext
+* @param g2k buffer stores first part of encryption (g^k % p)
+* @param encm buffer stores second part of encryption (y^k * in % p)
+* @param length length of g2k or in (must be equal to byte size of prime `p')
+* @param seckey private part of a key used for decryption
+* @param pubkey public domain parameters (p,g) used for decryption
+*
+* @pre g2k size must be at least equal to byte size of prime `p'
+* @pre encm size must be at least equal to byte size of prime `p'
+* @pre byte-size of `g2k' must be equal to `encm'
+*
+* @return 	on success - number of bytes written to g2k and encm
+*			on failure -1
+*/
+int pgp_elgamal_private_decrypt(
+        uint8_t *out,
+        const uint8_t *g2k,
+        const uint8_t *in,
+        size_t length,
+		const pgp_elgamal_seckey_t *seckey,
+		const pgp_elgamal_pubkey_t *pubkey);
 
 pgp_symm_alg_t pgp_str_to_cipher(const char *);
 unsigned pgp_block_size(pgp_symm_alg_t);

--- a/src/lib/openssl_crypto.c
+++ b/src/lib/openssl_crypto.c
@@ -95,6 +95,12 @@
 
 #include <botan/ffi.h>
 
+#define FAIL(str)  \
+  do { \
+    (void)fprintf(stderr, "%s:%u:%s(): "str"\n", __FILE__, __LINE__, __func__);  \
+    goto end; \
+  } while (0);
+
 struct PGPV_BIGNUM_st {
    botan_mp_t mp;
 };
@@ -861,165 +867,138 @@ openssl_read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int ver
 	return ok;
 }
 
-/*
- * Decide the number of bits in the random componont k
- *
- * It should be in the same range as p for signing (which
- * is deprecated), but can be much smaller for encrypting.
- *
- * Until I research it further, I just mimic gpg behaviour.
- * It has a special mapping table, for values <= 5120,
- * above that it uses 'arbitrary high number'.	Following
- * algorihm hovers 10-70 bits above gpg values.  And for
- * larger p, it uses gpg's algorihm.
- *
- * The point is - if k gets large, encryption will be
- * really slow.  It does not matter for decryption.
- */
-static int
-decide_k_bits(int p_bits)
-{
-	return (p_bits <= 5120) ? p_bits / 10 + 160 : (p_bits / 8 + 200) * 3 / 2;
-}
-
 int
-pgp_elgamal_public_encrypt(uint8_t *g_to_k, uint8_t *encm,
+pgp_elgamal_public_encrypt(
+      uint8_t *g2k,
+      uint8_t *encm,
 			const uint8_t *in,
-			size_t size,
+			size_t length,
 			const pgp_elgamal_pubkey_t *pubkey)
 {
-	int	ret = 0;
-	int	k_bits;
-	BIGNUM	   *m;
-	BIGNUM	   *p;
-	BIGNUM	   *g;
-	BIGNUM	   *y;
-	BIGNUM	   *k;
-	BIGNUM	   *yk;
-	BIGNUM	   *c1;
-	BIGNUM	   *c2;
-	BN_CTX	   *tmp;
+  botan_rng_t            rng            = NULL;
+  botan_pubkey_t         key            = NULL;
+  botan_pk_op_encrypt_t  op_ctx         = NULL;
+  int                    ret            = -1;
+  size_t                 p_len          = 0;
+  uint8_t                *bt_ciphertext = NULL;
 
-	m = BN_bin2bn(in, (int)size, NULL);
-	p = pubkey->p;
-	g = pubkey->g;
-	y = pubkey->y;
-	k = BN_new();
-	yk = BN_new();
-	c1 = BN_new();
-	c2 = BN_new();
-	tmp = BN_CTX_new();
-	if (!m || !p || !g || !y || !k || !yk || !c1 || !c2 || !tmp) {
-		goto done;
-	}
-	/*
-	 * generate k
-	 */
-	k_bits = decide_k_bits(BN_num_bits(p));
-	if (!BN_rand(k, k_bits, 0, 0)) {
-		goto done;
-	}
+  if (botan_rng_init(&rng, NULL)) {
 
-	/*
-	 * c1 = g^k c2 = m * y^k
-	 */
-	if (!BN_mod_exp(c1, g, k, p, tmp)) {
-		goto done;
-	}
-	if (!BN_mod_exp(yk, y, k, p, tmp)) {
-		goto done;
-	}
-	if (!BN_mod_mul(c2, m, yk, p, tmp)) {
-		goto done;
-	}
-	/* result */
-	BN_bn2bin(c1, g_to_k);
-	ret = BN_num_bytes(c1);	/* c1 = g^k */
-	BN_bn2bin(c2, encm);
-	ret += BN_num_bytes(c2); /* c2 = m * y^k */
-done:
-	if (tmp) {
-		BN_CTX_free(tmp);
-	}
-	if (c2) {
-		BN_clear_free(c2);
-	}
-	if (c1) {
-		BN_clear_free(c1);
-	}
-	if (yk) {
-		BN_clear_free(yk);
-	}
-	if (k) {
-		BN_clear_free(k);
-	}
-	return ret;
+      FAIL("Random initialization failure");
+  }
+
+  if (botan_mp_num_bytes(pubkey->p->mp, &p_len)) {
+
+      FAIL("Wrong public key");
+  }
+
+  // Initialize RNG and encrypt
+  if (botan_pubkey_load_elgamal(&key, pubkey->p->mp, pubkey->g->mp, pubkey->y->mp) ||
+      botan_pubkey_check_key(key, rng, 1)) {
+
+      FAIL("Wrong public key");
+  }
+
+  /* Max size of an output len is twice an order of underlying group (twice byte-size of p)
+   * Allocate all buffers needed for encryption and post encryption processing */
+  size_t out_len = p_len*2;
+  bt_ciphertext = calloc(out_len, 1);
+  if (!bt_ciphertext) {
+
+    FAIL("Memory allocation failure");
+  }
+
+  if (botan_pk_op_encrypt_create(&op_ctx, key, "Raw", 0) ||
+      botan_pk_op_encrypt(op_ctx, rng, bt_ciphertext, &out_len, in, length)) {
+
+      FAIL("Encryption fails");
+  }
+
+  /*
+   * Botan's ElGamal formats the g^k and msg*(y^k) together into a single byte string.
+   * We have to parse out the two values after encryption, as rnp stores those values separatelly.
+   */
+  memcpy(g2k, bt_ciphertext, p_len);
+  memcpy(encm, bt_ciphertext + p_len, p_len);
+
+  ret = (int)out_len;
+end:
+  if (botan_pk_op_encrypt_destroy(op_ctx) ||
+      botan_pubkey_destroy(key) ||
+      botan_rng_destroy(rng)) {
+
+      // should never happen
+      (void)fprintf(stderr, "%s:%d ERROR when deinitializing\n", __FILE__, __LINE__);
+      ret = -1;
+  }
+
+  free(bt_ciphertext);
+  return ret;
 }
 
 int
 pgp_elgamal_private_decrypt(uint8_t *out,
-				const uint8_t *g_to_k,
+				const uint8_t *g2k,
 				const uint8_t *in,
 				size_t length,
 				const pgp_elgamal_seckey_t *seckey,
 				const pgp_elgamal_pubkey_t *pubkey)
 {
-	BIGNUM	*bndiv;
-	BIGNUM	*c1x;
-	BN_CTX	*tmp;
-	BIGNUM	*c1;
-	BIGNUM	*c2;
-	BIGNUM	*p;
-	BIGNUM	*x;
-	BIGNUM	*m;
-	int	 ret;
+  botan_rng_t            rng          = NULL;
+  botan_privkey_t        key          = NULL;
+  botan_pk_op_decrypt_t  op_ctx       = NULL;
+  int                    ret          = -1;
+  size_t                 out_len      = 0;
+  size_t                 p_len        = 0;
+  uint8_t*               bt_plaintext = NULL;
 
-	ret = 0;
-	/* c1 and c2 are in g_to_k and in, respectively*/
-	c1 = BN_bin2bn(g_to_k, (int)length, NULL);
-	c2 = BN_bin2bn(in, (int)length, NULL);
-	/* other bits */
-	p = pubkey->p;
-	x = seckey->x;
-	c1x = BN_new();
-	bndiv = BN_new();
-	m = BN_new();
-	tmp = BN_CTX_new();
-	if (!c1 || !c2 || !p || !x || !c1x || !bndiv || !m || !tmp) {
-		goto done;
-	}
-	/*
-	 * m = c2 / (c1^x)
-	 */
-	if (!BN_mod_exp(c1x, c1, x, p, tmp)) {
-		goto done;
-	}
-	if (!BN_mod_inverse(bndiv, c1x, p, tmp)) {
-		goto done;
-	}
-	if (!BN_mod_mul(m, c2, bndiv, p, tmp)) {
-		goto done;
-	}
-	/* result */
-	ret = BN_bn2bin(m, out);
-done:
-	if (tmp) {
-		BN_CTX_free(tmp);
-	}
-	if (m) {
-		BN_clear_free(m);
-	}
-	if (bndiv) {
-		BN_clear_free(bndiv);
-	}
-	if (c1x) {
-		BN_clear_free(c1x);
-	}
-	if (c1) {
-		BN_clear_free(c1);
-	}
-	if (c2) {
-		BN_clear_free(c2);
-	}
-	return ret;
+  if (botan_rng_init(&rng, NULL)) {
+
+      FAIL("Random initialization failure");
+  }
+
+  // Output len is twice an order of underlying group
+  if (botan_mp_num_bytes(pubkey->p->mp, &p_len) ||
+      (length != p_len)) {
+
+      FAIL("Wrong public key");
+  }
+
+  /* Max size of an output len is twice an order of underlying group (twice byte-size of p)
+   * Allocate all buffers needed for encryption and post encryption processing */
+  out_len = p_len*2;
+
+  bt_plaintext = calloc(out_len, 1);
+  if (!bt_plaintext) {
+
+      FAIL("Memory allocation failure");
+  }
+
+  if (botan_privkey_load_elgamal(&key, pubkey->p->mp, pubkey->g->mp, seckey->x->mp) ||
+      botan_privkey_check_key(key, rng, 1)) {
+
+      FAIL("Wrong private key");
+  }
+
+  memcpy(bt_plaintext, g2k, p_len);
+  memcpy(bt_plaintext + p_len, in, p_len);
+
+  if (botan_pk_op_decrypt_create(&op_ctx, key, "Raw", 0) ||
+      botan_pk_op_decrypt(op_ctx, out, &out_len, bt_plaintext, p_len*2)) {
+
+      FAIL("Decryption fails");
+  }
+
+  ret = (int)out_len;
+
+end:
+  if (botan_pk_op_decrypt_destroy(op_ctx) ||
+      botan_privkey_destroy(key) ||
+      botan_rng_destroy(rng)) {
+
+      ret = -1;
+  }
+
+  free(bt_plaintext);
+  return ret;
 }


### PR DESCRIPTION
    * Reimplements `pgp_elgamal_private_decrypt' and `pgp_elgamal_public_encrypt'
      - Botan is used instead of OpenSSL BN API
    * Updates description of both function
    * This patch depends on newer version of Botan (see changes to README.md) 