### PR TITLE
Add a test for RSA signature generation and verification

### DIFF
--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -152,10 +152,10 @@ pgp_getpassphrase(void *in, char *phrase, size_t size)
 		}
 		(void) snprintf(phrase, size, "%s", p);
 	} else {
+                memset(phrase, 0, size);
 		if (fgets(phrase, (int)size, in) == NULL) {
 			return 0;
 		}
-		phrase[strlen(phrase) - 1] = 0x0;
 	}
 	return 1;
 }

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -175,12 +175,16 @@ rsa_sign(pgp_hash_t *hash,
 		prefix = prefix_sha1;
 		prefixsize = sizeof(prefix_sha1);
 		expected = PGP_SHA1_HASH_SIZE;
-	} else {
+	} else if(strcmp(hash->name, "SHA256") == 0) {
 		hashsize = PGP_SHA256_HASH_SIZE + sizeof(prefix_sha256);
 		prefix = prefix_sha256;
 		prefixsize = sizeof(prefix_sha256);
 		expected = PGP_SHA256_HASH_SIZE;
-	}
+	} else {
+               (void)fprintf(stderr, "rsa_sign unsupported hash %s\n", hash->name);
+               return 0;
+        }
+
 	keysize = (BN_num_bits(pubrsa->n) + 7) / 8;
 	if (keysize > sizeof(hashbuf)) {
 		(void) fprintf(stderr, "rsa_sign: keysize too big\n");
@@ -204,7 +208,7 @@ rsa_sign(pgp_hash_t *hash,
 	(void) memcpy(&hashbuf[n], prefix, prefixsize);
 	n += prefixsize;
 	if ((t = hash->finish(hash, &hashbuf[n])) != expected) {
-		(void) fprintf(stderr, "rsa_sign: short %s hash\n", hash->name);
+                (void) fprintf(stderr, "rsa_sign: short %s hash (%d != %d)\n", hash->name, t, expected);
 		return 0;
 	}
 


### PR DESCRIPTION
This would have caught #79

Fixes two bugs I found along the way: in `pgp_getpassphrase` the password read from the file descriptor had its last character truncated. The library uses different codepaths to read the passphrase during keygen vs all other operations, so the result was that after generating a key with passphrase "abc" the decryption would fail because it would treat the entered passphrase as "ab" even though the pipe contained "abc". I think this doesn't come up in manual testing because `rnp` command line program doesn't use pass-fd. 

Also fix a bug in rsa_sign - if the requested hash is not SHA-1 or SHA-256 then it would just default to SHA-256, then be confused when the hash output a different length. Found because initially I was testing with MD5 also, which failed.