### PR TITLE
Fix an invalid free in the block cipher code (GH #112)

### DIFF
--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -100,7 +100,7 @@ static void
 std_finish(pgp_crypt_t *crypt)
 {
 	if (crypt->block_cipher_obj) {
-		free(crypt->block_cipher_obj);
+		botan_block_cipher_destroy(crypt->block_cipher_obj);
 		crypt->block_cipher_obj = NULL;
 	}
 }
@@ -111,6 +111,7 @@ std_init(pgp_crypt_t *crypt, const char* cipher_name)
 	if (crypt->block_cipher_obj)
         {
            botan_block_cipher_destroy(crypt->block_cipher_obj);
+           crypt->block_cipher_obj = NULL;
 	}
 
         int rc = botan_block_cipher_init(&(crypt->block_cipher_obj), cipher_name);


### PR DESCRIPTION
Was confused that valgrind showed all clean until I realized cmocka runs the tests in a new process (that's how it catches SIGSEGVs and the like inside a test). With `valgrind --trace-children=yes` the error popped right out. Also found a couple of other bugs that I'll post either PRs or issues for momentarily.