### PR TITLE
Change to use Botan's PKCS padding code for encryption

### DIFF
--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -183,7 +183,7 @@ static void cipher_test_success(void **state)
 
 //#define DEBUG_PRINT
 
-static void raw_rsa_test_success(void **state)
+static void pkcs1_rsa_test_success(void **state)
 {
    uint8_t ptext[1024/8] = { 'a', 'b', 'c', 0 };
 
@@ -213,13 +213,14 @@ static void raw_rsa_test_success(void **state)
    printf("D = "); BN_print_fp(stdout, sec_rsa->d); printf("\n");
 #endif
 
-   ctext_size = pgp_rsa_public_encrypt(ctext, ptext, sizeof(ptext), pub_rsa);
+   ctext_size = pgp_rsa_encrypt_pkcs1(ctext, sizeof(ctext), ptext, 3, pub_rsa);
 
    assert_int_equal(ctext_size, 1024/8);
 
    memset(decrypted, 0, sizeof(decrypted));
-   decrypted_size = pgp_rsa_private_decrypt(decrypted, ctext, ctext_size,
-                                            sec_rsa, pub_rsa);
+   decrypted_size = pgp_rsa_decrypt_pkcs1(decrypted, sizeof(decrypted),
+                                          ctext, ctext_size,
+                                          sec_rsa, pub_rsa);
 
 #if defined(DEBUG_PRINT)
    tmp = hex_encode(ctext, ctext_size);         printf("C = 0x%s\n", tmp);  free(tmp);
@@ -228,7 +229,7 @@ static void raw_rsa_test_success(void **state)
 
    test_value_equal("RSA 1024 decrypt", "616263", decrypted, 3);
 
-   assert_int_equal(decrypted_size, 1024/8);
+   assert_int_equal(decrypted_size, 3);
 
 }
 
@@ -265,7 +266,7 @@ static void raw_elg_test_success(void **state)
 
   // Encrypt
   unsigned ctext_size
-    = pgp_elgamal_public_encrypt(
+    = pgp_elgamal_public_encrypt_pkcs1(
         g_to_k,
         encm,
         plaintext,
@@ -293,7 +294,7 @@ static void raw_elg_test_success(void **state)
 #endif
 
   assert_int_not_equal(
-    pgp_elgamal_private_decrypt(decryption_result, g_to_k, encm, ctext_size, &sec_elg, &pub_elg),
+    pgp_elgamal_private_decrypt_pkcs1(decryption_result, g_to_k, encm, ctext_size, &sec_elg, &pub_elg),
     -1);
 
   test_value_equal("ElGamal decrypt", "0102030417", decryption_result, sizeof(plaintext));
@@ -309,7 +310,7 @@ int main(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(hash_test_success),
         cmocka_unit_test(cipher_test_success),
-        cmocka_unit_test(raw_rsa_test_success),
+        cmocka_unit_test(pkcs1_rsa_test_success),
         cmocka_unit_test(raw_elg_test_success),
     };
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/lib/create.h
+++ b/src/lib/create.h
@@ -115,8 +115,6 @@ unsigned pgp_write_rsa_pubkey(time_t, const BIGNUM *, const BIGNUM *,
 void pgp_fast_create_rsa_seckey(pgp_seckey_t *, time_t, BIGNUM *,
 				BIGNUM *, BIGNUM *, BIGNUM *,
 				BIGNUM *, BIGNUM *);
-unsigned encode_m_buf(const uint8_t *, size_t, const pgp_pubkey_t *,
-				uint8_t *);
 unsigned pgp_fileread_litdata(const char *, const pgp_litdata_enum,
 				pgp_output_t *);
 unsigned pgp_write_symm_enc_data(const uint8_t *, const int,

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -125,14 +125,29 @@ unsigned pgp_dsa_verify(const uint8_t *, size_t,
 			const pgp_dsa_sig_t *,
 			const pgp_dsa_pubkey_t *);
 
-int pgp_rsa_public_decrypt(uint8_t *, const uint8_t *, size_t,
-			const pgp_rsa_pubkey_t *);
+/*
+* RSA encrypt/decrypt
+*/
+
 int pgp_rsa_public_encrypt(uint8_t *, const uint8_t *, size_t,
 			const pgp_rsa_pubkey_t *);
 
+int pgp_rsa_encrypt_pkcs1(uint8_t* out, size_t out_len,
+                          const uint8_t* key, size_t key_len,
+                          const pgp_rsa_pubkey_t* pubkey);
+
+int pgp_rsa_decrypt_pkcs1(uint8_t* out, size_t out_len,
+                          const uint8_t* key, size_t key_len,
+                          const pgp_rsa_seckey_t* privkey,
+                          const pgp_rsa_pubkey_t* pubkey);
+
+/*
+* RSA signature generation and verification
+*/
+int pgp_rsa_public_decrypt(uint8_t *, const uint8_t *, size_t,
+			const pgp_rsa_pubkey_t *);
+
 int pgp_rsa_private_encrypt(uint8_t *, const uint8_t *, size_t,
-			const pgp_rsa_seckey_t *, const pgp_rsa_pubkey_t *);
-int pgp_rsa_private_decrypt(uint8_t *, const uint8_t *, size_t,
 			const pgp_rsa_seckey_t *, const pgp_rsa_pubkey_t *);
 
 /*
@@ -151,7 +166,7 @@ int pgp_rsa_private_decrypt(uint8_t *, const uint8_t *, size_t,
 * @return 	on success - number of bytes written to g2k and encm
 *			on failure -1
 */
-int pgp_elgamal_public_encrypt(
+int pgp_elgamal_public_encrypt_pkcs1(
         uint8_t *g2k,
         uint8_t *encm,
         const uint8_t *in,
@@ -175,7 +190,7 @@ int pgp_elgamal_public_encrypt(
 * @return 	on success - number of bytes written to g2k and encm
 *			on failure -1
 */
-int pgp_elgamal_private_decrypt(
+int pgp_elgamal_private_decrypt_pkcs1(
         uint8_t *out,
         const uint8_t *g2k,
         const uint8_t *in,
@@ -210,13 +225,6 @@ void pgp_reader_pop_hash(pgp_stream_t *);
 
 int pgp_decrypt_decode_mpi(uint8_t *, unsigned, const BIGNUM *,
 			const BIGNUM *, const pgp_seckey_t *);
-
-unsigned pgp_rsa_encrypt_mpi(const uint8_t *, const size_t,
-			const pgp_pubkey_t *,
-			pgp_pk_sesskey_params_t *);
-unsigned pgp_elgamal_encrypt_mpi(const uint8_t *, const size_t,
-			const pgp_pubkey_t *,
-			pgp_pk_sesskey_params_t *);
 
 /* Encrypt everything that's written */
 struct pgp_key_data;

--- a/src/lib/elgamal.c
+++ b/src/lib/elgamal.c
@@ -88,7 +88,7 @@
   } while (0)
 
 int
-pgp_elgamal_public_encrypt(
+pgp_elgamal_public_encrypt_pkcs1(
       uint8_t *g2k,
       uint8_t *encm,
 			const uint8_t *in,
@@ -132,7 +132,7 @@ pgp_elgamal_public_encrypt(
     FAIL("Memory allocation failure");
   }
 
-  if (botan_pk_op_encrypt_create(&op_ctx, key, "Raw", 0)) {
+  if (botan_pk_op_encrypt_create(&op_ctx, key, "PKCS1v15", 0)) {
 
     FAIL("Failed to create operation context");
   }
@@ -167,7 +167,7 @@ end:
 }
 
 int
-pgp_elgamal_private_decrypt(uint8_t *out,
+pgp_elgamal_private_decrypt_pkcs1(uint8_t *out,
 				const uint8_t *g2k,
 				const uint8_t *in,
 				size_t length,
@@ -221,7 +221,7 @@ pgp_elgamal_private_decrypt(uint8_t *out,
   memcpy(bt_plaintext, g2k, p_len);
   memcpy(bt_plaintext + p_len, in, p_len);
 
-  if (botan_pk_op_decrypt_create(&op_ctx, key, "Raw", 0)) {
+  if (botan_pk_op_decrypt_create(&op_ctx, key, "PKCS1v15", 0)) {
 
     FAIL("Failed to create operation context");
   }


### PR DESCRIPTION
First part of GH #50. This PR changes the encryption/decryption padding, but not the signature padding. The signature padding changes will be more complicated and will come in a later PR (probably next week or week after).

Tested by encrypting a file with master rnp and decrypting it with this branch, and also the reverse direction. Everything worked. But only RSA is tested so I may have flubbed something in the ElGamal code.