### PR TITLE
Cleanup in RSA key generation

### DIFF
--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -319,6 +319,7 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_seckey_t *sec_rsa;
 
     pgp_key = pgp_rsa_new_key(1024, 65537, "userid", "AES-128");
+    assert_true(pgp_key != NULL);
     sec_key = pgp_get_seckey(pgp_key);
     pub_key = pgp_get_pubkey(pgp_key);
     pub_rsa = &pub_key->key.rsa;

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __RNP__UTILS_H__
+#define __RNP__UTILS_H__
+
+#define RNP_LOG(msg) \
+	(void)fprintf(stderr, "%s:%d:%s "msg"\n", __FILE__, __LINE__, __func__)
+
+#define CHECK(exp, val, err)										\
+	do { 															\
+		if ((exp)!=(val)) 											\
+		{															\
+			RNP_LOG("ERROR: ("#exp")!=("#val")");				 	\
+			ret = (err); 											\
+			goto end; 												\
+		}	 														\
+	} while(false)
+
+#define CHECK_BOTAN(exp, err) \
+	CHECK((exp), 0, (err))
+
+#endif

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -840,6 +840,9 @@ pgp_output_new(void)
 void
 pgp_output_delete(pgp_output_t *output)
 {
+    if (!output) {
+        return;
+    }
     pgp_writer_info_delete(&output->writer);
     free(output);
 }

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -543,3 +543,10 @@ new_BN_take_mp(botan_mp_t mp)
     a->mp = mp;
     return a;
 }
+
+void
+destroy_BN_mp(BIGNUM** a)
+{
+    free(*a);
+    *a = NULL;
+}

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -332,4 +332,6 @@ struct pgp_stream_t {
  * \brief Allocates BIGNUM and mp value assigned
  */
 BIGNUM *new_BN_take_mp(botan_mp_t mp);
+void destroy_BN_mp(BIGNUM** a);
+
 #endif /* CRYPTO_H_ */

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -707,6 +707,9 @@ pgp_memory_new(void)
 void
 pgp_memory_free(pgp_memory_t *mem)
 {
+    if (!mem) {
+        return;
+    }
     pgp_memory_release(mem);
     free(mem);
 }

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -1850,7 +1850,9 @@ pgp_setup_memory_write(pgp_output_t **output, pgp_memory_t **mem, size_t bufsz)
 void
 pgp_teardown_memory_write(pgp_output_t *output, pgp_memory_t *mem)
 {
-    pgp_writer_close(output); /* new */
+    if (output) {
+        pgp_writer_close(output); /* new */
+    }
     pgp_output_delete(output);
     pgp_memory_free(mem);
 }


### PR DESCRIPTION
Few things I've found during EC implementation, but not really related to EC
 
   * Remove DSA and Elgamal key serialization from RSA key generation
    * User doesn't need to free memory after rsa_generate_keypair fails
    * Fixes memory leaks that occure when RSA key generation fails in the middle
