### PR TITLE
fix build on 32 bit by avoiding using %zu for unsigned long, fixes #193

### DIFF
--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -325,7 +325,7 @@ rsa_generate_keypair(pgp_key_t *         keydata,
     }
 
     if (e != 65537) {
-        fprintf(stderr, "Unexpected RSA e value %zu, key generation failed\n", e);
+        fprintf(stderr, "Unexpected RSA e value %lu, key generation failed\n", e);
         return false;
     }
 


### PR DESCRIPTION
No change in logic.
Apart from this no build issues on 32 bit.