### PR TITLE
Introduced `rnp_set_keyring_format` to specified a keyring format for #33

### DIFF
--- a/include/rnp.h
+++ b/include/rnp.h
@@ -45,6 +45,8 @@
 
 __BEGIN_DECLS
 
+enum keyring_format_t {GPG_KEYRING, SSH_KEYRING};
+
 /* structure used to hold (key,value) pair information */
 typedef struct rnp_t {
 	unsigned	  c;		/* # of elements used */
@@ -55,6 +57,8 @@ typedef struct rnp_t {
 	void		 *secring;	/* s3kr1t key ring */
 	void		 *io;		/* the io struct for results/errs */
 	void		 *passfp;	/* file pointer for password input */
+
+	enum keyring_format_t   keyring_format;   /* keyring format */
 } rnp_t;
 
 /* begin and end */
@@ -72,6 +76,9 @@ int rnp_setvar(rnp_t *, const char *, const char *);
 char *rnp_getvar(rnp_t *, const char *);
 int rnp_incvar(rnp_t *, const char *, const int);
 int rnp_unsetvar(rnp_t *, const char *);
+
+/* set keyring format information */
+int rnp_set_keyring_format(rnp_t *, char *);
 
 /* set home directory information */
 int rnp_set_homedir(rnp_t *, char *, const char *, const int);

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -80,6 +80,12 @@ The following functions are for variable management:
 .Fa "rnp_t *rnp" "const char *name" "const int delta"
 .Fc
 .Pp
+The following function sets the keyring format:
+.Ft int
+.Fo rnp_set_keyring_format
+.Fa "rnp_t *rnp" "char *format"
+.Fc
+.Pp
 The following function sets the home directory:
 .Ft int
 .Fo rnp_set_homedir
@@ -205,6 +211,11 @@ a subset of the keys in the keyring.
 If the expression to match is NULL,
 the search will degenerate into a
 listing of all keys in the keyring.
+.Pp
+The keyring format is specified as an internal variable,
+and its existence is checked using the
+.Fn rnp_set_keyring_format
+function.
 .Pp
 The home directory is specified as an internal variable,
 and its existence is checked using the

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -953,9 +953,24 @@ init_new_io(rnp_t *rnp)
 }
 
 static int
+parse_keyring_format(rnp_t *rnp, enum keyring_format_t *keyring_format, char *format)
+{
+	if (rnp_strcasecmp(format, "GPG") == 0) {
+		*keyring_format = GPG_KEYRING;
+	} else if (rnp_strcasecmp(format, "SSH") == 0) {
+		*keyring_format = SSH_KEYRING;
+	} else {
+		fprintf(stderr, "rnp: unsupported keyring format: \"%s\"\n", format);
+		return 0;
+	}
+	return 1;
+}
+
+
+static int
 use_ssh_keys(rnp_t *rnp)
 {
-	return rnp_getvar(rnp, "ssh keys") != NULL;
+	return rnp->keyring_format == SSH_KEYRING;
 }
 
 static int
@@ -1089,11 +1104,32 @@ init_touch_initialized(rnp_t *rnp)
 }
 
 static int
+init_default_format(rnp_t *rnp)
+{
+	char *format = rnp_getvar(rnp, "keyring_format");
+
+	// default format is GPG
+	if (format == NULL) {
+		format = "GPG";
+	}
+
+	// if provided "ssh keys" variable, switch to SSH format
+	if (rnp_getvar(rnp, "ssh keys")) {
+		format = "SSH";
+	}
+
+	return rnp_set_keyring_format(rnp, format);
+}
+
+static int
 init_default_homedir(rnp_t *rnp)
 {
 	char *home = getenv("HOME");
-	char *subdir = rnp_getvar(rnp, "ssh keys")
-			? SUBDIRECTORY_SSH : SUBDIRECTORY_GNUPG;
+	char *subdir = SUBDIRECTORY_GNUPG;
+
+	if (use_ssh_keys(rnp)) {
+		subdir = SUBDIRECTORY_SSH;
+	}
 
 	if (home == NULL) {
 		fputs("rnp: HOME environment variable is not set\n", stderr);
@@ -1148,6 +1184,11 @@ rnp_init(rnp_t *rnp)
 	if (coredumps) {
 		fputs("rnp: warning: core dumps enabled, "
 		      "sensitive data may be leaked to disk\n", io->errs);
+	}
+
+	/* Initialize the context with the default keyring format. */
+	if (! init_default_format(rnp)) {
+		return 0;
 	}
 
 	/* Initialize the context with the default home directory. */
@@ -1600,7 +1641,7 @@ rnp_decrypt_file(rnp_t *rnp, const char *f, char *out, int armored)
 		return 0;
 	}
 	realarmor = isarmoured(io, f, NULL, ARMOR_HEAD);
-	sshkeys = (unsigned)(rnp_getvar(rnp, "ssh keys") != NULL);
+	sshkeys = (unsigned)use_ssh_keys(rnp);
 	if ((numtries = rnp_getvar(rnp, "numtries")) == NULL ||
 	    (attempts = atoi(numtries)) <= 0) {
 		attempts = MAX_PASSPHRASE_ATTEMPTS;
@@ -1665,7 +1706,7 @@ rnp_sign_file(rnp_t *rnp,
 					&pubkey->key.pubkey, 0);
 			}
 		}
-		if (rnp_getvar(rnp, "ssh keys") == NULL) {
+		if (!use_ssh_keys(rnp)) {
 			/* now decrypt key */
 			seckey = pgp_decrypt_seckey(keypair, rnp->passfp);
 			if (seckey == NULL) {
@@ -1794,7 +1835,7 @@ rnp_sign_memory(rnp_t *rnp,
 					&pubkey->key.pubkey, 0);
 			}
 		}
-		if (rnp_getvar(rnp, "ssh keys") == NULL) {
+		if (!use_ssh_keys(rnp)) {
 			/* now decrypt key */
 			seckey = pgp_decrypt_seckey(keypair, rnp->passfp);
 			if (seckey == NULL) {
@@ -1951,7 +1992,7 @@ rnp_decrypt_memory(rnp_t *rnp, const void *input, const size_t insize,
 		return 0;
 	}
 	realarmour = isarmoured(io, NULL, input, ARMOR_HEAD);
-	sshkeys = (unsigned)(rnp_getvar(rnp, "ssh keys") != NULL);
+	sshkeys = (unsigned)use_ssh_keys(rnp);
 	if ((numtries = rnp_getvar(rnp, "numtries")) == NULL ||
 	    (attempts = atoi(numtries)) <= 0) {
 		attempts = MAX_PASSPHRASE_ATTEMPTS;
@@ -2116,6 +2157,17 @@ rnp_incvar(rnp_t *rnp, const char *name, const int delta)
 	}
 	(void) snprintf(num, sizeof(num), "%d", val + delta);
 	rnp_setvar(rnp, name, num);
+	return 1;
+}
+
+/* set keyring format information */
+int
+rnp_set_keyring_format(rnp_t *rnp, char *format)
+{
+	if (! parse_keyring_format(rnp, &rnp->keyring_format, format)) {
+		return 0;
+	}
+	rnp_setvar(rnp, "keyring_format", format);
 	return 1;
 }
 

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -67,6 +67,7 @@ static const char *usage =
 	"\t[--coredumps] AND/OR\n"
 	"\t[--homedir=<homedir>] AND/OR\n"
 	"\t[--keyring=<keyring>] AND/OR\n"
+	"\t[--keyring-format=<format>] AND/OR\n"
 	"\t[--numtries=<attempts>] AND/OR\n"
 	"\t[--userid=<userid>] AND/OR\n"
 	"\t[--maxmemalloc=<number of bytes>] AND/OR\n"
@@ -88,6 +89,7 @@ enum optdefs {
 	/* options */
 	SSHKEYS,
 	KEYRING,
+	KEYRING_FORMAT,
 	USERID,
 	ARMOUR,
 	HOMEDIR,
@@ -137,6 +139,7 @@ static struct option options[] = {
 	{"sshkeyfile",	required_argument, 	NULL,	SSHKEYFILE},
 	{"coredumps",	no_argument, 		NULL,	COREDUMPS},
 	{"keyring",	required_argument, 	NULL,	KEYRING},
+	{"keyring-format",	required_argument,	NULL, 	KEYRING_FORMAT},
 	{"userid",	required_argument, 	NULL,	USERID},
 	{"home",	required_argument, 	NULL,	HOMEDIR},
 	{"homedir",	required_argument, 	NULL,	HOMEDIR},
@@ -383,7 +386,7 @@ setoption(rnp_t *rnp, prog_t *p, int val, char *arg)
 		exit(EXIT_SUCCESS);
 		/* options */
 	case SSHKEYS:
-		rnp_setvar(rnp, "ssh keys", "1");
+		rnp_setvar(rnp, "keyring_format", "SSH");
 		break;
 	case KEYRING:
 		if (arg == NULL) {
@@ -391,6 +394,13 @@ setoption(rnp_t *rnp, prog_t *p, int val, char *arg)
 			exit(EXIT_ERROR);
 		}
 		snprintf(p->keyring, sizeof(p->keyring), "%s", arg);
+		break;
+	case KEYRING_FORMAT:
+		if (arg == NULL) {
+            (void) fprintf(stderr, "No keyring format argument provided\n");
+            exit(EXIT_ERROR);
+		}
+		rnp_setvar(rnp, "keyring_format", arg);
 		break;
 	case USERID:
 		if (arg == NULL) {
@@ -455,7 +465,7 @@ setoption(rnp_t *rnp, prog_t *p, int val, char *arg)
 		rnp_setvar(rnp, "results", arg);
 		break;
 	case SSHKEYFILE:
-		rnp_setvar(rnp, "ssh keys", "1");
+		rnp_setvar(rnp, "keyring_format", "SSH");
 		rnp_setvar(rnp, "sshkeyfile", arg);
 		break;
 	case MAX_MEM_ALLOC:
@@ -556,7 +566,7 @@ main(int argc, char **argv)
 		} else {
 			switch (ch) {
 			case 'S':
-				rnp_setvar(&rnp, "ssh keys", "1");
+				rnp_setvar(&rnp, "keyring_format", "SSH");
 				rnp_setvar(&rnp, "sshkeyfile", optarg);
 				break;
 			case 'V':

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -73,6 +73,7 @@ static const char *usage =
 	"\t[--hash=<hash alg>] AND/OR\n"
 	"\t[--homedir=<homedir>] AND/OR\n"
 	"\t[--keyring=<keyring>] AND/OR\n"
+	"\t[--keyring-format=<format>] AND/OR\n"
 	"\t[--userid=<userid>] AND/OR\n"
 	"\t[--verbose]\n";
 
@@ -92,6 +93,7 @@ enum optdefs {
 	/* options */
 	SSHKEYS,
 	KEYRING,
+	KEYRING_FORMAT,
 	USERID,
 	HOMEDIR,
 	NUMBITS,
@@ -134,6 +136,7 @@ static struct option options[] = {
 	/* options */
 	{"coredumps",	no_argument, 		NULL,	COREDUMPS},
 	{"keyring",	required_argument, 	NULL,	KEYRING},
+	{"keyring-format",	required_argument,	NULL, 	KEYRING_FORMAT},
 	{"userid",	required_argument, 	NULL,	USERID},
 	{"format",	required_argument, 	NULL,	FORMAT},
 	{"hash-alg",	required_argument, 	NULL,	HASH_ALG},
@@ -281,7 +284,7 @@ setoption(rnp_t *rnp, prog_t *p, int val, char *arg)
 		exit(EXIT_SUCCESS);
 		/* options */
 	case SSHKEYS:
-		rnp_setvar(rnp, "ssh keys", "1");
+		rnp_setvar(rnp, "keyring_format", "SSH");
 		break;
 	case KEYRING:
 		if (arg == NULL) {
@@ -290,6 +293,13 @@ setoption(rnp_t *rnp, prog_t *p, int val, char *arg)
 			exit(EXIT_ERROR);
 		}
 		snprintf(p->keyring, sizeof(p->keyring), "%s", arg);
+		break;
+	case KEYRING_FORMAT:
+		if (arg == NULL) {
+            (void) fprintf(stderr, "No keyring format argument provided\n");
+            exit(EXIT_ERROR);
+		}
+		rnp_setvar(rnp, "keyring_format", arg);
 		break;
 	case USERID:
 		if (optarg == NULL) {
@@ -349,7 +359,7 @@ setoption(rnp_t *rnp, prog_t *p, int val, char *arg)
 		rnp_setvar(rnp, "res", arg);
 		break;
 	case SSHKEYFILE:
-		rnp_setvar(rnp, "ssh keys", "1");
+		rnp_setvar(rnp, "keyring_format", "SSH");
 		rnp_setvar(rnp, "sshkeyfile", arg);
 		break;
 	case FORMAT:
@@ -436,7 +446,7 @@ main(int argc, char **argv)
 		} else {
 			switch (ch) {
 			case 'S':
-				rnp_setvar(&rnp, "ssh keys", "1");
+				rnp_setvar(&rnp, "keyring_format", "SSH");
 				rnp_setvar(&rnp, "sshkeyfile", optarg);
 				break;
 			case 'V':


### PR DESCRIPTION
Introduced `rnp_set_keyring_format` to specified a keyring format for #33 

By default the keyring format is GPG, but when someone provides ssh-related option, it switched to SSH.

For example, list keys for different formats:
```
➜  rnp git:(abstract_keyring) ✗ ./src/rnpkeys/rnpkeys --list-keys
1 key found
signature  2048/RSA (Encrypt or Sign) 85af26f0509e9014 2017-05-18
Key fingerprint: 5b4f d40e 3c4f 5b20 b92c 61c0 85af 26f0 509e 9014
uid              RSA 2048-bit key <catap@localhost>

➜  rnp git:(abstract_keyring) ✗ ./src/rnpkeys/rnpkeys --keyring-format=GPG --list-keys
1 key found
signature  2048/RSA (Encrypt or Sign) 85af26f0509e9014 2017-05-18
Key fingerprint: 5b4f d40e 3c4f 5b20 b92c 61c0 85af 26f0 509e 9014
uid              RSA 2048-bit key <catap@localhost>

➜  rnp git:(abstract_keyring) ✗ ./src/rnpkeys/rnpkeys --keyring-format=SSH --list-keys
1 key found
signature  2048/RSA (Encrypt or Sign) 463f788c98577410 1970-01-01
Key fingerprint: 43f4 4c17 47fc 1f5e 44a6 4221 463f 788c 9857 7410
uid              Kirills-MacBookPro.local (/Users/catap/.ssh/id_rsa.pub) <catap@satellite>

➜  rnp git:(abstract_keyring) ✗
```