### PR TITLE
This code can't be build without json-c, fix it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,7 @@ AC_SEARCH_LIBS([_cmocka_run_group_tests], [cmocka],,AC_MSG_ERROR(CMocka not foun
 AC_SEARCH_LIBS([gzopen], [z],,AC_MSG_ERROR(libz not found!))
 AC_SEARCH_LIBS([BZ2_bzDecompress], [bz2],,AC_MSG_ERROR(Libbz2 not found!))
 
-PKG_CHECK_MODULES(JSON, json-c,, [AC_MSG_WARN("json-c not found")])
+PKG_CHECK_MODULES(JSON, json-c,, [AC_MSG_ERROR("json-c not found")])
 
 # Initialize the testsuite
 #


### PR DESCRIPTION
The beset way is made it optional and don't try to build the code with json-c dependencies but stop at configure is better that pass it and crash at building.