### PR TITLE
Clean up symmetric cipher code

### DIFF
--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -273,32 +273,32 @@ static void cipher_test_success(void **state)
 
     memset(iv, 0x42, sizeof(iv));
 
-    crypt.set_crypt_key(&crypt, key);
-    crypt.block_encrypt(&crypt, block, block);
+    pgp_cipher_set_key(&crypt, key);
+    pgp_cipher_block_encrypt(&crypt, block, block);
 
     test_value_equal("AES ECB encrypt",
             "66E94BD4EF8A2C3B884CFA59CA342B2E",
             block, sizeof(block));
 
-    crypt.block_decrypt(&crypt, block, block);
+    pgp_cipher_block_decrypt(&crypt, block, block);
 
     test_value_equal("AES ECB decrypt",
             "00000000000000000000000000000000",
             block, sizeof(block));
 
-    crypt.set_iv(&crypt, iv);
-    crypt.cfb_encrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data));
+    pgp_cipher_set_iv(&crypt, iv);
+    pgp_cipher_cfb_encrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data));
 
     test_value_equal("AES CFB encrypt",
             "BFDAA57CB812189713A950AD9947887983021617",
             cfb_data, sizeof(cfb_data));
 
-    crypt.set_iv(&crypt, iv);
-    crypt.cfb_decrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data));
+    pgp_cipher_set_iv(&crypt, iv);
+    pgp_cipher_cfb_decrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data));
     test_value_equal("AES CFB decrypt",
             "0000000000000000000000000000000000000000",
             cfb_data, sizeof(cfb_data));
-    crypt.decrypt_finish(&crypt);
+    pgp_cipher_finish(&crypt);
 }
 
 static void pkcs1_rsa_test_success(void **state)

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -521,8 +521,6 @@ static void rnpkeys_generatekey_testSignature(void **state)
                                 continue;
                         }
 
-                        printf("Testing cleartext=%d armor=%d\n", cleartext, armored);
-
                         close(pipefd[0]);
                         /* Setup the pass phrase fd to avoid user-input*/
                         assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -558,6 +556,89 @@ static void rnpkeys_generatekey_testSignature(void **state)
 
         rnp_end(&rnp); //Free memory and other allocated resources.
     }
+}
+
+static void rnpkeys_generatekey_testEncryption(void **state)
+{
+        const char* cipherAlg[] = {
+                "Blowfish",
+                "Twofish",
+                "CAST5",
+                "TripleDES",
+                "AES128",
+                "AES192",
+                "AES256",
+                "Camellia128",
+                "Camellia192",
+                "Camellia256",
+                NULL
+        };
+
+        rnp_t rnp;
+        const int numbits = 1024;
+        char passfd[4] = {0};
+        int pipefd[2];
+
+        char memToEncrypt[] = "A simple test message";
+        char ciphertextBuf[4096] = { 0 };
+        char plaintextBuf[4096] = { 0 };
+        char userId[128] = { 0 };
+
+        /* Setup the pass phrase fd to avoid user-input*/
+        assert_int_equal(setupPassphrasefd(pipefd), 1);
+
+        /*Initialize the basic RNP structure. */
+        memset(&rnp, '\0', sizeof(rnp));
+
+        /*Set the default parameters*/
+        rnp_setvar(&rnp, "sshkeydir", "/etc/ssh");
+        rnp_setvar(&rnp, "res",       "<stdout>");
+
+        rnp_setvar(&rnp, "format",    "human");
+        rnp_setvar(&rnp, "pass-fd",  uint_to_string(passfd,4,pipefd[0],16));
+        rnp_setvar(&rnp, "need seckey", "true");
+
+        int retVal = rnp_init (&rnp);
+        assert_int_equal(retVal,1); //Ensure the rnp core structure is correctly initialized.
+
+        strcpy(userId, "ciphertest");
+
+        retVal = rnp_generate_key(&rnp, userId, numbits);
+        assert_int_equal(retVal,1); //Ensure the key was generated 
+
+        /*Load the newly generated rnp key*/
+        retVal = rnp_load_keys(&rnp);
+        assert_int_equal(retVal,1); //Ensure the keyring is loaded. 
+
+        retVal = rnp_find_key(&rnp, userId);
+        assert_int_equal(retVal,1); //Ensure the key can be found with the userId
+
+        for (int i = 0; cipherAlg[i] != NULL; i++)
+        {
+                for(unsigned int armored = 0; armored <= 1; ++armored)
+                {
+                        rnp_setvar(&rnp, "pass-fd",  uint_to_string(passfd,4,pipefd[0],16));
+                        assert_int_equal(rnp_setvar(&rnp, "cipher",     cipherAlg[i]), 1);
+
+                        retVal = rnp_encrypt_memory(&rnp, userId, memToEncrypt, strlen(memToEncrypt),
+                                                    ciphertextBuf, sizeof(ciphertextBuf), armored);
+                        assert_int_not_equal(retVal, 0); // Ensure signature operation succeeded
+
+                        const int ctextLen = retVal;
+
+                        close(pipefd[0]);
+                        /* Setup the pass phrase fd to avoid user-input*/
+                        assert_int_equal(setupPassphrasefd(pipefd), 1);
+                        retVal = rnp_decrypt_memory(&rnp, ciphertextBuf, ctextLen,
+                                                    plaintextBuf, sizeof(plaintextBuf),
+                                                    armored);
+
+                        // Ensure plaintext recovered
+                        assert_int_equal(retVal, strlen(memToEncrypt));
+                        assert_string_equal(memToEncrypt, plaintextBuf);
+                }
+        }
+        rnp_end(&rnp); //Free memory and other allocated resources.
 }
 
 static void rnpkeys_generatekey_verifySupportedHashAlg(void **state)
@@ -987,6 +1068,7 @@ int main(void) {
         cmocka_unit_test(pkcs1_rsa_test_success),
         cmocka_unit_test(raw_elg_test_success),
         cmocka_unit_test(rnpkeys_generatekey_testSignature),
+        cmocka_unit_test(rnpkeys_generatekey_testEncryption),
         cmocka_unit_test(rnpkeys_generatekey_verifySupportedHashAlg),
         cmocka_unit_test(rnpkeys_generatekey_verifyUserIdOption),
         cmocka_unit_test(rnpkeys_generatekey_verifykeyHomeDirOption),

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -494,8 +494,8 @@ write_seckey_body(const pgp_seckey_t *key,
 	/* use this session key to encrypt */
 
 	pgp_crypt_any(&crypted, key->alg);
-	crypted.set_iv(&crypted, key->iv);
-	crypted.set_crypt_key(&crypted, sesskey);
+        pgp_cipher_set_iv(&crypted, key->iv);
+        pgp_cipher_set_key(&crypted, sesskey);
 	pgp_encrypt_init(&crypted);
 
 	if (pgp_get_debug_level(__FILE__)) {

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -61,39 +61,13 @@
 #include "packet.h"
 #include "memory.h"
 #include "packet-parse.h"
+#include "symmetric.h"
 #include "bn.h"
 
 #define PGP_MIN_HASH_SIZE	16
 
 struct PGPV_BIGNUM_st {
    botan_mp_t mp;
-};
-
-/** pgp_crypt_t */
-struct pgp_crypt_t {
-	pgp_symm_alg_t	alg;
-	size_t			blocksize;
-	size_t			keysize;
-	void 			(*set_iv)(pgp_crypt_t *, const uint8_t *);
-	void			(*set_crypt_key)(pgp_crypt_t *, const uint8_t *);
-	int			(*base_init)(pgp_crypt_t *);
-	void			(*decrypt_resync)(pgp_crypt_t *);
-	/* encrypt/decrypt one block */
-	void			(*block_encrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *);
-	void			(*block_decrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *);
-	/* Standard CFB encrypt/decrypt (as used by Sym Enc Int Prot packets) */
-	void 			(*cfb_encrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *, size_t);
-	void			(*cfb_decrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *, size_t);
-	void			(*decrypt_finish)(pgp_crypt_t *);
-	uint8_t			iv[PGP_MAX_BLOCK_SIZE];
-	uint8_t			civ[PGP_MAX_BLOCK_SIZE];
-	uint8_t			siv[PGP_MAX_BLOCK_SIZE];
-		/* siv is needed for weird v3 resync */
-	uint8_t			key[PGP_MAX_KEY_SIZE];
-	int			num;
-		/* num is offset for CFB */
-	struct botan_block_cipher_struct			*block_cipher_obj;
-
 };
 
 void pgp_crypto_finish(void);
@@ -180,23 +154,6 @@ int pgp_elgamal_private_decrypt_pkcs1(
         size_t length,
 		const pgp_elgamal_seckey_t *seckey,
 		const pgp_elgamal_pubkey_t *pubkey);
-
-pgp_symm_alg_t pgp_str_to_cipher(const char *);
-unsigned pgp_block_size(pgp_symm_alg_t);
-unsigned pgp_key_size(pgp_symm_alg_t);
-
-int pgp_decrypt_data(pgp_content_enum, pgp_region_t *,
-			pgp_stream_t *);
-
-int pgp_crypt_any(pgp_crypt_t *, pgp_symm_alg_t);
-int pgp_decrypt_init(pgp_crypt_t *);
-int pgp_encrypt_init(pgp_crypt_t *);
-
-size_t pgp_decrypt_se(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_encrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-unsigned pgp_is_sa_supported(pgp_symm_alg_t);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *,
 			pgp_region_t *);

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -620,37 +620,6 @@ pgp_calc_mdc_hash(const uint8_t *preamble,
 	}
 }
 
-/* structure to map string to cipher def */
-typedef struct str2cipher_t {
-	const char	*s;	/* cipher name */
-	pgp_symm_alg_t i;	/* cipher def */
-} str2cipher_t;
-
-static str2cipher_t	str2cipher[] = {
-	{	"cast5",		PGP_SA_CAST5		},
-	{	"idea",			PGP_SA_IDEA		},
-	{	"aes128",		PGP_SA_AES_128		},
-	{	"aes256",		PGP_SA_AES_256		},
-	{	"camellia128",		PGP_SA_CAMELLIA_128	},
-	{	"camellia256",		PGP_SA_CAMELLIA_256	},
-	{	"tripledes",		PGP_SA_TRIPLEDES	},
-	{	NULL,			0			}
-};
-
-/* convert from a string to a cipher definition */
-pgp_symm_alg_t
-pgp_str_to_cipher(const char *cipher)
-{
-	str2cipher_t	*sp;
-
-	for (sp = str2cipher ; cipher && sp->s ; sp++) {
-		if (rnp_strcasecmp(cipher, sp->s) == 0) {
-			return sp->i;
-		}
-	}
-	return PGP_SA_DEFAULT_CIPHER;
-}
-
 void
 pgp_random(void *dest, size_t length)
 {

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -2569,8 +2569,8 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
 			hexdump(stderr, "input iv", pkt.u.seckey.iv, pgp_block_size(pkt.u.seckey.alg));
 			hexdump(stderr, "key", key, PGP_CAST_KEY_LENGTH);
 		}
-		decrypt.set_iv(&decrypt, pkt.u.seckey.iv);
-		decrypt.set_crypt_key(&decrypt, key);
+                pgp_cipher_set_iv(&decrypt, pkt.u.seckey.iv);
+                pgp_cipher_set_key(&decrypt, key);
 
 		/* now read encrypted data */
 
@@ -2881,8 +2881,8 @@ parse_pk_sesskey(pgp_region_t *region,
 		(void) fprintf(stderr, "parse_pk_sesskey: bad alloc\n");
 		return 0;
 	}
-	stream->decrypt.set_iv(&stream->decrypt, iv);
-	stream->decrypt.set_crypt_key(&stream->decrypt, pkt.u.pk_sesskey.key);
+        pgp_cipher_set_iv(&stream->decrypt, iv);
+        pgp_cipher_set_key(&stream->decrypt, pkt.u.pk_sesskey.key);
 	pgp_encrypt_init(&stream->decrypt);
 	free(iv);
 	return 1;
@@ -2919,9 +2919,8 @@ decrypt_se_data(pgp_content_enum tag, pgp_region_t *region,
 			return 0;
 		}
 		if (tag == PGP_PTAG_CT_SE_DATA_BODY) {
-			decrypt->decrypt_resync(decrypt);
-			decrypt->block_encrypt(decrypt, decrypt->civ,
-					decrypt->civ);
+                        pgp_cipher_cfb_resync(decrypt);
+                        pgp_cipher_block_encrypt(decrypt, decrypt->civ, decrypt->civ);
 		}
 		r = pgp_parse(stream, !printerrors);
 

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -1407,7 +1407,7 @@ encrypted_data_reader(pgp_stream_t *stream, void *dest,
 				"encrypted_data_reader: bad v3 secret\n");
 			return -1;
 		}
-		encrypted->decrypt->decrypt_resync(encrypted->decrypt);
+                pgp_cipher_cfb_resync(encrypted->decrypt);
 		encrypted->prevplain = 0;
 	} else if (readinfo->parent->reading_v3_secret &&
 		   readinfo->parent->reading_mpi_len) {
@@ -1536,7 +1536,7 @@ pgp_reader_pop_decrypt(pgp_stream_t *stream)
 	encrypted_t	*encrypted;
 
 	encrypted = pgp_reader_get_arg(pgp_readinfo(stream));
-	encrypted->decrypt->decrypt_finish(encrypted->decrypt);
+        pgp_cipher_finish(encrypted->decrypt);
 	free(encrypted);
 	pgp_reader_pop(stream);
 }

--- a/src/lib/ssh2pgp.c
+++ b/src/lib/ssh2pgp.c
@@ -439,8 +439,8 @@ pgp_ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey
 		}
 	}
 	pgp_crypt_any(&crypted, key->key.seckey.alg);
-	crypted.set_iv(&crypted, key->key.seckey.iv);
-	crypted.set_crypt_key(&crypted, sesskey);
+        pgp_cipher_set_iv(&crypted, key->key.seckey.iv);
+        pgp_cipher_set_key(&crypted, sesskey);
 	pgp_encrypt_init(&crypted);
 	key->key.seckey.pubkey.alg = PGP_PKA_RSA;
 	pgp_fingerprint(&key->sigfingerprint, pubkey, hashtype);

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -68,6 +68,7 @@ __RCSID("$NetBSD: symmetric.c,v 1.18 2010/11/07 08:39:59 agc Exp $");
 #include "crypto.h"
 #include "packet-show.h"
 #include "rnpdefs.h"
+#include "rnpsdk.h"
 
 int pgp_cipher_set_iv(pgp_crypt_t* cipher, const uint8_t *iv)
 {
@@ -157,6 +158,42 @@ pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
    }
    return 0;
 }
+
+/* structure to map string to cipher def */
+typedef struct str2cipher_t {
+	const char	*s;	/* cipher name */
+	pgp_symm_alg_t i;	/* cipher def */
+} str2cipher_t;
+
+static str2cipher_t	str2cipher[] = {
+	{	"cast5",		PGP_SA_CAST5		},
+	{	"idea",			PGP_SA_IDEA		},
+	{	"blowfish",		PGP_SA_BLOWFISH		},
+	{	"twofish",		PGP_SA_TWOFISH		},
+	{	"aes128",		PGP_SA_AES_128		},
+	{	"aes192",		PGP_SA_AES_192		},
+	{	"aes256",		PGP_SA_AES_256		},
+	{	"camellia128",		PGP_SA_CAMELLIA_128	},
+	{	"camellia192",		PGP_SA_CAMELLIA_192	},
+	{	"camellia256",		PGP_SA_CAMELLIA_256	},
+	{	"tripledes",		PGP_SA_TRIPLEDES	},
+	{	NULL,			0			}
+};
+
+/* convert from a string to a cipher definition */
+pgp_symm_alg_t
+pgp_str_to_cipher(const char *cipher)
+{
+	str2cipher_t	*sp;
+
+	for (sp = str2cipher ; cipher && sp->s ; sp++) {
+		if (rnp_strcasecmp(cipher, sp->s) == 0) {
+			return sp->i;
+		}
+	}
+	return PGP_SA_DEFAULT_CIPHER;
+}
+
 
 static
 const char* pgp_sa_to_botan_string(pgp_symm_alg_t alg)

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -69,24 +69,23 @@ __RCSID("$NetBSD: symmetric.c,v 1.18 2010/11/07 08:39:59 agc Exp $");
 #include "packet-show.h"
 #include "rnpdefs.h"
 
-static void 
-std_set_iv(pgp_crypt_t *crypt, const uint8_t *iv)
+int pgp_cipher_set_iv(pgp_crypt_t* cipher, const uint8_t *iv)
 {
-	(void) memcpy(crypt->iv, iv, crypt->blocksize);
-	crypt->num = 0;
+	(void) memcpy(cipher->iv, iv, cipher->blocksize);
+	cipher->num = 0;
+        return 0;
 }
 
-static void 
-std_set_key(pgp_crypt_t *crypt, const uint8_t *key)
+int pgp_cipher_set_key(pgp_crypt_t* cipher, const uint8_t *key)
 {
-	(void) memcpy(crypt->key, key, crypt->keysize);
+	(void) memcpy(cipher->key, key, cipher->keysize);
+        return 0;
 }
 
-static void 
-std_resync(pgp_crypt_t *decrypt)
+int pgp_cipher_cfb_resync(pgp_crypt_t *decrypt)
 {
 	if ((size_t) decrypt->num == decrypt->blocksize) {
-		return;
+		return 0;
 	}
 
 	memmove(decrypt->civ + decrypt->blocksize - decrypt->num, decrypt->civ,
@@ -94,55 +93,36 @@ std_resync(pgp_crypt_t *decrypt)
 	(void) memcpy(decrypt->civ, decrypt->siv + decrypt->num,
 	       decrypt->blocksize - decrypt->num);
 	decrypt->num = 0;
+        return 0;
 }
 
-static void 
-std_finish(pgp_crypt_t *crypt)
+int pgp_cipher_finish(pgp_crypt_t *crypt)
 {
 	if (crypt->block_cipher_obj) {
 		botan_block_cipher_destroy(crypt->block_cipher_obj);
 		crypt->block_cipher_obj = NULL;
 	}
+        return 0;
 }
 
-static int 
-std_init(pgp_crypt_t *crypt, const char* cipher_name)
+int
+pgp_cipher_block_encrypt(const pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
 {
-	if (crypt->block_cipher_obj)
-        {
-           botan_block_cipher_destroy(crypt->block_cipher_obj);
-           crypt->block_cipher_obj = NULL;
-	}
-
-        int rc = botan_block_cipher_init(&(crypt->block_cipher_obj), cipher_name);
-        if (rc != 0)
-        {
-           (void) fprintf(stderr, "Block cipher '%s' not available %d\n", cipher_name, rc);
-           return 0;
-        }
-
-        if (botan_block_cipher_set_key(crypt->block_cipher_obj, crypt->key, crypt->keysize))
-        {
-           (void) fprintf(stderr, "failure setting key\n");
-           return 0;
-        }
-	return 1;
+        if (botan_block_cipher_encrypt_blocks(crypt->block_cipher_obj, in, out, 1) == 0)
+                return 0;
+        return -1;
 }
 
-static void 
-std_block_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
+int
+pgp_cipher_block_decrypt(const pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
 {
-   botan_block_cipher_encrypt_blocks(crypt->block_cipher_obj, in, out, 1);
+        if (botan_block_cipher_decrypt_blocks(crypt->block_cipher_obj, in, out, 1) == 0)
+                return 0;
+        return -1;
 }
 
-static void 
-std_block_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
-{
-   botan_block_cipher_decrypt_blocks(crypt->block_cipher_obj, in, out, 1);
-}
-
-static void
-std_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
+int
+pgp_cipher_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
 {
    for(size_t i = 0; i < bytes; ++i)
    {
@@ -155,10 +135,11 @@ std_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t byte
 
       crypt->num = (crypt->num + 1) % crypt->blocksize;
    }
+   return 0;
 }
 
-static void 
-std_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
+int
+pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
 {
    for(size_t i = 0; i < bytes; ++i)
    {
@@ -174,288 +155,127 @@ std_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t byte
 
       crypt->num = (crypt->num + 1) % crypt->blocksize;
    }
+   return 0;
 }
 
-#define TRAILER		"","","","",0,NULL
-
-#if defined(BOTAN_HAS_CAST)
-
-static int 
-cast5_init(pgp_crypt_t *crypt)
+static
+const char* pgp_sa_to_botan_string(pgp_symm_alg_t alg)
 {
-        return std_init(crypt, "CAST-128");
-}
-
-#define CAST_BLOCK 8
-#define CAST_KEY_LENGTH 16
-
-static pgp_crypt_t cast5 =
-{
-	PGP_SA_CAST5,
-	CAST_BLOCK,
-	CAST_KEY_LENGTH,
-	std_set_iv,
-	std_set_key,
-	cast5_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
-#endif
-
+        switch(alg)
+        {
 #if defined(BOTAN_HAS_IDEA)
-
-static int 
-idea_init(pgp_crypt_t *crypt)
-{
-        return std_init(crypt, "IDEA");
-}
-
-#define IDEA_BLOCK 8
-#define IDEA_KEY_LENGTH 16
-
-static const pgp_crypt_t idea =
-{
-	PGP_SA_IDEA,
-	IDEA_BLOCK,
-	IDEA_KEY_LENGTH,
-	std_set_iv,
-	std_set_key,
-	idea_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
-#endif
-
-#if defined(BOTAN_HAS_AES)
-
-/* AES with 128-bit key (AES) */
-
-#define KEYBITS_AES128 128
-
-static int 
-aes128_init(pgp_crypt_t *crypt)
-{
-        return std_init(crypt, "AES-128");
-}
-
-#define AES_BLOCK_SIZE 16
-#define AES128_KEY_LENGTH 16
-
-static const pgp_crypt_t aes128 =
-{
-	PGP_SA_AES_128,
-	AES_BLOCK_SIZE,
-	AES128_KEY_LENGTH,
-	std_set_iv,
-	std_set_key,
-	aes128_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
-/* AES with 256-bit key */
-
-#define AES256_KEY_LENGTH 32
-
-static int 
-aes256_init(pgp_crypt_t *crypt)
-{
-        return std_init(crypt, "AES-256");
-}
-
-static const pgp_crypt_t aes256 =
-{
-	PGP_SA_AES_256,
-	AES_BLOCK_SIZE,
-        AES256_KEY_LENGTH,
-	std_set_iv,
-	std_set_key,
-	aes256_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
+	case PGP_SA_IDEA: return "IDEA";
 #endif
 
 #if defined(BOTAN_HAS_DES)
-
-/* Triple DES */
-
-static int 
-tripledes_init(pgp_crypt_t *crypt)
-{
-        return std_init(crypt, "3DES");
-}
-
-static const pgp_crypt_t tripledes =
-{
-	PGP_SA_TRIPLEDES,
-	8,
-	24,
-	std_set_iv,
-	std_set_key,
-	tripledes_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
+	case PGP_SA_TRIPLEDES: return "TripleDES";
 #endif
 
-#if defined(BOTAN_HAS_CAMELLIA)
-
-/* Camellia with 128-bit key (CAMELLIA) */
-
-#define CAMELLIA_BLOCK_SIZE 16
-#define CAMELLIA128_KEY_LENGTH 16
-
-static int 
-camellia128_init(pgp_crypt_t *crypt)
-{
-        return std_init(crypt, "Camellia-128");
-}
-
-static const pgp_crypt_t camellia128 =
-{
-	PGP_SA_CAMELLIA_128,
-	CAMELLIA_BLOCK_SIZE,
-        CAMELLIA128_KEY_LENGTH,
-	std_set_iv,
-	std_set_key,
-	camellia128_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
-/* Camellia with 256-bit key (CAMELLIA) */
-
-#define CAMELLIA256_KEY_LENGTH 32
-
-static int 
-camellia256_init(pgp_crypt_t *crypt)
-{
-        return std_init(crypt, "Camellia-256");
-}
-
-static const pgp_crypt_t camellia256 =
-{
-	PGP_SA_CAMELLIA_256,
-	CAMELLIA_BLOCK_SIZE,
-        CAMELLIA256_KEY_LENGTH,
-	std_set_iv,
-	std_set_key,
-	camellia256_init,
-	std_resync,
-	std_block_encrypt,
-	std_block_decrypt,
-	std_cfb_encrypt,
-	std_cfb_decrypt,
-	std_finish,
-	TRAILER
-};
-
-#endif
-
-static const pgp_crypt_t *
-get_proto(pgp_symm_alg_t alg)
-{
-        // TODO: check botan/build.h macros?
-	switch (alg) {
 #if defined(BOTAN_HAS_CAST)
-	case PGP_SA_CAST5:
-		return &cast5;
+	case PGP_SA_CAST5: return "CAST-128";
 #endif
 
-#if defined(BOTAN_HAS_IDEA)
-	case PGP_SA_IDEA:
-		return &idea;
+#if defined(BOTAN_HAS_BLOWFISH)
+	case PGP_SA_BLOWFISH: return "Blowfish";
 #endif
 
 #if defined(BOTAN_HAS_AES)
-	case PGP_SA_AES_128:
-		return &aes128;
-	case PGP_SA_AES_256:
-		return &aes256;
+	case PGP_SA_AES_128: return "AES-128";
+	case PGP_SA_AES_192: return "AES-192";
+	case PGP_SA_AES_256: return "AES-256";
+#endif
+
+#if defined(BOTAN_HAS_TWOFISH)
+	case PGP_SA_TWOFISH: return "Twofish";
 #endif
 
 #if defined(BOTAN_HAS_CAMELLIA)
-	case PGP_SA_CAMELLIA_128:
-		return &camellia128;
-	case PGP_SA_CAMELLIA_256:
-		return &camellia256;
+	case PGP_SA_CAMELLIA_128: return "Camellia-128";
+	case PGP_SA_CAMELLIA_192: return "Camellia-192";
+	case PGP_SA_CAMELLIA_256: return "Camellia-256";
 #endif
 
-#if defined(BOTAN_HAS_DES)
-	case PGP_SA_TRIPLEDES:
-		return &tripledes;
-#endif
-
-	default:
-		(void) fprintf(stderr, "Unknown algorithm: %d (%s)\n",
-			alg, pgp_show_symm_alg(alg));
-	}
-	return NULL;
+        case PGP_SA_PLAINTEXT:
+                return NULL; // ???
+        default:
+                fprintf(stderr, "Unsupported PGP symmetric alg %d", (int)alg);
+                return NULL;
+        }
 }
 
-int 
+int
 pgp_crypt_any(pgp_crypt_t *crypt, pgp_symm_alg_t alg)
 {
-	const pgp_crypt_t *ptr = get_proto(alg);
+        const char* cipher_name = pgp_sa_to_botan_string(alg);
+        if (cipher_name == NULL)
+                return 0;
 
-	if (ptr) {
-		*crypt = *ptr;
-		return 1;
-	} else {
-		(void) memset(crypt, 0x0, sizeof(*crypt));
-		return 0;
-	}
+        memset(crypt, 0x0, sizeof(*crypt));
+
+        crypt->alg = alg;
+        crypt->blocksize = pgp_block_size(alg);
+        crypt->keysize = pgp_key_size(alg);
+
+        if (botan_block_cipher_init(&(crypt->block_cipher_obj), cipher_name) != 0)
+        {
+           (void) fprintf(stderr, "Block cipher '%s' not available\n", cipher_name);
+           return 0;
+        }
+
+        return 1;
 }
 
-unsigned 
+unsigned
 pgp_block_size(pgp_symm_alg_t alg)
 {
-	const pgp_crypt_t *p = get_proto(alg);
+        switch(alg)
+        {
+	case PGP_SA_IDEA:
+	case PGP_SA_TRIPLEDES:
+	case PGP_SA_CAST5:
+	case PGP_SA_BLOWFISH:
+                return 8;
 
-	return (p == NULL) ? 0 : (unsigned)p->blocksize;
+	case PGP_SA_AES_128:
+	case PGP_SA_AES_192:
+	case PGP_SA_AES_256:
+	case PGP_SA_TWOFISH:
+	case PGP_SA_CAMELLIA_128:
+	case PGP_SA_CAMELLIA_192:
+	case PGP_SA_CAMELLIA_256:
+                return 16;
+
+        default:
+                fprintf(stderr, "Unknown PGP symmetric alg %d", (int)alg);
+                return 0;
+        }
 }
 
-unsigned 
+unsigned
 pgp_key_size(pgp_symm_alg_t alg)
 {
-	const pgp_crypt_t *p = get_proto(alg);
+        switch(alg)
+        {
+	case PGP_SA_IDEA:
+	case PGP_SA_CAST5:
+	case PGP_SA_BLOWFISH:
+	case PGP_SA_AES_128:
+	case PGP_SA_CAMELLIA_128:
+                return 16;
 
-	return (p == NULL) ? 0 : (unsigned)p->keysize;
+	case PGP_SA_TRIPLEDES:
+	case PGP_SA_AES_192:
+	case PGP_SA_CAMELLIA_192:
+                return 24;
+
+	case PGP_SA_TWOFISH:
+	case PGP_SA_AES_256:
+	case PGP_SA_CAMELLIA_256:
+                return 32;
+
+        default:
+                return 0;
+        }
 }
 
 int
@@ -466,16 +286,18 @@ pgp_encrypt_init(pgp_crypt_t *encrypt)
 }
 
 int
-pgp_decrypt_init(pgp_crypt_t *decrypt)
+pgp_decrypt_init(pgp_crypt_t *crypt)
 {
-        if(decrypt->base_init(decrypt) == 1)
+        if (botan_block_cipher_set_key(crypt->block_cipher_obj, crypt->key, crypt->keysize) != 0)
         {
-           decrypt->block_encrypt(decrypt, decrypt->siv, decrypt->iv);
-           (void) memcpy(decrypt->civ, decrypt->siv, decrypt->blocksize);
-           decrypt->num = 0;
-           return 1;
+           (void) fprintf(stderr, "Failure setting key on block cipher object\n");
+           return 0;
         }
-        return 0;
+
+        pgp_cipher_block_encrypt(crypt, crypt->siv, crypt->iv);
+        (void) memcpy(crypt->civ, crypt->siv, crypt->blocksize);
+        crypt->num = 0;
+        return 1;
 }
 
 size_t
@@ -496,8 +318,7 @@ pgp_decrypt_se(pgp_crypt_t *decrypt, void *outvoid, const void *invoid,
 		if ((size_t) decrypt->num == decrypt->blocksize) {
 			(void) memcpy(decrypt->siv, decrypt->civ,
 					decrypt->blocksize);
-			decrypt->block_decrypt(decrypt, decrypt->civ,
-					decrypt->civ);
+                        pgp_cipher_block_decrypt(decrypt, decrypt->civ, decrypt->civ);
 			decrypt->num = 0;
 		}
 		t = decrypt->civ[decrypt->num];
@@ -507,7 +328,7 @@ pgp_decrypt_se(pgp_crypt_t *decrypt, void *outvoid, const void *invoid,
 	return (size_t)saved;
 }
 
-size_t 
+size_t
 pgp_encrypt_se(pgp_crypt_t *encrypt, void *outvoid, const void *invoid,
 	       size_t count)
 {
@@ -523,8 +344,7 @@ pgp_encrypt_se(pgp_crypt_t *encrypt, void *outvoid, const void *invoid,
 		if ((size_t) encrypt->num == encrypt->blocksize) {
 			(void) memcpy(encrypt->siv, encrypt->civ,
 					encrypt->blocksize);
-			encrypt->block_encrypt(encrypt, encrypt->civ,
-					encrypt->civ);
+                        pgp_cipher_block_encrypt(encrypt, encrypt->civ, encrypt->civ);
 			encrypt->num = 0;
 		}
 		encrypt->civ[encrypt->num] = *out++ =
@@ -541,20 +361,19 @@ pgp_encrypt_se(pgp_crypt_t *encrypt, void *outvoid, const void *invoid,
 \param alg Symmetric Algorithm to check
 \return 1 if supported; else 0
 */
-unsigned 
+unsigned
 pgp_is_sa_supported(pgp_symm_alg_t alg)
 {
-        const pgp_crypt_t* proto = get_proto(alg);
-        if (proto != 0) {
+        const char* cipher_name = pgp_sa_to_botan_string(alg);
+        if (cipher_name != NULL)
                 return 1;
-        }
 
 	fprintf(stderr, "\nWarning: %s not supported\n",
 		pgp_show_symm_alg(alg));
 	return 0;
 }
 
-size_t 
+size_t
 pgp_encrypt_se_ip(pgp_crypt_t *crypt, void *out, const void *in,
 		  size_t count)
 {
@@ -562,13 +381,13 @@ pgp_encrypt_se_ip(pgp_crypt_t *crypt, void *out, const void *in,
 		return 0;
 	}
 
-	crypt->cfb_encrypt(crypt, out, in, count);
+        pgp_cipher_cfb_encrypt(crypt, out, in, count);
 
 	/* \todo test this number was encrypted */
 	return count;
 }
 
-size_t 
+size_t
 pgp_decrypt_se_ip(pgp_crypt_t *crypt, void *out, const void *in,
 		  size_t count)
 {
@@ -576,7 +395,7 @@ pgp_decrypt_se_ip(pgp_crypt_t *crypt, void *out, const void *in,
 		return 0;
 	}
 
-	crypt->cfb_decrypt(crypt, out, in, count);
+        pgp_cipher_cfb_decrypt(crypt, out, in, count);
 
 	/* \todo check this number was in fact decrypted */
 	return count;

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -73,7 +73,6 @@ unsigned pgp_block_size(pgp_symm_alg_t);
 unsigned pgp_key_size(pgp_symm_alg_t);
 unsigned pgp_is_sa_supported(pgp_symm_alg_t);
 
-
 int pgp_crypt_any(pgp_crypt_t *, pgp_symm_alg_t);
 int pgp_decrypt_init(pgp_crypt_t *);
 int pgp_encrypt_init(pgp_crypt_t *);
@@ -99,38 +98,5 @@ size_t pgp_decrypt_se(pgp_crypt_t *, void *, const void *, size_t);
 size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
 size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
 size_t pgp_encrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-
-
-#if 0
-// Initialize a cipher object
-void pgp_cipher_create(pgp_cipher_t** cipher, pgp_symm_alg_t algo);
-
-// Destroy a cipher object, freeing all resources
-void pgp_cipher_finish(pgp_cipher_t* cipher);
-
-// Return blocksize of cipher or 0 if error
-size_t pgp_cipher_blocksize(const pgp_cipher_t* cipher);
-
-// Return key length of cipher or 0 if error
-size_t pgp_cipher_keysize(const pgp_cipher_t* cipher);
-
-// IV is always pgp_cipher_blocksize(cipher) bytes long
-void pgp_cipher_set_iv(pgp_cipher_t* cipher, const uint8_t iv[]);
-
-// Key is always pgp_cipher_keysize(cipher) bytes long
-void pgp_cipher_set_key(pgp_cipher_t* cipher, const uint8_t key[]);
-
-void pgp_cipher_decrypt_resync(pgp_cipher_t* cipher);
-
-void pgp_cipher_block_encrypt(const pgp_cipher_t* cipher, uint8_t *block_out, const uint8_t *block_in);
-void pgp_cipher_block_decrypt(const pgp_cipher_t* cipher, uint8_t *block_out, const uint8_t *block_in);
-
-void pgp_cipher_cfb_encrypt(const pgp_cipher_t* cipher, uint8_t *text_out, const uint8_t *text_in, size_t len);
-void pgp_cipher_cfb_decrypt(const pgp_cipher_t* cipher, uint8_t *text_out, const uint8_t *text_in, size_t len);
-
-// FIXME remove this
-#define pgp_crypt_t pgp_cipher_t
-#endif
-
 
 #endif

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2009 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is originally derived from software contributed to
+ * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
+ * carried further by Ribose Inc (https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * Copyright (c) 2005-2008 Nominet UK (www.nic.uk)
+ * All rights reserved.
+ * Contributors: Ben Laurie, Rachel Willmer. The Contributors have asserted
+ * their moral rights under the UK Copyright Design and Patents Act 1988 to
+ * be recorded as the authors of this copyright work.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SYMMETRIC_CRYPTO_H_
+#define SYMMETRIC_CRYPTO_H_
+
+/** pgp_crypt_t */
+struct pgp_crypt_t {
+	pgp_symm_alg_t	alg;
+	size_t			blocksize;
+	size_t			keysize;
+	void 			(*set_iv)(pgp_crypt_t *, const uint8_t *);
+	void			(*set_crypt_key)(pgp_crypt_t *, const uint8_t *);
+	int			(*base_init)(pgp_crypt_t *);
+	void			(*decrypt_resync)(pgp_crypt_t *);
+	/* encrypt/decrypt one block */
+	void			(*block_encrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *);
+	void			(*block_decrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *);
+	/* Standard CFB encrypt/decrypt (as used by Sym Enc Int Prot packets) */
+	void 			(*cfb_encrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *, size_t);
+	void			(*cfb_decrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *, size_t);
+	void			(*decrypt_finish)(pgp_crypt_t *);
+	uint8_t			iv[PGP_MAX_BLOCK_SIZE];
+	uint8_t			civ[PGP_MAX_BLOCK_SIZE];
+	uint8_t			siv[PGP_MAX_BLOCK_SIZE];
+		/* siv is needed for weird v3 resync */
+	uint8_t			key[PGP_MAX_KEY_SIZE];
+	int			num;
+		/* num is offset for CFB */
+	struct botan_block_cipher_struct			*block_cipher_obj;
+
+};
+
+pgp_symm_alg_t pgp_str_to_cipher(const char *name);
+unsigned pgp_block_size(pgp_symm_alg_t);
+unsigned pgp_key_size(pgp_symm_alg_t);
+unsigned pgp_is_sa_supported(pgp_symm_alg_t);
+
+size_t pgp_decrypt_se(pgp_crypt_t *, void *, const void *, size_t);
+size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
+size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
+size_t pgp_encrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
+unsigned pgp_is_sa_supported(pgp_symm_alg_t);
+
+int pgp_crypt_any(pgp_crypt_t *, pgp_symm_alg_t);
+int pgp_decrypt_init(pgp_crypt_t *);
+int pgp_encrypt_init(pgp_crypt_t *);
+
+size_t pgp_decrypt_se(pgp_crypt_t *, void *, const void *, size_t);
+size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
+size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
+size_t pgp_encrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
+
+
+
+#if 0
+// Initialize a cipher object
+void pgp_cipher_create(pgp_cipher_t** cipher, pgp_symm_alg_t algo);
+
+// Destroy a cipher object, freeing all resources
+void pgp_cipher_finish(pgp_cipher_t* cipher);
+
+// Return blocksize of cipher or 0 if error
+size_t pgp_cipher_blocksize(const pgp_cipher_t* cipher);
+
+// Return key length of cipher or 0 if error
+size_t pgp_cipher_keysize(const pgp_cipher_t* cipher);
+
+// IV is always pgp_cipher_blocksize(cipher) bytes long
+void pgp_cipher_set_iv(pgp_cipher_t* cipher, const uint8_t iv[]);
+
+// Key is always pgp_cipher_keysize(cipher) bytes long
+void pgp_cipher_set_key(pgp_cipher_t* cipher, const uint8_t key[]);
+
+void pgp_cipher_decrypt_resync(pgp_cipher_t* cipher);
+
+void pgp_cipher_block_encrypt(const pgp_cipher_t* cipher, uint8_t *block_out, const uint8_t *block_in);
+void pgp_cipher_block_decrypt(const pgp_cipher_t* cipher, uint8_t *block_out, const uint8_t *block_in);
+
+void pgp_cipher_cfb_encrypt(const pgp_cipher_t* cipher, uint8_t *text_out, const uint8_t *text_in, size_t len);
+void pgp_cipher_cfb_decrypt(const pgp_cipher_t* cipher, uint8_t *text_out, const uint8_t *text_in, size_t len);
+
+// FIXME remove this
+#define pgp_crypt_t pgp_cipher_t
+#endif
+
+
+#endif

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -57,17 +57,6 @@ struct pgp_crypt_t {
 	pgp_symm_alg_t	alg;
 	size_t			blocksize;
 	size_t			keysize;
-	void 			(*set_iv)(pgp_crypt_t *, const uint8_t *);
-	void			(*set_crypt_key)(pgp_crypt_t *, const uint8_t *);
-	int			(*base_init)(pgp_crypt_t *);
-	void			(*decrypt_resync)(pgp_crypt_t *);
-	/* encrypt/decrypt one block */
-	void			(*block_encrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *);
-	void			(*block_decrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *);
-	/* Standard CFB encrypt/decrypt (as used by Sym Enc Int Prot packets) */
-	void 			(*cfb_encrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *, size_t);
-	void			(*cfb_decrypt)(pgp_crypt_t *, uint8_t *, const uint8_t *, size_t);
-	void			(*decrypt_finish)(pgp_crypt_t *);
 	uint8_t			iv[PGP_MAX_BLOCK_SIZE];
 	uint8_t			civ[PGP_MAX_BLOCK_SIZE];
 	uint8_t			siv[PGP_MAX_BLOCK_SIZE];
@@ -84,21 +73,32 @@ unsigned pgp_block_size(pgp_symm_alg_t);
 unsigned pgp_key_size(pgp_symm_alg_t);
 unsigned pgp_is_sa_supported(pgp_symm_alg_t);
 
-size_t pgp_decrypt_se(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_encrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-unsigned pgp_is_sa_supported(pgp_symm_alg_t);
 
 int pgp_crypt_any(pgp_crypt_t *, pgp_symm_alg_t);
 int pgp_decrypt_init(pgp_crypt_t *);
 int pgp_encrypt_init(pgp_crypt_t *);
 
+// Deallocate all storage
+int pgp_cipher_finish(pgp_crypt_t *cipher);
+
+int pgp_cipher_set_key(pgp_crypt_t* cipher, const uint8_t *key);
+int pgp_cipher_set_iv(pgp_crypt_t* cipher, const uint8_t *iv);
+
+// Encrypt or decrypt a single block
+int pgp_cipher_block_encrypt(const pgp_crypt_t* cipher, uint8_t* out, const uint8_t* in);
+int pgp_cipher_block_decrypt(const pgp_crypt_t* cipher, uint8_t* out, const uint8_t* in);
+
+// CFB encryption/decryption
+int pgp_cipher_cfb_encrypt(pgp_crypt_t* cipher, uint8_t *out, const uint8_t* in, size_t len);
+int pgp_cipher_cfb_decrypt(pgp_crypt_t* cipher, uint8_t *out, const uint8_t* in, size_t len);
+
+int pgp_cipher_cfb_resync(pgp_crypt_t* cipher);
+
+// Higher level operations
 size_t pgp_decrypt_se(pgp_crypt_t *, void *, const void *, size_t);
 size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
 size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
 size_t pgp_encrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-
 
 
 #if 0

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -948,8 +948,7 @@ encrypt_writer(const uint8_t *src,
 		unsigned        size = (remaining < BUFSZ) ? remaining : BUFSZ;
 
 		/* memcpy(buf,src,size); // \todo copy needed here? */
-		pgp_encrypt->crypt->cfb_encrypt(pgp_encrypt->crypt, encbuf,
-					src + done, size);
+                pgp_cipher_cfb_encrypt(pgp_encrypt->crypt, encbuf, src + done, size);
 
 		if (pgp_get_debug_level(__FILE__)) {
 			hexdump(stderr, "unencrypted", &src[done], 16);
@@ -1055,8 +1054,8 @@ pgp_push_enc_se_ip(pgp_output_t *output, const pgp_key_t *pubkey, const char *ci
 		(void) fprintf(stderr, "pgp_push_enc_se_ip: bad alloc\n");
 		return 0;
 	}
-	encrypted->set_iv(encrypted, iv);
-	encrypted->set_crypt_key(encrypted, &encrypted_pk_sesskey->key[0]);
+        pgp_cipher_set_iv(encrypted, iv);
+        pgp_cipher_set_key(encrypted, &encrypted_pk_sesskey->key[0]);
 	pgp_encrypt_init(encrypted);
 
 	se_ip->crypt = encrypted;
@@ -1439,8 +1438,8 @@ pgp_push_stream_enc_se_ip(pgp_output_t *output, const pgp_key_t *pubkey, const c
 			"pgp_push_stream_enc_se_ip: bad alloc\n");
 		return;
 	}
-	encrypted->set_iv(encrypted, iv);
-	encrypted->set_crypt_key(encrypted, &encrypted_pk_sesskey->key[0]);
+        pgp_cipher_set_iv(encrypted, iv);
+        pgp_cipher_set_key(encrypted, &encrypted_pk_sesskey->key[0]);
 	pgp_encrypt_init(encrypted);
 
 	se_ip->crypt = encrypted;
@@ -1785,7 +1784,7 @@ str_enc_se_ip_destroyer(pgp_writer_t *writer)
 	pgp_teardown_memory_write(se_ip->litoutput, se_ip->litmem);
 	pgp_teardown_memory_write(se_ip->se_ip_out, se_ip->se_ip_mem);
 
-	se_ip->crypt->decrypt_finish(se_ip->crypt);
+        pgp_cipher_finish(se_ip->crypt);
 
 	free(se_ip->crypt);
 	free(se_ip);


### PR DESCRIPTION
I started by trying to make the structure completely opaque but kind of ran into a quagmire with that, so for now I limited the change to removing the function pointers from `pgp_crypt_t`. This alone greatly simplifies `symmetric.c`

While there implemented support for Blowfish/Twofish (#107), and also Camellia-192 which was missing.

At this point the only algorithm-specific code in `symmetric.c` are a handful of switch statements, so I'm not sure if breaking up the file (as suggested in #101) makes sense anymore - @ronaldtse your thoughts?

 Changes to `src/lib` are done and ready for review, and there is even a test now.