### PR TITLE
Add a simple fuzzer for public keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ src/cmocka/Makefile
 src/cmocka/Makefile.in
 src/cmocka/config.h
 src/cmocka/rnp_tests
+src/fuzzers/Makefile
+src/fuzzers/Makefile.in
+src/fuzzers/config.h
+src/fuzzers/fuzz_keys
 tests/Makefile
 tests/Makefile.in
 tests/atconfig

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,7 @@ AC_CONFIG_FILES([
         src/rnpkeys/Makefile
         src/rnpv/Makefile
         src/cmocka/Makefile
+        src/fuzzing/Makefile
         tests/Makefile
         tests/atlocal
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = libmj lib rnp rnpkeys rnpv cmocka
+SUBDIRS = libmj lib rnp rnpkeys rnpv cmocka fuzzing

--- a/src/fuzzing/Makefile.am
+++ b/src/fuzzing/Makefile.am
@@ -1,0 +1,9 @@
+AM_CFLAGS		= $(WARNCFLAGS)
+
+bin_PROGRAMS		= fuzz_keys
+
+fuzz_keys_SOURCES		= fuzz_keys.c
+
+fuzz_keys_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/libmj -I$(top_srcdir)/src/lib
+
+fuzz_keys_LDADD		= ../lib/librnp.la

--- a/src/fuzzing/fuzz_keys.c
+++ b/src/fuzzing/fuzz_keys.c
@@ -1,0 +1,15 @@
+#include <stdint.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <rnp.h>
+#include <keyring.h>
+
+int main(int argc, char* argv[])
+   {
+   pgp_keyring_t keyring;
+   memset(&keyring, 0, sizeof(keyring));
+   pgp_keyring_fileread(&keyring, 1, argv[1]);
+   }

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -714,7 +714,7 @@ streamread(pgp_stream_t *stream, unsigned c)
 static int
 coalesce_blocks(pgp_stream_t *stream, unsigned length)
 {
-	unsigned	c;
+	unsigned	c = 0;
 
 	stream->coalescing = 1;
 	/* already read a partial block length - prime the array */

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -832,7 +832,27 @@ disable_core_dumps(void)
 	errno = 0;
 	memset(&limit, 0, sizeof(limit));
 	error = setrlimit(RLIMIT_CORE, &limit);
-	return error != -1 && error > 0 ? 0 : -1;
+
+        if (error == 0)
+           {
+           error = getrlimit(RLIMIT_CORE, &limit);
+           if(error)
+              {
+              return error;
+              }
+           else if(limit.rlim_cur == 0)
+              {
+              return 1; // disabling core dumps ok
+              }
+           else
+              {
+              return 0; // failed for some reason?
+              }
+           }
+        else
+           {
+           return -1;
+           }
 }
 
 /* Disable core dumps according to the coredumps setting variable.
@@ -849,7 +869,7 @@ set_core_dumps(rnp_t *rnp)
 
 	setting = rnp_getvar(rnp, "coredumps") != NULL;
 	if (! setting) {
-		return disable_core_dumps() == 0 ? 0 : 1;
+		return disable_core_dumps() == 0 ? 1 : 0;
 	}
 
 	return 1;


### PR DESCRIPTION
I don't know if you necessarily want to merge this (but maybe you do). Adds a simple fuzzer for key parsing. Using just a single valid public key as initial input, AFL (http://lcamtuf.coredump.cx/afl/) found 38 unique crash bugs in about a minute and a half of runtime (I don't know if all of those are truly unique, sometimes a single bug can be reached by more than one path and that causes AFL to categorize them as different crashes).

Basic usage:

```
CC=afl-gcc ./configure
mkdir afl_in afl_out
cp <some keys> afl_in
afl-fuzz -i afl_in -o afl_out ./src/fuzzing/.libs/fuzz_keys @@ 
(look at the pretty screen until some crashes are found)
valgrind -v ./src/fuzzing/.libs/fuzz_keys < afl_out/crashes/...
```

Example issues

```
==2427== Invalid read of size 4
==2427==    at 0x4E5DAE7: cb_keyring_read (keyring.c:581)
==2427==    by 0x4E8C375: parse_v4_sig (packet-parse.c:1959)
==2427==    by 0x4E8C375: parse_sig (packet-parse.c:2102)
==2427==    by 0x4E8C375: parse_packet (packet-parse.c:3165)
==2427==    by 0x4E8F49A: pgp_parse (packet-parse.c:3295)
==2427==    by 0x4E63602: pgp_parse_and_accumulate (misc.c:193)
==2427==    by 0x4E5FD6A: pgp_keyring_fileread (keyring.c:723)
==2427==    by 0x400856: main (fuzz_keys.c:14)
==2427==  Address 0x1cffffffe50 is not stack'd, malloc'd or (recently) free'd
```

```
==2506== Invalid read of size 1
==2506==    at 0x4C31A38: memmove (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2506==    by 0x4ED468F: read_partial_data (reader.c:134)
==2506==    by 0x4ED468F: mmap_reader (reader.c:2354)
==2506==    by 0x4E80CF2: sub_base_read (packet-parse.c:233)
==2506==    by 0x4ED50F3: read_char (reader.c:443)
==2506==    by 0x4ED50F3: armoured_data_reader (reader.c:1230)
==2506==    by 0x4E80CF2: sub_base_read (packet-parse.c:233)
==2506==    by 0x4E819EF: full_read (packet-parse.c:316)
==2506==    by 0x4E819EF: pgp_limited_read (packet-parse.c:412)
==2506==    by 0x4E852A5: limread_data (packet-parse.c:127)
==2506==    by 0x4E852A5: read_data (packet-parse.c:147)
==2506==    by 0x4E852A5: consume_packet.constprop.11 (packet-parse.c:2336)
==2506==    by 0x4E880CC: parse_packet (packet-parse.c:3228)
==2506==    by 0x4E8F49A: pgp_parse (packet-parse.c:3295)
==2506==    by 0x4E63602: pgp_parse_and_accumulate (misc.c:193)
==2506==    by 0x4E5FD6A: pgp_keyring_fileread (keyring.c:723)
==2506==    by 0x400856: main (fuzz_keys.c:14)
==2506==  Address 0x707751a is 1 bytes after a block of size 185 alloc'd
```

I haven't analyzed any of the crash bugs.

Somewhat unrelated changes made along the way: Fix the coredump logic - conditionals look totally bogus to my eye. This will shut up rnp about not being able to disable coredumps :) And fix a uninitialized variable warning in packet-parse.c - afl-gcc warns about this where gcc doesn't, not sure why. I can split these changes out into a different PR if you don't want to merge the fuzzer stub.
