### PR TITLE
Fix a memory leak in RSA key generation

### DIFF
--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -1070,7 +1070,7 @@ pgp_create_pk_sesskey(const pgp_key_t *key, const char *ciphername)
                                      encoded_key, sz_encoded_key,
                                      &pubkey->key.rsa);
            if (n <= 0) {
-              (void) fprintf(stderr, "pgp_rsa_public_encrypt failure\n");
+              (void) fprintf(stderr, "pgp_rsa_encrypt_pkcs1 failure\n");
               free(sesskey);
               sesskey = NULL;
               goto done;

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -130,9 +130,6 @@ unsigned pgp_dsa_verify(const uint8_t *, size_t,
 * RSA encrypt/decrypt
 */
 
-int pgp_rsa_public_encrypt(uint8_t *, const uint8_t *, size_t,
-			const pgp_rsa_pubkey_t *);
-
 int pgp_rsa_encrypt_pkcs1(uint8_t* out, size_t out_len,
                           const uint8_t* key, size_t key_len,
                           const pgp_rsa_pubkey_t* pubkey);


### PR DESCRIPTION
Fixes #123 

The change is not actually very large but reindenting within the function + moving some lines caused the diff to kind of blow up.

Removes pgp_rsa_public_encrypt, unused since #50 was resolved.