### PR TITLE
Removes memory leaks from rnpkeys

### DIFF
--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -469,6 +469,7 @@ write_seckey_body(const pgp_seckey_t *key,
 			 */
 			(void) memcpy(&sesskey[i * hashsize],
 					hashed, (unsigned)size);
+			free(hashed);
 			done += (unsigned)size;
 			if (done > PGP_CAST_KEY_LENGTH) {
 				(void) fprintf(stderr,
@@ -538,6 +539,7 @@ write_seckey_body(const pgp_seckey_t *key,
 	}
 
 	pgp_writer_pop(output);
+	pgp_cipher_finish(&crypted);
 
 	return 1;
 }

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -952,13 +952,9 @@ disable_core_dumps(void)
 static int
 set_core_dumps(rnp_t *rnp)
 {
-	int setting;
-
-	setting = rnp_getvar(rnp, "coredumps") != NULL;
-	if (! setting) {
+	if (findvar(rnp, "coredumps") == -1) {
 		return disable_core_dumps() == 1 ? 0 : -1;
 	}
-
 	return 1;
 }
 


### PR DESCRIPTION
* Removes memory leaks from rnpkeys that occur on key generation
* Makes set_core_dumps more readable