### PR TITLE
ci: Add sanitize-leaks build to matrix (failure allowed for now).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,12 @@ matrix:
       compiler: clang
     - env: BUILD_MODE=sanitize
       compiler: clang
+    - env: BUILD_MODE=sanitize-leaks
+      compiler: clang
     - env: BUILD_MODE=coverage
       compiler: gcc
   allow_failures:
-    - env: BUILD_MODE=sanitize
+    - env: BUILD_MODE=sanitize-leaks
 
 cache:
   directories:

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -9,12 +9,21 @@ JSON_LIBS="-L${JSON_C_INSTALL}/lib -ljson-c"
 JSON_CFLAGS="-I${JSON_C_INSTALL}/include/json-c"
 
 [ "$BUILD_MODE" = "coverage" ] && CFLAGS+=" -O0 --coverage"
-[ "$BUILD_MODE" = "sanitize" ] && CFLAGS+=" -fsanitize=leak,address,undefined"
+
+# CFLAGS for sanitize and sanitize-leaks
+[ "$BUILD_MODE" = "sanitize" -o "$BUILD_MODE" = "sanitize-leaks" ] && CFLAGS+=" \
+ -fsanitize=leak,address,undefined   \
+ -fno-omit-frame-pointer             \
+ -fno-common"
+
+# No leak detection for main sanitize run (only for sanitize-leaks)
+[ "$BUILD_MODE" = "sanitize" ] && export ASAN_OPTIONS=detect_leaks=0
 
 export LD_LIBRARY_PATH CFLAGS LDFLAGS JSON_CFLAGS JSON_LIBS
 
 autoreconf -vfi
 ./configure --with-botan=${BOTAN_INSTALL}
+make clean
 make -j2
 
 : "${COVERITY_SCAN_BRANCH:=0}"


### PR DESCRIPTION
This just separates "sanitize" and "sanitize-leaks".
The "sanitize" run is no longer permitted to fail.
This way, we can still catch other things in the sanitize run, like heap overflows, but allow memory leaks for now.