### PR TITLE
Initialize memory from realloc in pgp_memory_pad

### DIFF
--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -884,12 +884,15 @@ pgp_memory_pad(pgp_memory_t *mem, size_t length)
 		return;
 	}
 	if (mem->allocated < mem->length + length) {
-		mem->allocated = mem->allocated * 2 + length;
-		temp = realloc(mem->buf, mem->allocated);
+                size_t newsize = mem->allocated * 2 + length;
+		temp = realloc(mem->buf, newsize);
 		if (temp == NULL) {
 			(void) fprintf(stderr, "pgp_memory_pad: bad alloc\n");
+                        // TODO return an error here
 		} else {
 			mem->buf = temp;
+                        memset(mem->buf + mem->allocated, 0, newsize - mem->allocated);
+                        mem->allocated = newsize;
 		}
 	}
 	if (mem->allocated < mem->length + length) {


### PR DESCRIPTION
I'm not so certain about this change, it might just be papering over some other problem. But I see the following in valgrind

```
Conditional jump or move depends on uninitialised value(s)
    at 0x4C2E128: strlen (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4E4CB6D: rnp_strdup (misc.c:1344)
    by 0x4E4AA38: pgp_export_key (keyring.c:1067)
    by 0x401996: rnpkeys_exportkey_verifyUserId (rnp_tests.c:928)
  Uninitialised value was created by a heap allocation
    at 0x4C2D13F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    by 0x4E4B6DB: pgp_memory_pad (misc.c:888)
    by 0x4E4B794: pgp_memory_add (misc.c:910)
    by 0x4E64DAF: memory_writer (writer.c:1271)
```

Zeroing the return value of `realloc` at least prevents using uninitialized memory.

Maybe the problem really is that `pgp_write_xfer_pubkey` and `pgp_write_xfer_seckey`, if emitting armored data, need to emit a trailing null at the end?

Consider this more of an issue for discussion than a patch, though maybe zeroing this memory really is the right thing to do.