### PR TITLE
Fix a 4-byte memory overwrite when encrypting private key with hash=MD5

### DIFF
--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -435,11 +435,13 @@ write_seckey_body(const pgp_seckey_t *key,
 			hashsize = pgp_hash_size(key->hash_alg);
 			needed = PGP_CAST_KEY_LENGTH - done;
 			size = MIN(needed, hashsize);
-			if ((hashed = calloc(1, hashsize)) == NULL) {
+
+			if ((hashed = calloc(1, PGP_SHA1_HASH_SIZE)) == NULL) {
 				(void) fprintf(stderr, "write_seckey_body: bad alloc\n");
 				return 0;
 			}
 			if (!hash.init(&hash)) {
+                                free(hashed);
 				(void) fprintf(stderr, "write_seckey_body: bad alloc\n");
 				return 0;
 			}
@@ -469,6 +471,7 @@ write_seckey_body(const pgp_seckey_t *key,
 			(void) memcpy(&sesskey[i * hashsize],
 					hashed, (unsigned)size);
 			done += (unsigned)size;
+                        free(hashed);
 			if (done > PGP_CAST_KEY_LENGTH) {
 				(void) fprintf(stderr,
 					"write_seckey_body: short add\n");


### PR DESCRIPTION
Found by running valgrind over the tests.

The buffer to hold the hash output was sized to pgp_hash_size(key->hash_alg) but the actual hash used for the S2K is always SHA-1, so with an MD5 hash this caused a 4-byte overflow.

Also, free the buffer :)