### PR TITLE
Developers guide and clang-format styling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,67 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Mozilla
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: true
+ColumnLimit:     95
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -13,15 +13,15 @@ See the file `.travis.yml` and the scripts in `ci/` for the most up-to-date deta
 Sometimes tests fail in Travis CI and you will want to reproduce them locally for easier troubleshooting.
 We can use a container for this, like so:
 
-```
-docker run -ti --rm travisci/ci-garnet:packer-1490989530 bash -l
+``` sh
+$ docker run -ti --rm travisci/ci-garnet:packer-1490989530 bash -l
 ```
 
 (Refer to [here](https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image) and [here](https://hub.docker.com/r/travisci/ci-garnet/tags/))
 
 Inside the container, you will need to perform steps like the following:
 
-```
+``` sh
 $ git clone https://github.com/riboseinc/rnp.git
 $ cd rnp
 $ export BOTAN_INSTALL="$HOME/builds/botan-install"
@@ -50,7 +50,7 @@ Coverity Scan is used for occasional static analysis of the code base.
 To initiate analysis, a developer must push to the `coverity_scan` branch.
 You may wish to perform a clean clone for this, like so:
 
-```
+``` sh
 $ cd /tmp
 $ git clone git@github.com:riboseinc/rnp.git
 $ git checkout coverity_scan                    # switch to the coverity_scan branch
@@ -70,7 +70,7 @@ Clang includes a useful static analyzer that can also be used to locate potentia
 
 To use it, pass the build command to `scan-build`:
 
-```
+``` sh
 $ ./configure
 $ scan-build make -j4
 [...]
@@ -99,7 +99,7 @@ Currently, we have a very simple test program in `src/fuzzers/fuzz_keys`, which 
 
 Here is an example:
 
-```
+``` sh
 $ env CC=afl-gcc AFL_HARDEN=1 CFLAGS=-ggdb ./configure --disable-shared
 $ make -j$(grep -c '^$' /proc/cpuinfo) clean all
 $ mkdir afl_in afl_out
@@ -120,7 +120,7 @@ Clang and GCC both support a number of sanitizers that can help locate issues in
 
 To use them, you should rebuild with the sanitizers enabled, and then run the tests (or any executable):
 
-```
+``` sh
 $ env CC=clang CFLAGS="-fsanitize=address,undefined" LDFLAGS="-fsanitize=address,undefined" ./configure
 $ make -j4
 $ src/cmocka/rnp_tests
@@ -141,7 +141,7 @@ C is a very flexible and powerful language. Because of this, it is important to 
 
 A git pre-commit hook exists to perform this task automatically, and can be enabled like so:
 
-```
+``` sh
 $ cd rnp
 $ git-hooks/enable.sh
 ```
@@ -156,7 +156,7 @@ Note that if you have unstaged changes on some of the files you are attempting t
 
 If you are not able to use the git hook, you can run clang-format manually.
 
-```
+``` sh
 $ clang-format -style=file -i src/lib/some_changed_file.c
 ```
 

--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -1,0 +1,195 @@
+# Introduction
+
+The following are a set of conventions and items that are relevant to contributors.
+
+# Continuous Integration (Travis CI)
+
+Travis CI is used for continuously testing new commits and pull requests.
+We use the sudo-less beta Ubuntu Trusty containers, which do not permit root access.
+See the file `.travis.yml` and the scripts in `ci/` for the most up-to-date details.
+
+## Reproducing Locally
+
+Sometimes tests fail in Travis CI and you will want to reproduce them locally for easier troubleshooting.
+We can use a container for this, like so:
+
+```
+docker run -ti --rm travisci/ci-garnet:packer-1490989530 bash -l
+```
+
+(Refer to [here](https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image) and [here](https://hub.docker.com/r/travisci/ci-garnet/tags/))
+
+Inside the container, you will need to perform steps like the following:
+
+```
+$ git clone https://github.com/riboseinc/rnp.git
+$ cd rnp
+$ export BOTAN_INSTALL="$HOME/builds/botan-install"
+$ export CMOCKA_INSTALL="$HOME/builds/cmocka-install"
+$ export JSON_C_INSTALL="$HOME/builds/json-c-install"
+$ ci/install.sh
+$ env BUILD_MODE=normal CC=clang ci/main.sh
+```
+
+(The above uses clang as the compiler -- use `CC=gcc` for GCC)
+Refer to the current `.travis.yml` for the most up-to-date information on what environment variables need to be set.
+
+# Code Coverage
+
+CodeCov is used for assessing our test coverage.
+The current coverage can always be viewed here: https://codecov.io/github/riboseinc/rnp/
+
+# Security / Bug Hunting
+
+## Static Analysis
+
+### Coverity Scan
+
+Coverity Scan is used for occasional static analysis of the code base.
+
+To initiate analysis, a developer must push to the `coverity_scan` branch.
+You may wish to perform a clean clone for this, like so:
+
+```
+$ cd /tmp
+$ git clone git@github.com:riboseinc/rnp.git
+$ git checkout coverity_scan                    # switch to the coverity_scan branch
+$ git rebase master coverity_scan               # replay all commits from master onto coverity_scan
+$ git push -u origin coverity_scan -f           # forcefully push the coverity_scan branch
+```
+
+Note: Some of these steps are overly verbose, and not all are necessary.
+
+The results can be accessed on scan.coverity.com. You will need to create an account and request access to the riboseinc/rnp project.
+
+Since the scan results are not updated live, line numbers may no longer be accurate against master, issues may already be resolved, etc.
+
+### Clang Static Analyzer
+
+Clang includes a useful static analyzer that can also be used to locate potential bugs.
+
+To use it, pass the build command to `scan-build`:
+
+```
+$ ./configure
+$ scan-build make -j4
+[...]
+scan-build: 6 bugs found.
+scan-build: Run 'scan-view /tmp/scan-build-2017-05-29-223318-9830-1' to examine bug reports.
+```
+
+Then use `scan-view`, as indicated above, to start a web server and use your web browser to view the results.
+
+## Dynamic Analysis
+
+### Fuzzer
+
+It is often useful to utilize a fuzzer like [AFL](http://lcamtuf.coredump.cx/afl/) to find ways to improve the robustness of the code base.
+
+Currently, we have a very simple test program in `src/fuzzers/fuzz_keys`, which will attempt to load an armored key file passed on the command line. We can use this with AFL to try to produce crashes, which we can then analyze for issues.
+
+1. Install AFL.
+2. Rebuild, using the afl-gcc compiler.
+    * It's probably easiest to also do a static build, using the `--disable-shared` option to `configure`.
+    * It may be helpful to occasionally enable the address sanitizer, which tends to help produce crashes that may not otherwise be found. Read the documentation for AFL first to understand the challenges with ASan and AFL.
+3. Create directories for input files, and for AFL output. 
+4. Run `afl-fuzz`.
+5. When satisfied, exit with `CTRL-C`.
+6. Analyze the crashes/hangs in the output directory.
+
+Here is an example:
+
+```
+$ env CC=afl-gcc AFL_HARDEN=1 CFLAGS=-ggdb ./configure --disable-shared
+$ make -j$(grep -c '^$' /proc/cpuinfo) clean all
+$ mkdir afl_in afl_out
+$ cp some_tests/*.asc afl_in/
+$ afl-fuzz -i afl_in -o afl_out src/fuzzing/fuzz_keys @@
+# ctrl-c to exit
+$ valgrind -q src/fuzzing/fuzz_keys < afl_out/[...]
+```
+
+#### Further Reading
+
+* AFL's README, parallel_fuzzing.txt, and other bundled documentation.
+* https://fuzzing-project.org/tutorial3.html
+
+### Clang Sanitizer
+
+Clang and GCC both support a number of sanitizers that can help locate issues in the code base during runtime.
+
+To use them, you should rebuild with the sanitizers enabled, and then run the tests (or any executable):
+
+```
+$ env CC=clang CFLAGS="-fsanitize=address,undefined" LDFLAGS="-fsanitize=address,undefined" ./configure
+$ make -j4
+$ src/cmocka/rnp_tests
+```
+
+Here we are using the [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) and [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html).
+This will produce output showing any memory leaks, heap overflows, or other issues.
+
+# Code Conventions
+
+C is a very flexible and powerful language. Because of this, it is important to establish a set of conventions to avoid common problems and to maintain a consistent code base.
+
+## Code Formatting
+
+`clang-format` (v4+) can be used to format the code base, utilizing the `.clang-format` file included in the repository.
+
+### clang-format git hook
+
+A git pre-commit hook exists to perform this task automatically, and can be enabled like so:
+
+```
+$ cd rnp
+$ git-hooks/enable.sh
+```
+
+If you do not have clang-format v4+ available, you can use a docker container for this purpose by setting `USE_DOCKER="yes"` in `git-hooks/pre-commit.sh`.
+
+This should generally work if you commit from the command line.
+
+Note that if you have unstaged changes on some of the files you are attempting to commit, which have formatting issues detected, you will have to resolve this yourself (the script will inform you of this).
+
+### clang-format (manually)
+
+If you are not able to use the git hook, you can run clang-format manually.
+
+```
+$ clang-format -style=file -i src/lib/some_changed_file.c
+```
+
+(Or, if you do not have clang-form v4 available, use a container)
+
+### Style Guide
+
+In order to keep the code base consistent, we should define and adhere to a single style.
+When in doubt, consult the existing code base.
+
+#### Naming
+
+The following are samples that demonstrate the style for naming different things.
+
+* Functions: `some_function`
+* Variables: `some_variable`
+* Filenames: `crypto.c`
+* Struct: `pgp_key_t`
+* Typedefed Enums: `pgp_pubkey_alg_t`
+* Enum Values: `PGP_PKA_RSA = 1`
+* Constants (macro): `RNP_BUFSIZ`
+
+#### General Guidelines
+
+Do:
+
+* Do use header guards (`#ifndef SOME_HEADER_H [...]`) in headers.
+* Do use `sizeof(variable)`, rather than `sizeof(type)`. Or `sizeof(*variable)` as appropriate.
+* Do use commit messages that close GitHub issues automatically, when applicable. `Fix XYZ. Closes #78.` See [here.](https://help.github.com/articles/closing-issues-via-commit-messages/).
+* Do declare functions `static` when they do not need to be referenced outside the current source file.
+* Do omit braces for simple one-line conditionals. (Unless attached to another conditional with multiple lines.)
+
+Do not:
+* Do not use static storage-class for variables.
+* Do not use `pragma`.
+

--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -60,9 +60,9 @@ $ git push -u origin coverity_scan -f           # forcefully push the coverity_s
 
 Note: Some of these steps are overly verbose, and not all are necessary.
 
-The results can be accessed on scan.coverity.com. You will need to create an account and request access to the riboseinc/rnp project.
+The results can be accessed on https://scan.coverity.com/projects/riboseinc-rnp. You will need to create an account and request access to the riboseinc/rnp project.
 
-Since the scan results are not updated live, line numbers may no longer be accurate against master, issues may already be resolved, etc.
+Since the scan results are not updated live, line numbers may no longer be accurate against the `master` branch, issues may already be resolved, etc.
 
 ### Clang Static Analyzer
 
@@ -92,7 +92,7 @@ Currently, we have a very simple test program in `src/fuzzers/fuzz_keys`, which 
 2. Rebuild, using the afl-gcc compiler.
     * It's probably easiest to also do a static build, using the `--disable-shared` option to `configure`.
     * It may be helpful to occasionally enable the address sanitizer, which tends to help produce crashes that may not otherwise be found. Read the documentation for AFL first to understand the challenges with ASan and AFL.
-3. Create directories for input files, and for AFL output. 
+3. Create directories for input files, and for AFL output.
 4. Run `afl-fuzz`.
 5. When satisfied, exit with `CTRL-C`.
 6. Analyze the crashes/hangs in the output directory.
@@ -111,7 +111,7 @@ $ valgrind -q src/fuzzing/fuzz_keys < afl_out/[...]
 
 #### Further Reading
 
-* AFL's README, parallel_fuzzing.txt, and other bundled documentation.
+* AFL's `README`, `parallel_fuzzing.txt`, and other bundled documentation.
 * https://fuzzing-project.org/tutorial3.html
 
 ### Clang Sanitizer
@@ -162,12 +162,12 @@ $ clang-format -style=file -i src/lib/some_changed_file.c
 
 (Or, if you do not have clang-form v4 available, use a container)
 
-### Style Guide
+## Style Guide
 
 In order to keep the code base consistent, we should define and adhere to a single style.
 When in doubt, consult the existing code base.
 
-#### Naming
+### Naming
 
 The following are samples that demonstrate the style for naming different things.
 
@@ -179,7 +179,7 @@ The following are samples that demonstrate the style for naming different things
 * Enum Values: `PGP_PKA_RSA = 1`
 * Constants (macro): `RNP_BUFSIZ`
 
-#### General Guidelines
+### General Guidelines
 
 Do:
 

--- a/git-hooks/enable.sh
+++ b/git-hooks/enable.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ln -sf ../../git-hooks/pre-commit.sh "$(git rev-parse --show-toplevel)/.git/hooks/pre-commit"
+

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -eEu
+
+# Path to clang-format. If it's in your PATH, "clang-format" is fine.
+# If you do not have it (or the version is too old), see USE_DOCKER.
+CLANG_FORMAT="/usr/bin/clang-format"
+
+# Set to "yes" if you want to create and use a docker container
+# for clang-format.
+USE_DOCKER="yes"
+
+# Set this to "yes" if you typically commit from the command line
+# and wish to be prompted on whether to apply any patches
+# automatically.
+INTERACTIVE="yes"
+
+# Leave this stuff
+STASH_NAME="pre-commit-$(date +%s)"
+CONTAINER_NAME="clang-format-$(date +%s)"
+
+apply_patch() {
+  local patchfile=$1
+  git apply --index "$patchfile"
+  rm -f "$patchfile"
+  exit 0
+}
+
+stash() {
+  git stash save -q --keep-index "$STASH_NAME"
+}
+
+unstash() {
+  if git stash list | head -n 1 | grep -Fq "$STASH_NAME"; then
+    git stash pop -q || true
+  fi
+}
+
+cleanup() {
+  ec=$?
+  unstash
+  if [ $USE_DOCKER == "yes" ]; then
+    docker kill "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  fi
+  if [ $ec -ne 0 ]; then
+    echo Aborted.
+  fi
+  exit $ec
+}
+
+if [ $USE_DOCKER == "yes" ]; then
+  if [ ! "$(docker images clang-format --format '{{.Repository}}')" ]; then
+    echo "Creating docker image for clang-format (one time only)..."
+    docker run --name=clang-format alpine:latest apk --no-cache add clang >/dev/null 2>&1
+    docker commit clang-format clang-format >/dev/null 2>&1
+    docker rm clang-format
+  fi
+  CLANG_FORMAT="docker exec $CONTAINER_NAME clang-format"
+  docker run --rm --name "$CONTAINER_NAME" -t -d -v "$(git rev-parse --show-toplevel)":/src -w /src clang-format tail -f /dev/null >/dev/null 2>&1
+  # alternatively (slower for multiple files)
+  #CLANG_FORMAT="docker run --rm -v $(git rev-parse --show-toplevel):/src -w /src clang-format clang-format"
+fi
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+exec 1>&2
+
+patchfile=$(mktemp --tmpdir --suffix=.patch git-clang-format.XXXXXX)
+stash
+trap "cleanup" SIGHUP SIGINT SIGTERM EXIT ERR
+
+git diff-index --cached --diff-filter=ACMR --name-only $against -- | grep "\.[ch]$" | while read -r file;
+do
+  $CLANG_FORMAT -style=file "$file" |     \
+    diff -u "$file" - |                     \
+    sed -e "1s|--- |--- a/|" -e "2s|+++ -|+++ b/$file|" >> "$patchfile"
+
+  # cat is just here to ignore the exit status of diff
+  $CLANG_FORMAT -style=file "$file" | diff -u --color=always "$file" - | cat
+done
+unstash
+
+if [ ! -s "$patchfile" ]; then
+  rm -f "$patchfile"
+  exit 0
+fi
+
+echo
+echo Formatting changes requested.
+echo "See $patchfile"
+echo
+
+if ! git apply --index --check "$patchfile"; then
+  echo You may have unstaged changes to files that require formatting updates.
+  echo It is not safe for this script to apply the patch automatically.
+  exit 1
+fi
+
+if [ $INTERACTIVE == "yes" ]; then
+  while true; do
+    exec < /dev/tty
+    read -rp "Apply now (y/n)? " yn
+    exec <&-
+    case $yn in
+      [Yy]* ) apply_patch "$patchfile"; exit 0;;
+      [Nn]* ) break;;
+      * ) echo Please answer yes or no. ;;
+    esac
+  done
+fi
+
+echo
+echo You should manually apply the patch with:
+echo "git apply --index \"$patchfile\""
+echo "Or use another method, and then restage."
+exit 1
+


### PR DESCRIPTION
Feedback would be much appreciated.

There's mostly 2 things here:

#### Developer's Guide

This is just a simple introduction to some of the things we use (travis, codecov, coverity, ...), and some general guidelines, etc.
It can probably be expanded later on, and I guess we would want to add a link from the README.md.

#### clang-format

The idea here is to introduce clang-format for keeping a consistent code base.
I basically pinned down the settings for the current code base, as closely as possible.
The only major change I added in here was using spaces, rather than tabs.

I think all of us have had issues with tabs and accidentally committed spaces.
Every editor seems to handle tabs differently, and I think we may be better off avoiding them.

I created a git pre-commit hook that works well for me. It looks like this:
```
$ git commit -m 'do some commit with incorrect formatting'
--- src/lib/crypto.c	2017-05-30 20:58:48.279764787 -0400
+++ -	2017-05-30 20:58:48.309445645 -0400
@@ -495,8 +495,7 @@
 	pgp_memory_add(inmem, input, insize);
 
 	/* set up to read from memory */
-pgp_setup_memory_read(io,
- &parse, inmem, NULL, write_parsed_cb, 0);
+	pgp_setup_memory_read(io, &parse, inmem, NULL, write_parsed_cb, 0);
 
 	/* setup for writing decrypted contents to given output file */
 	pgp_setup_memory_write(&parse->cbinfo.output, &outmem, insize);

Formatting changes requested.
See /tmp/git-clang-format.lTv6U4.patch

Apply now (y/n)? y
[master b9c3b10] do some commit with incorrect formatting
```
It just shows a colorized diff of the formatting violations and asks if you would like to apply that before committing (else the commit is aborted).

It defaults to using a docker container (which has a slight delay), but if you have clang-format v4 (Arch Linux does) locally, then you can set `USE_DOCKER="no"` in `pre-commit.sh`.

Before we would use the hook, we would have to run clang-format on the existing code base.

The only issue I'm aware of with the styling that clang-format does is with the asterisk alignment in function definitions (IIRC):
https://github.com/llvm-mirror/clang/blob/6878143d92cd036e9916ff853b8bc522e6e118b7/lib/Format/WhitespaceManager.cpp#L406

It's a nuisance but hopefully will get fixed.

Closes #128 and #61