### PR TITLE
Purge tab characters from source.

### DIFF
--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -276,8 +276,8 @@ bzip2_compressed_data_reader(pgp_stream_t *stream,
 /**
  * \ingroup Core_Compress
  *
- * \param *region 	Pointer to a region
- * \param *stream 	How to parse
+ * \param *region     Pointer to a region
+ * \param *stream     How to parse
  * \param type Which compression type to expect
  */
 

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -1062,7 +1062,7 @@ pgp_write_pk_sesskey(pgp_output_t *output, pgp_pk_sesskey_t *pksk)
                pgp_write(output, pksk->key_id, 8) &&
                pgp_write_scalar(output, (unsigned) pksk->alg, 1) &&
                pgp_write_mpi(output, pksk->params.rsa.encrypted_m)
-          /* ??	&& pgp_write_scalar(output, 0, 2); */
+          /* ??    && pgp_write_scalar(output, 0, 2); */
           ;
     case PGP_PKA_DSA:
     case PGP_PKA_ELGAMAL:
@@ -1076,7 +1076,7 @@ pgp_write_pk_sesskey(pgp_output_t *output, pgp_pk_sesskey_t *pksk)
                pgp_write_scalar(output, (unsigned) pksk->alg, 1) &&
                pgp_write_mpi(output, pksk->params.elgamal.g_to_k) &&
                pgp_write_mpi(output, pksk->params.elgamal.encrypted_m)
-          /* ??	&& pgp_write_scalar(output, 0, 2); */
+          /* ??    && pgp_write_scalar(output, 0, 2); */
           ;
     default:
         (void) fprintf(stderr, "pgp_write_pk_sesskey: bad algorithm\n");

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -132,8 +132,8 @@ int pgp_rsa_pkcs1_sign_hash(uint8_t *      sig_buf,
  * @pre g2k size must be at least equal to byte size of prime `p'
  * @pre encm size must be at least equal to byte size of prime `p'
  *
- * @return 	on success - number of bytes written to g2k and encm
- *			on failure -1
+ * @return     on success - number of bytes written to g2k and encm
+ *            on failure -1
  */
 int pgp_elgamal_public_encrypt_pkcs1(uint8_t *                   g2k,
                                      uint8_t *                   encm,
@@ -155,8 +155,8 @@ int pgp_elgamal_public_encrypt_pkcs1(uint8_t *                   g2k,
  * @pre encm size must be at least equal to byte size of prime `p'
  * @pre byte-size of `g2k' must be equal to `encm'
  *
- * @return 	on success - number of bytes written to g2k and encm
- *			on failure -1
+ * @return     on success - number of bytes written to g2k and encm
+ *            on failure -1
  */
 int pgp_elgamal_private_decrypt_pkcs1(uint8_t *                   out,
                                       const uint8_t *             g2k,

--- a/src/lib/errors.h
+++ b/src/lib/errors.h
@@ -64,10 +64,10 @@
 /** error codes */
 /* Remember to add names to map in errors.c */
 typedef enum {
-    PGP_E_OK = 0x0000,   /* no error */
-    PGP_E_FAIL = 0x0001, /* general error */
-    PGP_E_SYSTEM_ERROR = 0x0002, /* system error, look at errno for
-                                  * details */
+    PGP_E_OK = 0x0000,            /* no error */
+    PGP_E_FAIL = 0x0001,          /* general error */
+    PGP_E_SYSTEM_ERROR = 0x0002,  /* system error, look at errno for
+                                   * details */
     PGP_E_UNIMPLEMENTED = 0x0003, /* feature not yet implemented */
 
     /* reader errors */
@@ -128,8 +128,8 @@ typedef enum {
 /** one entry in a linked list of errors */
 typedef struct pgp_error {
     pgp_errcode_t errcode;
-    int sys_errno; /* irrelevent unless errcode ==
-                    * PGP_E_SYSTEM_ERROR */
+    int           sys_errno; /* irrelevent unless errcode ==
+                              * PGP_E_SYSTEM_ERROR */
     char *            comment;
     const char *      file;
     int               line;

--- a/src/lib/key_store_ssh.c
+++ b/src/lib/key_store_ssh.c
@@ -161,17 +161,17 @@ getbignum(bufgap_t *bg, char *buf, const char *header)
 static int
 putbignum(bufgap_t *bg, BIGNUM *bignum)
 {
-	uint32_t	 len;
+    uint32_t     len;
 
-	len = BN_num_bytes(bignum);
-	(void) bufgap_insert(bg, &len, sizeof(len));
-	(void) bufgap_insert(bg, buf, len);
-	bignum = BN_bin2bn((const uint8_t *)buf, (int)len, NULL);
-	if (rnp_get_debug(__FILE__)) {
-		hexdump(stderr, header, buf, (int)len);
-	}
-	(void) bufgap_seek(bg, len, BGFromHere, BGByte);
-	return bignum;
+    len = BN_num_bytes(bignum);
+    (void) bufgap_insert(bg, &len, sizeof(len));
+    (void) bufgap_insert(bg, buf, len);
+    bignum = BN_bin2bn((const uint8_t *)buf, (int)len, NULL);
+    if (rnp_get_debug(__FILE__)) {
+        hexdump(stderr, header, buf, (int)len);
+    }
+    (void) bufgap_seek(bg, len, BGFromHere, BGByte);
+    return bignum;
 }
 #endif
 

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -224,7 +224,7 @@ pgp_push_error(pgp_error_t **errstack,
 
     if ((err = calloc(1, sizeof(*err))) == NULL) {
         (void) fprintf(stderr, "calloc comment failure\n");
-        free((void*) comment);
+        free((void *) comment);
         return;
     }
 

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -110,10 +110,10 @@ typedef struct {
  * limread_data reads the specified amount of the subregion's data
  * into a data_t structure
  *
- * \param data	Empty structure which will be filled with data
- * \param len	Number of octets to read
+ * \param data    Empty structure which will be filled with data
+ * \param len    Number of octets to read
  * \param subregion
- * \param stream	How to parse
+ * \param stream    How to parse
  *
  * \return 1 on success, 0 on failure
  */
@@ -351,10 +351,10 @@ full_read(pgp_stream_t *stream,
  * This function does not know or care about packet boundaries. It
  * also assumes that an EOF is an error.
  *
- * \param *result	The scalar value is stored here
- * \param *reader	Our reader
- * \param length	How many bytes to read
- * \return		1 on success, 0 on failure
+ * \param *result    The scalar value is stored here
+ * \param *reader    Our reader
+ * \param length    How many bytes to read
+ * \return        1 on success, 0 on failure
  */
 static unsigned
 _read_scalar(unsigned *result, unsigned length, pgp_stream_t *stream)
@@ -398,13 +398,13 @@ _read_scalar(unsigned *result, unsigned length, pgp_stream_t *stream)
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param dest		The destination buffer
- * \param length	How many bytes to read
- * \param region	Pointer to packet region
+ * \param dest        The destination buffer
+ * \param length    How many bytes to read
+ * \param region    Pointer to packet region
  * \param errors    Error stack
- * \param readinfo		Reader info
- * \param cbinfo	Callback info
- * \return		1 on success, 0 on error
+ * \param readinfo        Reader info
+ * \param cbinfo    Callback info
+ * \return        1 on success, 0 on error
  */
 unsigned
 pgp_limited_read(pgp_stream_t *stream,
@@ -482,10 +482,10 @@ exact_limread(uint8_t *dest, unsigned len, pgp_region_t *region, pgp_stream_t *s
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param length	How many bytes to skip
- * \param *region	Pointer to packet region
- * \param *stream	How to parse
- * \return		1 on success, 0 on error (calls the cb with PGP_PARSER_ERROR in
+ * \param length    How many bytes to skip
+ * \param *region    Pointer to packet region
+ * \param *stream    How to parse
+ * \return        1 on success, 0 on error (calls the cb with PGP_PARSER_ERROR in
  * limread()).
  */
 static int
@@ -511,12 +511,12 @@ limskip(unsigned length, pgp_region_t *region, pgp_stream_t *stream)
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param *dest		The scalar value is stored here
- * \param length	How many bytes make up this scalar (at most 4)
- * \param *region	Pointer to current packet region
- * \param *stream	How to parse
- * \param *cb		The callback
- * \return		1 on success, 0 on error (calls the cb with PGP_PARSER_ERROR in
+ * \param *dest        The scalar value is stored here
+ * \param length    How many bytes make up this scalar (at most 4)
+ * \param *region    Pointer to current packet region
+ * \param *stream    How to parse
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error (calls the cb with PGP_PARSER_ERROR in
  * limread()).
  *
  * \see RFC4880 3.1
@@ -557,12 +557,12 @@ limread_scalar(unsigned *dest, unsigned len, pgp_region_t *region, pgp_stream_t 
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param *dest		The scalar value is stored here
- * \param length	How many bytes make up this scalar (at most 4)
- * \param *region	Pointer to current packet region
- * \param *stream	How to parse
- * \param *cb		The callback
- * \return		1 on success, 0 on error (calls the cb with PGP_PARSER_ERROR in
+ * \param *dest        The scalar value is stored here
+ * \param length    How many bytes make up this scalar (at most 4)
+ * \param *region    Pointer to current packet region
+ * \param *stream    How to parse
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error (calls the cb with PGP_PARSER_ERROR in
  * limread()).
  *
  * \see RFC4880 3.1
@@ -593,11 +593,11 @@ limread_size_t(size_t *dest, unsigned length, pgp_region_t *region, pgp_stream_t
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param *dest		The timestamp is stored here
- * \param *ptag		Pointer to current packet's Packet Tag.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		see limread_scalar()
+ * \param *dest        The timestamp is stored here
+ * \param *ptag        Pointer to current packet's Packet Tag.
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        see limread_scalar()
  *
  * \see RFC4880 3.5
  */
@@ -644,17 +644,17 @@ limited_read_time(time_t *dest, pgp_region_t *region, pgp_stream_t *stream)
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param **pgn		return the integer there - the BIGNUM is created by BN_bin2bn() and
+ * \param **pgn        return the integer there - the BIGNUM is created by BN_bin2bn() and
  * probably needs to be freed
- * 				by the caller XXX right ben?
- * \param *ptag		Pointer to current packet's Packet Tag.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error (by limread_scalar() or limread() or if the
+ *                 by the caller XXX right ben?
+ * \param *ptag        Pointer to current packet's Packet Tag.
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error (by limread_scalar() or limread() or if the
  * MPI
  * is
  * not properly formed (XXX
- * 				 see comment below - the callback is called with a
+ *                  see comment below - the callback is called with a
  * PGP_PARSER_ERROR
  * in
  * case of an error)
@@ -754,9 +754,9 @@ coalesce_blocks(pgp_stream_t *stream, unsigned length)
  *
  * \sa Internet-Draft RFC4880.txt Section 4.2.2
  *
- * \param *length	Where the decoded length will be put
- * \param *stream	How to parse
- * \return		1 if OK, else 0
+ * \param *length    Where the decoded length will be put
+ * \param *stream    How to parse
+ * \return        1 if OK, else 0
  *
  */
 
@@ -808,15 +808,15 @@ read_new_length(unsigned *length, pgp_stream_t *stream)
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param *length	return the length here
- * \param *ptag		Pointer to current packet's Packet Tag.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error (by limread_scalar() or limread() or if the
+ * \param *length    return the length here
+ * \param *ptag        Pointer to current packet's Packet Tag.
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error (by limread_scalar() or limread() or if the
  * MPI
  * is
  * not properly formed (XXX
- * 				 see comment below)
+ *                  see comment below)
  *
  * \see RFC4880 4.2.2
  * \see pgp_ptag_t
@@ -1311,11 +1311,11 @@ parse_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
  *
  * Once the key has been parsed successfully, it is passed to the callback.
  *
- * \param *ptag		Pointer to the current Packet Tag.  This function should consume the
+ * \param *ptag        Pointer to the current Packet Tag.  This function should consume the
  * entire packet.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  *
  * \see RFC4880 5.5.2
  */
@@ -1398,11 +1398,11 @@ pgp_userid_free(uint8_t **id)
  *
  * Once the userid has been parsed successfully, it is passed to the callback.
  *
- * \param *ptag		Pointer to the Packet Tag.  This function should consume the entire
+ * \param *ptag        Pointer to the Packet Tag.  This function should consume the entire
  * packet.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  *
  * \see RFC4880 5.11
  */
@@ -1452,11 +1452,11 @@ parse_hash_find(pgp_stream_t *stream, const uint8_t *keyid)
  *
  * Once the signature has been parsed successfully, it is passed to the callback.
  *
- * \param *ptag		Pointer to the Packet Tag.  This function should consume the entire
+ * \param *ptag        Pointer to the Packet Tag.  This function should consume the entire
  * packet.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  *
  * \see RFC4880 5.2.2
  */
@@ -1567,11 +1567,11 @@ parse_v3_sig(pgp_region_t *region, pgp_stream_t *stream)
  *
  * Once the subpacket has been parsed successfully, it is passed to the callback.
  *
- * \param *ptag		Pointer to the Packet Tag.  This function should consume the entire
+ * \param *ptag        Pointer to the Packet Tag.  This function should consume the entire
  * subpacket.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  *
  * \see RFC4880 5.2.3
  */
@@ -1870,10 +1870,10 @@ parse_one_sig_subpacket(pgp_sig_t *sig, pgp_region_t *region, pgp_stream_t *stre
  * This function does not call the callback directly, parse_one_sig_subpacket() does for each
  * subpacket.
  *
- * \param *ptag		Pointer to the Packet Tag.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *ptag        Pointer to the Packet Tag.
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  *
  * \see RFC4880 5.2.3
  */
@@ -1915,10 +1915,10 @@ parse_sig_subpkts(pgp_sig_t *sig, pgp_region_t *region, pgp_stream_t *stream)
  *
  * Once the signature packet has been parsed successfully, it is passed to the callback.
  *
- * \param *ptag		Pointer to the Packet Tag.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *ptag        Pointer to the Packet Tag.
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  *
  * \see RFC4880 5.2.3
  */
@@ -2094,10 +2094,10 @@ parse_v4_sig(pgp_region_t *region, pgp_stream_t *stream)
  *
  * Once the signature packet has been parsed successfully, it is passed to the callback.
  *
- * \param *ptag		Pointer to the Packet Tag.
- * \param *reader	Our reader
- * \param *cb		The callback
- * \return		1 on success, 0 on error
+ * \param *ptag        Pointer to the Packet Tag.
+ * \param *reader    Our reader
+ * \param *cb        The callback
+ * \return        1 on success, 0 on error
  */
 static int
 parse_sig(pgp_region_t *region, pgp_stream_t *stream)
@@ -2962,7 +2962,7 @@ parse_se_data(pgp_region_t *region, pgp_stream_t *stream)
 static int
 parse_se_ip_data(pgp_region_t *region, pgp_stream_t *stream)
 {
-    pgp_packet_t pkt= {0};
+    pgp_packet_t pkt = {0};
     uint8_t      c = 0x0;
 
     if (!limread(&c, 1, region, stream)) {
@@ -3019,8 +3019,8 @@ parse_mdc(pgp_region_t *region, pgp_stream_t *stream)
  * content tag and then calls the appropriate function to handle the
  * content.
  *
- * \param *stream	How to parse
- * \param *pktlen	On return, will contain number of bytes in packet
+ * \param *stream    How to parse
+ * \param *pktlen    On return, will contain number of bytes in packet
  * \return 1 on success, 0 on error, -1 on EOF */
 static int
 parse_packet(pgp_stream_t *stream, uint32_t *pktlen)
@@ -3212,8 +3212,8 @@ parse_packet(pgp_stream_t *stream, uint32_t *pktlen)
  *
  * After returning, stream->errors holds any errors encountered while parsing.
  *
- * \param stream	Parsing configuration
- * \return		1 on success in all packets, 0 on error in any packet
+ * \param stream    Parsing configuration
+ * \return        1 on success in all packets, 0 on error in any packet
  *
  * \sa CoreAPI Overview
  *
@@ -3242,11 +3242,11 @@ pgp_parse(pgp_stream_t *stream, const int perrors)
  * \brief Specifies whether one or more signature
  * subpacket types should be returned parsed; or raw; or ignored.
  *
- * \param	stream	Pointer to previously allocated structure
- * \param	tag	Packet tag. PGP_PTAG_SS_ALL for all SS tags; or one individual
+ * \param    stream    Pointer to previously allocated structure
+ * \param    tag    Packet tag. PGP_PTAG_SS_ALL for all SS tags; or one individual
  * signature
  * subpacket tag
- * \param	type	Parse type
+ * \param    type    Parse type
  * \todo Make all packet types optional, not just subpackets */
 void
 pgp_parse_options(pgp_stream_t *stream, pgp_content_enum tag, pgp_parse_type_t type)

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -137,13 +137,13 @@ typedef struct {
  * \see RFC4880 4.2.1
  */
 typedef enum {
-    PGP_PTAG_OLD_LEN_1 = 0x00, /* Packet has a 1 byte length -
-                                * header is 2 bytes long. */
-    PGP_PTAG_OLD_LEN_2 = 0x01, /* Packet has a 2 byte length -
-                                * header is 3 bytes long. */
-    PGP_PTAG_OLD_LEN_4 = 0x02, /* Packet has a 4 byte
-                                * length - header is 5 bytes
-                                * long. */
+    PGP_PTAG_OLD_LEN_1 = 0x00,            /* Packet has a 1 byte length -
+                                           * header is 2 bytes long. */
+    PGP_PTAG_OLD_LEN_2 = 0x01,            /* Packet has a 2 byte length -
+                                           * header is 3 bytes long. */
+    PGP_PTAG_OLD_LEN_4 = 0x02,            /* Packet has a 4 byte
+                                           * length - header is 5 bytes
+                                           * long. */
     PGP_PTAG_OLD_LEN_INDETERMINATE = 0x03 /* Packet has a
                                            * indeterminate length. */
 } pgp_ptag_of_lt_t;
@@ -177,15 +177,15 @@ typedef enum {
  * \see RFC4880 5.2.3.1
  */
 typedef enum {
-    PGP_PTAG_CT_RESERVED = 0, /* Reserved - a packet tag must
-                               * not have this value */
+    PGP_PTAG_CT_RESERVED = 0,       /* Reserved - a packet tag must
+                                     * not have this value */
     PGP_PTAG_CT_PK_SESSION_KEY = 1, /* Public-Key Encrypted Session
                                      * Key Packet */
-    PGP_PTAG_CT_SIGNATURE = 2, /* Signature Packet */
+    PGP_PTAG_CT_SIGNATURE = 2,      /* Signature Packet */
     PGP_PTAG_CT_SK_SESSION_KEY = 3, /* Symmetric-Key Encrypted Session
                                      * Key Packet */
-    PGP_PTAG_CT_1_PASS_SIG = 4, /* One-Pass Signature
-                                 * Packet */
+    PGP_PTAG_CT_1_PASS_SIG = 4,     /* One-Pass Signature
+                                     * Packet */
     PGP_PTAG_CT_SECRET_KEY = 5,     /* Secret Key Packet */
     PGP_PTAG_CT_PUBLIC_KEY = 6,     /* Public Key Packet */
     PGP_PTAG_CT_SECRET_SUBKEY = 7,  /* Secret Subkey Packet */
@@ -199,9 +199,9 @@ typedef enum {
     PGP_PTAG_CT_RESERVED2 = 15,     /* reserved */
     PGP_PTAG_CT_RESERVED3 = 16,     /* reserved */
     PGP_PTAG_CT_USER_ATTR = 17,     /* User Attribute Packet */
-    PGP_PTAG_CT_SE_IP_DATA = 18, /* Sym. Encrypted and Integrity
-                                  * Protected Data Packet */
-    PGP_PTAG_CT_MDC = 19, /* Modification Detection Code Packet */
+    PGP_PTAG_CT_SE_IP_DATA = 18,    /* Sym. Encrypted and Integrity
+                                     * Protected Data Packet */
+    PGP_PTAG_CT_MDC = 19,           /* Modification Detection Code Packet */
 
     PGP_PARSER_PTAG = 0x100, /* Internal Use: The packet is the "Packet
                               * Tag" itself - used when callback sends
@@ -212,42 +212,42 @@ typedef enum {
 
     /* signature subpackets (0x200-2ff) (type+0x200) */
     /* only those we can parse are listed here */
-    PGP_PTAG_SIG_SUBPKT_BASE = 0x200,      /* Base for signature
-                                            * subpacket types - All
-                                            * signature type values
-                                            * are relative to this
-                                            * value. */
-    PGP_PTAG_SS_CREATION_TIME = 0x200 + 2, /* signature creation time */
+    PGP_PTAG_SIG_SUBPKT_BASE = 0x200,        /* Base for signature
+                                              * subpacket types - All
+                                              * signature type values
+                                              * are relative to this
+                                              * value. */
+    PGP_PTAG_SS_CREATION_TIME = 0x200 + 2,   /* signature creation time */
     PGP_PTAG_SS_EXPIRATION_TIME = 0x200 + 3, /* signature
                                               * expiration time */
 
-    PGP_PTAG_SS_EXPORT_CERT = 0x200 + 4, /* exportable certification */
-    PGP_PTAG_SS_TRUST = 0x200 + 5,       /* trust signature */
-    PGP_PTAG_SS_REGEXP = 0x200 + 6,      /* regular expression */
-    PGP_PTAG_SS_REVOCABLE = 0x200 + 7,   /* revocable */
-    PGP_PTAG_SS_KEY_EXPIRY = 0x200 + 9, /* key expiration
-                                         * time */
-    PGP_PTAG_SS_RESERVED = 0x200 + 10, /* reserved */
-    PGP_PTAG_SS_PREFERRED_SKA = 0x200 + 11, /* preferred symmetric
-                                             * algs */
-    PGP_PTAG_SS_REVOCATION_KEY = 0x200 + 12, /* revocation key */
-    PGP_PTAG_SS_ISSUER_KEY_ID = 0x200 + 16,  /* issuer key ID */
-    PGP_PTAG_SS_NOTATION_DATA = 0x200 + 20,  /* notation data */
-    PGP_PTAG_SS_PREFERRED_HASH = 0x200 + 21, /* preferred hash
-                                              * algs */
-    PGP_PTAG_SS_PREF_COMPRESS = 0x200 + 22, /* preferred
-                                             * compression
-                                             * algorithms */
-    PGP_PTAG_SS_KEYSERV_PREFS = 0x200 + 23, /* key server
-                                             * preferences */
-    PGP_PTAG_SS_PREF_KEYSERV = 0x200 + 24, /* Preferred Key
-                                            * Server */
-    PGP_PTAG_SS_PRIMARY_USER_ID = 0x200 + 25, /* primary User ID */
-    PGP_PTAG_SS_POLICY_URI = 0x200 + 26,      /* Policy URI */
-    PGP_PTAG_SS_KEY_FLAGS = 0x200 + 27,       /* key flags */
-    PGP_PTAG_SS_SIGNERS_USER_ID = 0x200 + 28, /* Signer's User ID */
-    PGP_PTAG_SS_REVOCATION_REASON = 0x200 + 29, /* reason for
-                                                 * revocation */
+    PGP_PTAG_SS_EXPORT_CERT = 0x200 + 4,         /* exportable certification */
+    PGP_PTAG_SS_TRUST = 0x200 + 5,               /* trust signature */
+    PGP_PTAG_SS_REGEXP = 0x200 + 6,              /* regular expression */
+    PGP_PTAG_SS_REVOCABLE = 0x200 + 7,           /* revocable */
+    PGP_PTAG_SS_KEY_EXPIRY = 0x200 + 9,          /* key expiration
+                                                  * time */
+    PGP_PTAG_SS_RESERVED = 0x200 + 10,           /* reserved */
+    PGP_PTAG_SS_PREFERRED_SKA = 0x200 + 11,      /* preferred symmetric
+                                                  * algs */
+    PGP_PTAG_SS_REVOCATION_KEY = 0x200 + 12,     /* revocation key */
+    PGP_PTAG_SS_ISSUER_KEY_ID = 0x200 + 16,      /* issuer key ID */
+    PGP_PTAG_SS_NOTATION_DATA = 0x200 + 20,      /* notation data */
+    PGP_PTAG_SS_PREFERRED_HASH = 0x200 + 21,     /* preferred hash
+                                                  * algs */
+    PGP_PTAG_SS_PREF_COMPRESS = 0x200 + 22,      /* preferred
+                                                  * compression
+                                                  * algorithms */
+    PGP_PTAG_SS_KEYSERV_PREFS = 0x200 + 23,      /* key server
+                                                  * preferences */
+    PGP_PTAG_SS_PREF_KEYSERV = 0x200 + 24,       /* Preferred Key
+                                                  * Server */
+    PGP_PTAG_SS_PRIMARY_USER_ID = 0x200 + 25,    /* primary User ID */
+    PGP_PTAG_SS_POLICY_URI = 0x200 + 26,         /* Policy URI */
+    PGP_PTAG_SS_KEY_FLAGS = 0x200 + 27,          /* key flags */
+    PGP_PTAG_SS_SIGNERS_USER_ID = 0x200 + 28,    /* Signer's User ID */
+    PGP_PTAG_SS_REVOCATION_REASON = 0x200 + 29,  /* reason for
+                                                  * revocation */
     PGP_PTAG_SS_FEATURES = 0x200 + 30,           /* features */
     PGP_PTAG_SS_SIGNATURE_TARGET = 0x200 + 31,   /* signature target */
     PGP_PTAG_SS_EMBEDDED_SIGNATURE = 0x200 + 32, /* embedded signature */
@@ -293,7 +293,7 @@ typedef enum {
     PGP_GET_SECKEY = 0x400 + 1,
 
     /* Errors */
-    PGP_PARSER_ERROR = 0x500, /* Internal Use: Parser Error */
+    PGP_PARSER_ERROR = 0x500,      /* Internal Use: Parser Error */
     PGP_PARSER_ERRCODE = 0x500 + 1 /* Internal Use: Parser Error
                                     * with errcode returned */
 } pgp_content_enum;
@@ -315,21 +315,21 @@ typedef struct {
  * \see RFC4880 4.2
  */
 typedef struct {
-    unsigned new_format; /* Whether this packet tag is new
-                          * (1) or old format (0) */
-    unsigned type; /* content_tag value - See
-                    * #pgp_content_enum for meanings */
-    pgp_ptag_of_lt_t length_type;       /* Length type (#pgp_ptag_of_lt_t)
-                                         * - only if this packet tag is old
-                                         * format.  Set to 0 if new format. */
+    unsigned new_format;            /* Whether this packet tag is new
+                                     * (1) or old format (0) */
+    unsigned type;                  /* content_tag value - See
+                                     * #pgp_content_enum for meanings */
+    pgp_ptag_of_lt_t length_type;   /* Length type (#pgp_ptag_of_lt_t)
+                                     * - only if this packet tag is old
+                                     * format.  Set to 0 if new format. */
     unsigned length; /* The length of the packet.  This value
-				 * is set when we read and compute the length
-				 * information, not at the same moment we
-				 * create the packet tag structure. Only
-	 * defined if #readc is set. */ /* XXX: Ben, is this correct? */
-    unsigned position; /* The position (within the
-                        * current reader) of the packet */
-    unsigned size; /* number of bits */
+                 * is set when we read and compute the length
+                 * information, not at the same moment we
+                 * create the packet tag structure. Only
+     * defined if #readc is set. */ /* XXX: Ben, is this correct? */
+    unsigned position;              /* The position (within the
+                                     * current reader) of the packet */
+    unsigned size;                  /* number of bits */
 } pgp_ptag_t;
 
 /** Public Key Algorithm Numbers.
@@ -340,14 +340,14 @@ typedef struct {
  * \see RFC4880 9.1
  */
 typedef enum {
-    PGP_PKA_NOTHING = 0, /* No PKA */
-    PGP_PKA_RSA = 1,     /* RSA (Encrypt or Sign) */
-    PGP_PKA_RSA_ENCRYPT_ONLY = 2, /* RSA Encrypt-Only (deprecated -
-                                   * \see RFC4880 13.5) */
-    PGP_PKA_RSA_SIGN_ONLY = 3, /* RSA Sign-Only (deprecated -
-                                * \see RFC4880 13.5) */
-    PGP_PKA_ELGAMAL = 16, /* Elgamal (Encrypt-Only) */
-    PGP_PKA_DSA = 17,     /* DSA (Digital Signature Algorithm) */
+    PGP_PKA_NOTHING = 0,                  /* No PKA */
+    PGP_PKA_RSA = 1,                      /* RSA (Encrypt or Sign) */
+    PGP_PKA_RSA_ENCRYPT_ONLY = 2,         /* RSA Encrypt-Only (deprecated -
+                                           * \see RFC4880 13.5) */
+    PGP_PKA_RSA_SIGN_ONLY = 3,            /* RSA Sign-Only (deprecated -
+                                           * \see RFC4880 13.5) */
+    PGP_PKA_ELGAMAL = 16,                 /* Elgamal (Encrypt-Only) */
+    PGP_PKA_DSA = 17,                     /* DSA (Digital Signature Algorithm) */
     PGP_PKA_RESERVED_ELLIPTIC_CURVE = 18, /* Reserved for Elliptic
                                            * Curve */
     PGP_PKA_RESERVED_ECDSA = 19,          /* Reserved for ECDSA */
@@ -543,12 +543,12 @@ typedef enum {
     PGP_SIG_TEXT = 0x01,       /* Signature of a canonical text document */
     PGP_SIG_STANDALONE = 0x02, /* Standalone signature */
 
-    PGP_CERT_GENERIC = 0x10, /* Generic certification of a User ID and
-                              * Public Key packet */
-    PGP_CERT_PERSONA = 0x11, /* Persona certification of a User ID and
-                              * Public Key packet */
-    PGP_CERT_CASUAL = 0x12, /* Casual certification of a User ID and
-                             * Public Key packet */
+    PGP_CERT_GENERIC = 0x10,  /* Generic certification of a User ID and
+                               * Public Key packet */
+    PGP_CERT_PERSONA = 0x11,  /* Persona certification of a User ID and
+                               * Public Key packet */
+    PGP_CERT_CASUAL = 0x12,   /* Casual certification of a User ID and
+                               * Public Key packet */
     PGP_CERT_POSITIVE = 0x13, /* Positive certification of a
                                * User ID and Public Key packet */
 
@@ -591,14 +591,14 @@ typedef struct pgp_elgamal_sig_t {
  * \see RFC4880 5.2.3
  */
 typedef struct pgp_sig_info_t {
-    pgp_version_t  version;   /* signature version number */
-    pgp_sig_type_t type;      /* signature type value */
-    time_t         birthtime; /* creation time of the signature */
-    time_t         duration;  /* number of seconds it's valid for */
+    pgp_version_t  version;                    /* signature version number */
+    pgp_sig_type_t type;                       /* signature type value */
+    time_t         birthtime;                  /* creation time of the signature */
+    time_t         duration;                   /* number of seconds it's valid for */
     uint8_t        signer_id[PGP_KEY_ID_SIZE]; /* Eight-octet key ID
                                                 * of signer */
-    pgp_pubkey_alg_t key_alg;  /* public key algorithm number */
-    pgp_hash_alg_t   hash_alg; /* hashing algorithm number */
+    pgp_pubkey_alg_t key_alg;                  /* public key algorithm number */
+    pgp_hash_alg_t   hash_alg;                 /* hashing algorithm number */
     union {
         pgp_rsa_sig_t     rsa;     /* An RSA Signature */
         pgp_dsa_sig_t     dsa;     /* A DSA Signature */

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -1293,7 +1293,7 @@ pgp_reader_push_dearmour(pgp_stream_t *parse_info)
  * // Allow no blank line at the start of armoured data unsigned no_gap,
  *
  * //Allow armoured data to have trailing whitespace where we strictly would not
- * expect it			      unsigned trailing_whitespace
+ * expect it                  unsigned trailing_whitespace
  */
 {
     dearmour_t *dearmour;
@@ -1693,13 +1693,13 @@ typedef struct mmap_reader_t {
  * descriptor in "parse_info" into the buffer starting at "dest" using the
  * rules contained in "flags"
  *
- * \param	dest	Pointer to previously allocated buffer
- * \param	plength Number of bytes to try to read
- * \param	flags	Rules about reading to use
- * \param	readinfo	Reader info
- * \param	cbinfo	Callback info
+ * \param    dest    Pointer to previously allocated buffer
+ * \param    plength Number of bytes to try to read
+ * \param    flags    Rules about reading to use
+ * \param    readinfo    Reader info
+ * \param    cbinfo    Callback info
  *
- * \return	n	Number of bytes read
+ * \return    n    Number of bytes read
  *
  * PGP_R_EARLY_EOF and PGP_R_ERROR push errors on the stack
  */

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -497,11 +497,11 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
         (void) fprintf(stderr, "formatobj: json is '%s'\n", json_object_to_json_string(obj));
     }
 #if 0 //?
-	if (obj->c == 2 && obj->value.v[1].type == MJ_STRING &&
-		strcmp(obj->value.v[1].value.s, "[REVOKED]") == 0) {
-		/* whole key has been rovoked - just return */
-		return;
-	}
+    if (obj->c == 2 && obj->value.v[1].type == MJ_STRING &&
+        strcmp(obj->value.v[1].value.s, "[REVOKED]") == 0) {
+        /* whole key has been rovoked - just return */
+        return;
+    }
 #endif
     json_object *tmp;
     if (json_object_object_get_ex(obj, "header", &tmp)) {
@@ -912,7 +912,7 @@ rnp_init(rnp_t *rnp)
 /* Before calling the init, the userdefined options are set.
  * DONOT MEMSET*/
 #if 0
-	memset((void *) rnp, '\0', sizeof(rnp_t));
+    memset((void *) rnp, '\0', sizeof(rnp_t));
 #endif
 
     /* Apply default settings. */
@@ -1986,7 +1986,7 @@ rnp_format_json(void *vp, const char *json, const int psigs)
     }
     /* convert from string into a json structure */
     ids = json_tokener_parse(json);
-    //	/* ids is an array of strings, each containing 1 entry */
+    //    /* ids is an array of strings, each containing 1 entry */
     idc = json_object_array_length(ids);
     (void) fprintf(fp, "%d key%s found\n", idc, (idc == 1) ? "" : "s");
     for (i = 0; i < idc; i++) {

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -924,9 +924,9 @@ pgp_sign_file(pgp_io_t *          io,
         pgp_setup_memory_write(&litoutput, &litmem, bufsz);
         pgp_setup_memory_write(&zoutput, &zmem, bufsz);
                 pgp_write_litdata(litoutput,
-			pgp_mem_data(pgp_mem_data(infile),
-			(const int)pgp_mem_len(infile), PGP_LDT_BINARY);
-		pgp_writez(zoutput, pgp_mem_data(litmem), pgp_mem_len(litmem));
+            pgp_mem_data(pgp_mem_data(infile),
+            (const int)pgp_mem_len(infile), PGP_LDT_BINARY);
+        pgp_writez(zoutput, pgp_mem_data(litmem), pgp_mem_len(litmem));
 #endif
 
         /* add creation time to signature */

--- a/src/rnpv/b64.c
+++ b/src/rnpv/b64.c
@@ -54,7 +54,7 @@ DESCRIPTION:
                 Decoding is the process in reverse.  A 'decode' lookup
                 table has been created to avoid string scans.
 
-DESIGN GOALS:	Specifically:
+DESIGN GOALS:    Specifically:
                 Code is a stand-alone utility to perform base64
                 encoding/decoding. It should be genuinely useful
                 when the need arises and it meets a need that is

--- a/src/rnpv/libverify.c
+++ b/src/rnpv/libverify.c
@@ -242,7 +242,7 @@ __printflike(2, 3) static bool obuf_printf(obuf_t *obuf, const char *fmt, ...)
         va_copy(argscpy, args);
         cc = vsnprintf(cp, 0, fmt, args);
         va_end(args);
-        if( (cc > 0) && ((cp = malloc( 1 + cc)) != NULL)){
+        if ((cc > 0) && ((cp = malloc(1 + cc)) != NULL)) {
             cc = vsprintf(cp, fmt, argscpy);
             va_end(argscpy);
             ret = obuf_add_mem(obuf, cp, (size_t) cc);


### PR DESCRIPTION
clang-format 4.0.0 does not remove them inside commented-out code.