### PR TITLE
Specify clang-format version required as v4.0.0.

### DIFF
--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -135,7 +135,7 @@ C is a very flexible and powerful language. Because of this, it is important to 
 
 ## Code Formatting
 
-`clang-format` (v4+) can be used to format the code base, utilizing the `.clang-format` file included in the repository.
+`clang-format` (v4.0.0) can be used to format the code base, utilizing the `.clang-format` file included in the repository.
 
 ### clang-format git hook
 
@@ -146,7 +146,7 @@ $ cd rnp
 $ git-hooks/enable.sh
 ```
 
-If you do not have clang-format v4+ available, you can use a docker container for this purpose by setting `USE_DOCKER="yes"` in `git-hooks/pre-commit.sh`.
+If you do not have clang-format v4.0.0 available, you can use a docker container for this purpose by setting `USE_DOCKER="yes"` in `git-hooks/pre-commit.sh`.
 
 This should generally work if you commit from the command line.
 
@@ -160,7 +160,7 @@ If you are not able to use the git hook, you can run clang-format manually.
 $ clang-format -style=file -i src/lib/some_changed_file.c
 ```
 
-(Or, if you do not have clang-form v4 available, use a container)
+(Or, if you do not have clang-form v4.0.0 available, use a container)
 
 ## Style Guide
 

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -70,6 +70,8 @@ fi
 
 exec 1>&2
 
+$CLANG_FORMAT -version | grep -Fq 4.0.0 || (echo Incorrect version of clang-format.; exit 1)
+
 patchfile=$(mktemp --tmpdir --suffix=.patch git-clang-format.XXXXXX)
 stash
 trap "cleanup" SIGHUP SIGINT SIGTERM EXIT ERR

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -17,7 +17,7 @@ INTERACTIVE="yes"
 # Leave this stuff
 STASH_NAME="pre-commit-$(date +%s)"
 CONTAINER_NAME="clang-format-$(date +%s)"
-CLANG_VERSION="4.0.0"
+CLANG_FORMAT_VERSION="4.0.0"
 
 apply_patch() {
   local patchfile=$1
@@ -71,7 +71,7 @@ fi
 
 exec 1>&2
 
-$CLANG_FORMAT -version | grep -Fq "$CLANG_VERSION" || (echo Incorrect version of clang-format.; exit 1)
+$CLANG_FORMAT -version | grep -Fq "$CLANG_FORMAT_VERSION" || (echo Incorrect version of clang-format.; exit 1)
 
 patchfile=$(mktemp --tmpdir --suffix=.patch git-clang-format.XXXXXX)
 stash

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -17,6 +17,7 @@ INTERACTIVE="yes"
 # Leave this stuff
 STASH_NAME="pre-commit-$(date +%s)"
 CONTAINER_NAME="clang-format-$(date +%s)"
+CLANG_VERSION="4.0.0"
 
 apply_patch() {
   local patchfile=$1
@@ -70,7 +71,7 @@ fi
 
 exec 1>&2
 
-$CLANG_FORMAT -version | grep -Fq 4.0.0 || (echo Incorrect version of clang-format.; exit 1)
+$CLANG_FORMAT -version | grep -Fq "$CLANG_VERSION" || (echo Incorrect version of clang-format.; exit 1)
 
 patchfile=$(mktemp --tmpdir --suffix=.patch git-clang-format.XXXXXX)
 stash


### PR DESCRIPTION
It looks like clang-format 4.0.0 is the newest official stable version.
At some point we may want to look at google's stable branch of clang for a newer clang-format (I think - may have to check on that).
But for now it's probably safest for us all to stick to 4.0.0.

This just clarifies things in the Developer's Guide, and adds a version check to the pre-commit hook.