### PR TITLE
Remove remaining references to OpenSSL in the source

### DIFF
--- a/ax_check_botan.m4
+++ b/ax_check_botan.m4
@@ -5,7 +5,7 @@
 # DESCRIPTION
 #
 #   Look for Botan in a number of default spots, or in a user-selected
-#   spot (via --with-openssl).  Sets
+#   spot (via --with-botan).  Sets
 #
 #     BOTAN_INCLUDES to the include directives required
 #     BOTAN_LIBS to the -l directives required
@@ -14,9 +14,9 @@
 #   and calls ACTION-IF-FOUND or ACTION-IF-NOT-FOUND appropriately
 #
 #   This macro sets BOTAN_INCLUDES such that source files should use the
-#   openssl/ directory in include directives:
+#   botan/ directory in include directives:
 #
-#     #include <openssl/hmac.h>
+#     #include <botan/hmac.h>
 #
 # LICENSE
 # Based on

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -39,12 +39,7 @@
 #include <keyring.h>
 #include <packet.h>
 #include <mj.h>
-
-#if defined(USE_BN_INTERFACE)
-  #include "bn.h"
-#else
-  #include <openssl/bn.h>
-#endif
+#include <bn.h>
 
 // returns new string containing hex value
 char* hex_encode(const uint8_t v[], size_t len)

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -277,7 +277,7 @@ DSA_SIG *pgp_dsa_sign(uint8_t *, unsigned,
                       const pgp_dsa_seckey_t *,
                       const pgp_dsa_pubkey_t *);
 
-int openssl_read_pem_seckey(const char *, pgp_key_t *, const char *, int);
+int read_pem_seckey(const char *, pgp_key_t *, const char *, int);
 
 /** pgp_reader_t */
 struct pgp_reader_t {

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -164,7 +164,7 @@ is a library interface to enable digital signatures to be created and
 verified, and also for files and memory to be encrypted and decrypted.
 Functions are also provided for management of user keys.
 .Pp
-The library uses functions from the openssl library for multi-precision
+The library uses functions from the botan library for multi-precision
 integer arithmetic, and for RSA and DSA key signing and verification,
 encryption and decryption.
 .Pp

--- a/src/lib/pem.c
+++ b/src/lib/pem.c
@@ -86,7 +86,7 @@
 #include "rnpdefs.h"
 
 int
-openssl_read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)
+read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)
 {
         uint8_t keybuf[RNP_BUFSIZ] = { 0 };
 	FILE	*fp;

--- a/src/lib/ssh2pgp.c
+++ b/src/lib/ssh2pgp.c
@@ -375,7 +375,7 @@ pgp_ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey
 
 	__PGP_USED(io);
 	/* XXX - check for rsa/dsa */
-	if (!openssl_read_pem_seckey(f, key, "ssh-rsa", 0)) {
+	if (!read_pem_seckey(f, key, "ssh-rsa", 0)) {
 		return 0;
 	}
 	if (pgp_get_debug_level(__FILE__)) {


### PR DESCRIPTION
Silly to leave these hanging around. 

@ronaldtse One thing you mentioned in the comment in #8 is `USE_BN_INTERFACE`, which controls if the BN function wrappers are exposed as `PGPV_BN_foo` or else `BN_foo`. What do you want to do here? Change all callers to `PGPV_BN_foo` [or some other prefix like `RNP_BN_foo`, easy to change this at the same time], or just remove the controlling macro and always have the `BN_foo` compatibility defines?