### PR TITLE
Set feature macros for glibc making nftw and mktdtemp visible

### DIFF
--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -25,6 +25,9 @@
  */
 
 
+#define _XOPEN_SOURCE 500
+#define _POSIX_C_SOURCE 200809
+
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
@@ -34,6 +37,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <limits.h>
+
 #include <ftw.h>
 
 #include <cmocka.h>


### PR DESCRIPTION
Both are not visible by default with glibc 2.25 (on Arch), I see the following errors

```
rnp_tests.c:144:78: error: 'struct FTW' declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
 int remove_cb(const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf)
                                                                              ^~~
rnp_tests.c: In function 'delete_recursively':
rnp_tests.c:162:5: error: implicit declaration of function 'nftw' [-Werror=implicit-function-declaration]
     nftw(path, remove_cb, 64, FTW_DEPTH | FTW_PHYS);
     ^~~~
rnp_tests.c:162:31: error: 'FTW_DEPTH' undeclared (first use in this function)
     nftw(path, remove_cb, 64, FTW_DEPTH | FTW_PHYS);
                               ^~~~~~~~~
rnp_tests.c:162:31: note: each undeclared identifier is reported only once for each function it appears in
rnp_tests.c:162:43: error: 'FTW_PHYS' undeclared (first use in this function)
     nftw(path, remove_cb, 64, FTW_DEPTH | FTW_PHYS);
```