### PR TITLE
Fix RSA signatures

### DIFF
--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -147,7 +147,7 @@ int pgp_rsa_decrypt_pkcs1(uint8_t* out, size_t out_len,
 int pgp_rsa_public_decrypt(uint8_t *, const uint8_t *, size_t,
 			const pgp_rsa_pubkey_t *);
 
-int pgp_rsa_private_encrypt(uint8_t *, const uint8_t *, size_t,
+int pgp_rsa_private_encrypt(uint8_t *, size_t, const uint8_t *, size_t,
 			const pgp_rsa_seckey_t *, const pgp_rsa_pubkey_t *);
 
 /*

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -80,6 +80,8 @@
 #include "readerwriter.h"
 #include "rnpdefs.h"
 
+#include <string.h>
+
 /**
    \ingroup Core_Crypto
    \brief Recovers message digest from the signature
@@ -112,6 +114,7 @@ pgp_rsa_public_decrypt(uint8_t *out,
         if(n_bytes < out_bytes)
            return 0;
 
+        memset(out, 0, n_bytes);
         botan_mp_to_bin(output, out + (n_bytes - out_bytes));
 
         return n_bytes;

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -192,7 +192,7 @@ pgp_rsa_private_encrypt(uint8_t *out,
    botan_privkey_t rsa_key;
    botan_pk_op_sign_t sign_op;
    botan_rng_t rng;
-   size_t out_length;
+   size_t out_length = in_length;
 
    if(seckey->q == NULL)
    {

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -219,8 +219,14 @@ pgp_rsa_private_encrypt(uint8_t *out,
       return 0;
    }
 
-   botan_pk_op_sign_update(sign_op, in, in_length);
-   botan_pk_op_sign_finish(sign_op, rng, out, &out_length);
+   if (botan_pk_op_sign_update(sign_op, in, in_length) != 0 ||
+       botan_pk_op_sign_finish(sign_op, rng, out, &out_length) != 0)
+   {
+      botan_pk_op_sign_destroy(sign_op);
+      botan_privkey_destroy(rsa_key);
+      botan_rng_destroy(rng);
+      return 0;
+   }
 
    botan_pk_op_sign_destroy(sign_op);
    botan_privkey_destroy(rsa_key);

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -183,6 +183,7 @@ done:
 */
 int
 pgp_rsa_private_encrypt(uint8_t *out,
+			size_t out_length,
 			const uint8_t *in,
 			size_t in_length,
 			const pgp_rsa_seckey_t *seckey,
@@ -192,7 +193,6 @@ pgp_rsa_private_encrypt(uint8_t *out,
    botan_privkey_t rsa_key;
    botan_pk_op_sign_t sign_op;
    botan_rng_t rng;
-   size_t out_length = in_length;
 
    if(seckey->q == NULL)
    {

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -203,7 +203,7 @@ pgp_rsa_private_encrypt(uint8_t *out,
    botan_rng_init(&rng, NULL);
 
    /* p and q are reversed from normal usage in PGP */
-   botan_privkey_load_rsa(&rsa_key, seckey->q->mp, seckey->p->mp, seckey->d->mp);
+   botan_privkey_load_rsa(&rsa_key, seckey->q->mp, seckey->p->mp, pubkey->e->mp);
 
    if(botan_privkey_check_key(rsa_key, rng, 0) != 0)
    {

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -301,6 +301,10 @@ rsa_verify(pgp_hash_alg_t type,
 		return 0;
 	}
 
+	if (hashbuf_from_sig[0] != 0 || hashbuf_from_sig[1] != 1) {
+		return 0;
+	}
+
 	switch (type) {
 	case PGP_HASH_MD5:
 		prefix = prefix_md5;

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -216,7 +216,7 @@ rsa_sign(pgp_hash_t *hash,
 		return 0;
 	}
 
-	t = pgp_rsa_private_encrypt(sigbuf, hashbuf, keysize, secrsa, pubrsa);
+	t = pgp_rsa_private_encrypt(sigbuf, sizeof(sigbuf), hashbuf, keysize, secrsa, pubrsa);
 	if (t == 0) {
 		(void) fprintf(stderr, "rsa_sign: pgp_rsa_private_encrypt failed\n");
 		return 0;

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -301,12 +301,6 @@ rsa_verify(pgp_hash_alg_t type,
 		return 0;
 	}
 
-	/* XXX: why is there a leading 0? The first byte should be 1... */
-	/* XXX: because the decrypt should use keysize and not sigsize? */
-	if (hashbuf_from_sig[0] != 0 || hashbuf_from_sig[1] != 1) {
-		return 0;
-	}
-
 	switch (type) {
 	case PGP_HASH_MD5:
 		prefix = prefix_md5;

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -217,6 +217,10 @@ rsa_sign(pgp_hash_t *hash,
 	}
 
 	t = pgp_rsa_private_encrypt(sigbuf, hashbuf, keysize, secrsa, pubrsa);
+	if (t == 0) {
+		(void) fprintf(stderr, "rsa_sign: pgp_rsa_private_encrypt failed\n");
+		return 0;
+	}
 	bn = BN_bin2bn(sigbuf, (int)t, NULL);
 	pgp_write_mpi(out, bn);
 	BN_free(bn);


### PR DESCRIPTION
Hopefully closes https://github.com/riboseinc/rnp/issues/79

I think the main piece I'm not sure on here is the removal of the legacy code, but it was necessary to get `rnp --verify` to agree with the other tools.
rnp/rnpv/gpg now all agree that the signatures are valid (and invalid when tampered with).

I think the crux of the issue here is a mismatch in parameter names in botan_privkey_load_rsa vs RSA_PrivateKey, so I filed a PR there: https://github.com/randombit/botan/pull/1045