### PR TITLE
Add Ed25519 signatures

### DIFF
--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -61,6 +61,8 @@ main(void)
     assert_int_equal(0, chdir(tmphome));
 
     struct CMUnitTest tests[] = {
+      cmocka_unit_test(rnp_test_eddsa),
+      #if 0
       cmocka_unit_test(hash_test_success),
       cmocka_unit_test(cipher_test_success),
       cmocka_unit_test(pkcs1_rsa_test_success),
@@ -73,6 +75,7 @@ main(void)
       cmocka_unit_test(rnpkeys_generatekey_verifykeyNonexistingHomeDir),
       cmocka_unit_test(rnpkeys_generatekey_verifykeyHomeDirNoPermission),
       cmocka_unit_test(rnpkeys_exportkey_verifyUserId),
+      #endif
     };
 
     /* Each test entry will invoke setup_test before running

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -61,12 +61,11 @@ main(void)
     assert_int_equal(0, chdir(tmphome));
 
     struct CMUnitTest tests[] = {
-      cmocka_unit_test(rnp_test_eddsa),
-      #if 0
       cmocka_unit_test(hash_test_success),
       cmocka_unit_test(cipher_test_success),
       cmocka_unit_test(pkcs1_rsa_test_success),
       cmocka_unit_test(raw_elg_test_success),
+      cmocka_unit_test(rnp_test_eddsa),
       cmocka_unit_test(rnpkeys_generatekey_testSignature),
       cmocka_unit_test(rnpkeys_generatekey_testEncryption),
       cmocka_unit_test(rnpkeys_generatekey_verifySupportedHashAlg),
@@ -75,7 +74,6 @@ main(void)
       cmocka_unit_test(rnpkeys_generatekey_verifykeyNonexistingHomeDir),
       cmocka_unit_test(rnpkeys_generatekey_verifykeyHomeDirNoPermission),
       cmocka_unit_test(rnpkeys_exportkey_verifyUserId),
-      #endif
     };
 
     /* Each test entry will invoke setup_test before running

--- a/src/cmocka/rnp_tests.h
+++ b/src/cmocka/rnp_tests.h
@@ -42,6 +42,8 @@ void rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state);
 
 void rnpkeys_exportkey_verifyUserId(void **state);
 
+void rnp_test_eddsa(void **state);
+
 void hash_test_success(void **state);
 
 void cipher_test_success(void **state);

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -216,6 +216,7 @@ void rnp_test_eddsa(void** state)
 
    BN_free(r);
    BN_free(s);
+   pgp_keydata_free(pgp_key);
    }
 
 void

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -213,6 +213,9 @@ void rnp_test_eddsa(void** state)
 
    // cut one byte off hash -> invalid sig
    assert_int_equal(pgp_eddsa_verify_hash(r, s, hash, sizeof(hash) - 1, &pgp_key->key.seckey.pubkey.key.ecc), 0);
+
+   BN_free(r);
+   BN_free(s);
    }
 
 void

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -24,6 +24,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <rsa.h>
+#include <dsa.h>
+#include <eddsa.h>
+#include <elgamal.h>
 #include <crypto.h>
 #include <key_store_pgp.h>
 #include <packet.h>
@@ -138,7 +142,7 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_pubkey_t *pub_rsa;
     const pgp_rsa_seckey_t *sec_rsa;
 
-    pgp_key = pgp_rsa_new_key(1024, 65537, "userid", "AES-128");
+    pgp_key = pgp_generate_keypair(PGP_PKA_RSA, 1024, NULL, "SHA-256", "AES-128");
     assert_true(pgp_key != NULL);
     sec_key = pgp_get_seckey(pgp_key);
     pub_key = pgp_get_pubkey(pgp_key);
@@ -188,6 +192,28 @@ pkcs1_rsa_test_success(void **state)
     assert_int_equal(decrypted_size, 3);
     pgp_keydata_free(pgp_key);
 }
+
+void rnp_test_eddsa(void** state)
+   {
+   pgp_key_t* pgp_key = pgp_generate_keypair(PGP_PKA_EDDSA, 255, NULL, "SHA-256", "AES-128");
+   assert_non_null(pgp_key);
+
+   const uint8_t hash[32] = { 0 };
+   BIGNUM* r = BN_new();
+   BIGNUM* s = BN_new();
+
+   assert_int_equal(pgp_eddsa_sign_hash(r, s, hash, sizeof(hash),
+                                        &pgp_key->key.seckey.key.ecc,
+                                        &pgp_key->key.seckey.pubkey.key.ecc), 0);
+
+   assert_int_equal(pgp_eddsa_verify_hash(r, s, hash, sizeof(hash), &pgp_key->key.seckey.pubkey.key.ecc), 1);
+
+   // swap r/s -> invalid sig
+   assert_int_equal(pgp_eddsa_verify_hash(s, r, hash, sizeof(hash), &pgp_key->key.seckey.pubkey.key.ecc), 0);
+
+   // cut one byte off hash -> invalid sig
+   assert_int_equal(pgp_eddsa_verify_hash(r, s, hash, sizeof(hash) - 1, &pgp_key->key.seckey.pubkey.key.ecc), 0);
+   }
 
 void
 raw_elg_test_success(void **state)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -37,6 +37,4 @@
         }                                             \
     } while (false)
 
-#define CHECK_BOTAN(exp, err) CHECK((exp), 0, (err))
-
 #endif

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -15,6 +15,7 @@ librnp_la_SOURCES	= \
 	create.c \
 	crypto.c \
 	dsa.c \
+	eddsa.c \
 	elgamal.c \
 	hash.c \
 	key_store.c \

--- a/src/lib/bn.c
+++ b/src/lib/bn.c
@@ -632,3 +632,37 @@ PGPV_BN_gcd(PGPV_BIGNUM *r, PGPV_BIGNUM *a, PGPV_BIGNUM *b, PGPV_BN_CTX *ctx)
     USE_ARG(ctx);
     return botan_mp_gcd(r->mp, a->mp, b->mp);
 }
+
+BIGNUM *
+new_BN_take_mp(botan_mp_t mp)
+{
+    PGPV_BIGNUM *a;
+
+    a = calloc(1, sizeof(*a));
+    a->mp = mp;
+    return a;
+}
+
+void
+destroy_BN_mp(BIGNUM **a)
+{
+    free(*a);
+    *a = NULL;
+}
+
+DSA_SIG *
+DSA_SIG_new()
+{
+    DSA_SIG *sig = calloc(1, sizeof(DSA_SIG));
+    sig->r = BN_new();
+    sig->s = BN_new();
+    return sig;
+}
+
+void
+DSA_SIG_free(DSA_SIG *sig)
+{
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+    free(sig);
+}

--- a/src/lib/bn.h
+++ b/src/lib/bn.h
@@ -29,6 +29,8 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#include <botan/ffi.h>
+
 #ifndef __BEGIN_DECLS
 #if defined(__cplusplus)
 #define __BEGIN_DECLS extern "C" {
@@ -103,9 +105,11 @@ __BEGIN_DECLS
 #endif /* USE_BN_INTERFACE */
 
 /*
- * PGPV_BIGNUM is an opaque struct
+ * PGPV_BIGNUM struct
  */
-typedef struct PGPV_BIGNUM_st PGPV_BIGNUM;
+typedef struct PGPV_BIGNUM_st {
+    botan_mp_t mp;
+} PGPV_BIGNUM;
 
 /* a "context" of mp integers - never really used */
 typedef struct bn_ctx_t {
@@ -223,6 +227,24 @@ int PGPV_BN_gcd(PGPV_BIGNUM * /*r*/,
                 PGPV_BIGNUM * /*a*/,
                 PGPV_BIGNUM * /*b*/,
                 PGPV_BN_CTX * /*ctx*/);
+
+/**
+ * \brief Allocates BIGNUM and mp value assigned
+ */
+BIGNUM *new_BN_take_mp(botan_mp_t mp);
+void destroy_BN_mp(BIGNUM **a);
+
+/*
+* This type is used to represent any signature where
+* a pair of MPIs is used (DSA, ECDSA, EdDSA, ...)
+*/
+typedef struct DSA_SIG_st {
+    BIGNUM *r;
+    BIGNUM *s;
+} DSA_SIG;
+
+DSA_SIG *DSA_SIG_new();
+void DSA_SIG_free(DSA_SIG *sig);
 
 __END_DECLS
 

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -80,6 +80,8 @@ __RCSID("$NetBSD: create.c,v 1.38 2010/11/15 08:03:39 agc Exp $");
 #endif
 
 #include "bn.h"
+#include "rsa.h"
+#include "elgamal.h"
 #include "create.h"
 #include "key_store_pgp.h"
 #include "packet.h"

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -534,19 +534,3 @@ pgp_crypto_finish(void)
     // currently empty implementation
 }
 
-BIGNUM *
-new_BN_take_mp(botan_mp_t mp)
-{
-    PGPV_BIGNUM *a;
-
-    a = calloc(1, sizeof(*a));
-    a->mp = mp;
-    return a;
-}
-
-void
-destroy_BN_mp(BIGNUM **a)
-{
-    free(*a);
-    *a = NULL;
-}

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -230,11 +230,13 @@ pgp_generate_keypair(pgp_pubkey_alg_t    alg,
        seckey->pubkey.alg == PGP_PKA_RSA_ENCRYPT_ONLY ||
        seckey->pubkey.alg == PGP_PKA_RSA_SIGN_ONLY)
        {
-       pgp_genkey_rsa(seckey, alg_params);
+       if (pgp_genkey_rsa(seckey, alg_params) != 1)
+          goto end;
        }
     else if(seckey->pubkey.alg == PGP_PKA_EDDSA)
        {
-       pgp_genkey_eddsa(seckey, alg_params);
+       if (pgp_genkey_eddsa(seckey, alg_params) != 1)
+          goto end;
        }
     else
        {
@@ -273,8 +275,8 @@ pgp_generate_keypair(pgp_pubkey_alg_t    alg,
        }
     else if(seckey->pubkey.alg == PGP_PKA_EDDSA)
        {
-       //...
-       //ret = true;
+       if(pgp_write_mpi(output, seckey->key.ecc.x) != 1)
+          goto end;
        }
     else
        {

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -61,104 +61,19 @@
 #include "memory.h"
 #include "packet-parse.h"
 #include "symmetric.h"
-#include "eddsa.h"
 
 #define PGP_MIN_HASH_SIZE 16
 
 void pgp_crypto_finish(void);
 
-unsigned pgp_dsa_verify(const uint8_t *,
-                        size_t,
-                        const pgp_dsa_sig_t *,
-                        const pgp_dsa_pubkey_t *);
+/* Key generation */
 
-/*
- * RSA encrypt/decrypt
- */
-
-int pgp_rsa_encrypt_pkcs1(uint8_t *               out,
-                          size_t                  out_len,
-                          const uint8_t *         key,
-                          size_t                  key_len,
-                          const pgp_rsa_pubkey_t *pubkey);
-
-int pgp_rsa_decrypt_pkcs1(uint8_t *               out,
-                          size_t                  out_len,
-                          const uint8_t *         key,
-                          size_t                  key_len,
-                          const pgp_rsa_seckey_t *privkey,
-                          const pgp_rsa_pubkey_t *pubkey);
-
-/*
- * RSA signature generation and verification
- */
-
-/*
- * Returns 1 for valid 0 for invalid/error
- */
-int pgp_rsa_pkcs1_verify_hash(const uint8_t *         sig_buf,
-                              size_t                  sig_buf_size,
-                              pgp_hash_alg_t          hash_alg,
-                              const uint8_t *         hash,
-                              size_t                  hash_len,
-                              const pgp_rsa_pubkey_t *pubkey);
-
-/*
- * Returns # bytes written to sig_buf on success, 0 on error
- */
-int pgp_rsa_pkcs1_sign_hash(uint8_t *      sig_buf,
-                            size_t         sig_buf_size,
-                            pgp_hash_alg_t hash_alg,
-                            const uint8_t *hash,
-                            size_t         hash_len,
-                            const pgp_rsa_seckey_t *,
-                            const pgp_rsa_pubkey_t *);
-
-/*
- * Performs ElGamal encryption
- * Result of an encryption is composed of two parts - g2k and encm
- *
- * @param g2k [out] buffer stores first part of encryption (g^k % p)
- * @param encm [out] buffer stores second part of encryption (y^k * in % p)
- * @param in plaintext to be encrypted
- * @param length length of an input
- * @param pubkey public key to be used for encryption
- *
- * @pre g2k size must be at least equal to byte size of prime `p'
- * @pre encm size must be at least equal to byte size of prime `p'
- *
- * @return     on success - number of bytes written to g2k and encm
- *            on failure -1
- */
-int pgp_elgamal_public_encrypt_pkcs1(uint8_t *                   g2k,
-                                     uint8_t *                   encm,
-                                     const uint8_t *             in,
-                                     size_t                      length,
-                                     const pgp_elgamal_pubkey_t *pubkey);
-
-/*
- * Performs ElGamal decryption
- *
- * @param out [out] decrypted plaintext
- * @param g2k buffer stores first part of encryption (g^k % p)
- * @param encm buffer stores second part of encryption (y^k * in % p)
- * @param length length of g2k or in (must be equal to byte size of prime `p')
- * @param seckey private part of a key used for decryption
- * @param pubkey public domain parameters (p,g) used for decryption
- *
- * @pre g2k size must be at least equal to byte size of prime `p'
- * @pre encm size must be at least equal to byte size of prime `p'
- * @pre byte-size of `g2k' must be equal to `encm'
- *
- * @return     on success - number of bytes written to g2k and encm
- *            on failure -1
- */
-int pgp_elgamal_private_decrypt_pkcs1(uint8_t *                   out,
-                                      const uint8_t *             g2k,
-                                      const uint8_t *             in,
-                                      size_t                      length,
-                                      const pgp_elgamal_seckey_t *seckey,
-                                      const pgp_elgamal_pubkey_t *pubkey);
+pgp_key_t*
+pgp_generate_keypair(pgp_pubkey_alg_t   alg,
+                     const int          alg_params,
+                     const uint8_t*     userid,
+                     const char*        hashalg,
+                     const char*        cipher);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);
@@ -206,18 +121,7 @@ pgp_memory_t *pgp_decrypt_buf(pgp_io_t *,
                               int,
                               pgp_cbfunc_t *);
 
-/* Keys */
-pgp_key_t *pgp_rsa_new_selfsign_key(const int           bits,
-                                    const unsigned long e,
-                                    uint8_t *           userid,
-                                    const char *        hash_alg,
-                                    const char *        cipher);
-pgp_key_t *pgp_rsa_new_key(const int, const unsigned long, const char *, const char *);
 
-int pgp_dsa_size(const pgp_dsa_pubkey_t *);
-
-typedef struct DSA_SIG_st DSA_SIG;
-DSA_SIG *pgp_dsa_sign(uint8_t *, unsigned, const pgp_dsa_seckey_t *, const pgp_dsa_pubkey_t *);
 
 int read_pem_seckey(const char *, pgp_key_t *, const char *, int);
 

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -55,20 +55,15 @@
 #ifndef CRYPTO_H_
 #define CRYPTO_H_
 
-#include <botan/ffi.h>
 #include "hash.h"
 #include "key_store_pgp.h"
 #include "packet.h"
 #include "memory.h"
 #include "packet-parse.h"
 #include "symmetric.h"
-#include "bn.h"
+#include "eddsa.h"
 
 #define PGP_MIN_HASH_SIZE 16
-
-struct PGPV_BIGNUM_st {
-    botan_mp_t mp;
-};
 
 void pgp_crypto_finish(void);
 
@@ -221,14 +216,7 @@ pgp_key_t *pgp_rsa_new_key(const int, const unsigned long, const char *, const c
 
 int pgp_dsa_size(const pgp_dsa_pubkey_t *);
 
-typedef struct {
-    BIGNUM *r;
-    BIGNUM *s;
-} DSA_SIG;
-
-DSA_SIG *DSA_SIG_new();
-void DSA_SIG_free(DSA_SIG *sig);
-
+typedef struct DSA_SIG_st DSA_SIG;
 DSA_SIG *pgp_dsa_sign(uint8_t *, unsigned, const pgp_dsa_seckey_t *, const pgp_dsa_pubkey_t *);
 
 int read_pem_seckey(const char *, pgp_key_t *, const char *, int);
@@ -327,11 +315,5 @@ struct pgp_stream_t {
     unsigned virtualoff;
     uint8_t *virtualpkt;
 };
-
-/**
- * \brief Allocates BIGNUM and mp value assigned
- */
-BIGNUM *new_BN_take_mp(botan_mp_t mp);
-void destroy_BN_mp(BIGNUM **a);
 
 #endif /* CRYPTO_H_ */

--- a/src/lib/dsa.c
+++ b/src/lib/dsa.c
@@ -77,6 +77,7 @@
  */
 #include <stdlib.h>
 #include "crypto.h"
+#include "bn.h"
 
 unsigned
 pgp_dsa_verify(const uint8_t *         hash,
@@ -107,23 +108,6 @@ pgp_dsa_verify(const uint8_t *         hash,
     free(encoded_signature);
 
     return valid;
-}
-
-DSA_SIG *
-DSA_SIG_new()
-{
-    DSA_SIG *sig = calloc(1, sizeof(DSA_SIG));
-    sig->r = calloc(1, sizeof(BIGNUM));
-    sig->s = calloc(1, sizeof(BIGNUM));
-    return sig;
-}
-
-void
-DSA_SIG_free(DSA_SIG *sig)
-{
-    BN_clear_free(sig->r);
-    BN_clear_free(sig->s);
-    free(sig);
 }
 
 DSA_SIG *
@@ -160,8 +144,6 @@ pgp_dsa_sign(uint8_t *               hashbuf,
 
     // Now load the DSA (r,s) values from the signature
     ret = DSA_SIG_new();
-    botan_mp_init(&(ret->r->mp));
-    botan_mp_init(&(ret->s->mp));
 
     botan_mp_from_bin(ret->r->mp, sigbuf, q_bytes);
     botan_mp_from_bin(ret->s->mp, sigbuf + q_bytes, q_bytes);

--- a/src/lib/dsa.c
+++ b/src/lib/dsa.c
@@ -76,7 +76,7 @@
 /** \file
  */
 #include <stdlib.h>
-#include "crypto.h"
+#include "dsa.h"
 #include "bn.h"
 
 unsigned

--- a/src/lib/dsa.h
+++ b/src/lib/dsa.h
@@ -49,42 +49,25 @@
  * limitations under the License.
  */
 
-#ifndef RNP_PACKET_KEY_H
-#define RNP_PACKET_KEY_H
+#ifndef RNP_DSA_H_
+#define RNP_DSA_H_
 
-#include <stdio.h>
+#include <stdint.h>
 #include "packet.h"
 
-struct pgp_key_t *pgp_keydata_new(void);
+/* TODO key generation */
 
-void pgp_keydata_free(pgp_key_t *);
+/* DSA signature/verify */
 
-const pgp_pubkey_t *pgp_get_pubkey(const pgp_key_t *);
+typedef struct DSA_SIG_st DSA_SIG;
 
-unsigned pgp_is_key_secret(const pgp_key_t *);
+int pgp_dsa_size(const pgp_dsa_pubkey_t *);
 
-const struct pgp_seckey_t *pgp_get_seckey(const pgp_key_t *);
+DSA_SIG *pgp_dsa_sign(uint8_t *, unsigned, const pgp_dsa_seckey_t *, const pgp_dsa_pubkey_t *);
 
-pgp_seckey_t *pgp_get_writable_seckey(pgp_key_t *);
+unsigned pgp_dsa_verify(const uint8_t *,
+                        size_t,
+                        const pgp_dsa_sig_t *,
+                        const pgp_dsa_pubkey_t *);
 
-pgp_seckey_t *pgp_decrypt_seckey(const pgp_key_t *, FILE *);
-
-void pgp_set_seckey(pgp_contents_t *, const pgp_key_t *);
-
-const unsigned char *pgp_get_key_id(const pgp_key_t *);
-
-unsigned pgp_get_userid_count(const pgp_key_t *);
-
-const unsigned char *pgp_get_userid(const pgp_key_t *, unsigned);
-
-unsigned pgp_is_key_supported(const pgp_key_t *);
-
-unsigned char *pgp_add_userid(pgp_key_t *, const unsigned char *);
-
-struct pgp_subpacket_t *pgp_add_subpacket(pgp_key_t *, const pgp_subpacket_t *);
-
-unsigned pgp_add_selfsigned_userid(pgp_key_t *, const unsigned char *);
-
-void pgp_keydata_init(pgp_key_t *, const pgp_content_enum);
-
-#endif // RNP_PACKET_KEY_H
+#endif

--- a/src/lib/eddsa.c
+++ b/src/lib/eddsa.c
@@ -63,8 +63,8 @@ int pgp_genkey_eddsa(pgp_seckey_t* seckey, size_t curve_len)
    seckey->pubkey.key.ecc.oid = calloc(1, sizeof(ed25519_oid));
    memcpy(seckey->pubkey.key.ecc.oid, ed25519_oid, sizeof(ed25519_oid));
 
-   // Hack to insert the required 0x04 prefix on the public key
-   key_bits[31] = 0x04;
+   // Hack to insert the required 0x40 prefix on the public key
+   key_bits[31] = 0x40;
    seckey->pubkey.key.ecc.point = BN_bin2bn(key_bits + 31, 33, NULL);
 
    retval = 1;

--- a/src/lib/eddsa.c
+++ b/src/lib/eddsa.c
@@ -83,7 +83,7 @@ int pgp_eddsa_verify_hash(const BIGNUM* r,
    {
    botan_pubkey_t eddsa = NULL;
    botan_pk_op_verify_t verify_op = NULL;
-   int result = -1;
+   int result = 0;
    uint8_t bn_buf[64];
 
    // Check curve OID matches 25519
@@ -97,7 +97,7 @@ int pgp_eddsa_verify_hash(const BIGNUM* r,
    BN_bn2bin(pubkey->point, bn_buf);
 
    // See draft-koch-eddsa-for-openpgp-04 section 3 "Point Format"
-   if(bn_buf[0] != 0x04)
+   if(bn_buf[0] != 0x40)
       goto done;
 
    if (botan_pubkey_load_ed25519(&eddsa, bn_buf + 1))

--- a/src/lib/eddsa.c
+++ b/src/lib/eddsa.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
  * All rights reserved.
  *
- * This code is originally derived from software contributed to
- * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
- * carried further by Ribose Inc (https://www.ribose.com).
- *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -96,7 +92,9 @@ int pgp_eddsa_verify_hash(const BIGNUM* r,
 
    BN_bn2bin(pubkey->point, bn_buf);
 
-   // See draft-koch-eddsa-for-openpgp-04 section 3 "Point Format"
+   /*
+   * See draft-ietf-openpgp-rfc4880bis-01 section 13.3
+   */
    if(bn_buf[0] != 0x40)
       goto done;
 
@@ -117,7 +115,7 @@ int pgp_eddsa_verify_hash(const BIGNUM* r,
    BN_bn2bin(r, bn_buf);
    BN_bn2bin(s, bn_buf + 32);
 
-   result = (botan_pk_op_verify_finish(verify_op, bn_buf, 64) == 0) ? 1 : 0;
+   result = (botan_pk_op_verify_finish(verify_op, bn_buf, 64) == 0);
 
    done:
    botan_pk_op_verify_destroy(verify_op);

--- a/src/lib/eddsa.c
+++ b/src/lib/eddsa.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * This code is originally derived from software contributed to
+ * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
+ * carried further by Ribose Inc (https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "eddsa.h"
+
+pgp_key_t* pgp_eddsa_new_key(const char* hash_alg,
+                             const char* cipher_alg,
+                             size_t curve_len)
+   {
+   if(curve_len != 255)
+      return NULL;
+
+   return NULL;
+   }
+
+int pgp_eddsa_verify_hash(const BIGNUM* r,
+                          const BIGNUM* s,
+                          const uint8_t *         hash,
+                          size_t                  hash_len,
+                          const pgp_ecc_pubkey_t *pubkey)
+   {
+   return 0;
+   }
+
+int pgp_eddsa_sign_hash(BIGNUM* r,
+                        BIGNUM* s,
+                        const uint8_t *hash,
+                        size_t         hash_len,
+                        const pgp_ecc_seckey_t *seckey,
+                        const pgp_ecc_pubkey_t *pubkey)
+   {
+   return 0;
+   }

--- a/src/lib/eddsa.h
+++ b/src/lib/eddsa.h
@@ -37,9 +37,7 @@
 * curve_len must be 255 currently (for Ed25519)
 * If Ed448 was supported in the future curve_len=448 would also be allowed.
 */
-pgp_key_t* pgp_eddsa_new_key(const char* hash_alg,
-                             const char* cipher_alg,
-                             size_t curve_len);
+int pgp_genkey_eddsa(pgp_seckey_t* seckey, size_t numbits);
 
 typedef struct DSA_SIG_st DSA_SIG;
 

--- a/src/lib/eddsa.h
+++ b/src/lib/eddsa.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * This code is originally derived from software contributed to
+ * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
+ * carried further by Ribose Inc (https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RNP_ED25519_H_
+#define RNP_ED25519_H_
+
+#include "packet-parse.h"
+
+/*
+* curve_len must be 255 currently (for Ed25519)
+* If Ed448 was supported in the future curve_len=448 would also be allowed.
+*/
+pgp_key_t* pgp_eddsa_new_key(const char* hash_alg,
+                             const char* cipher_alg,
+                             size_t curve_len);
+
+typedef struct DSA_SIG_st DSA_SIG;
+
+int pgp_eddsa_verify_hash(const BIGNUM* r,
+                          const BIGNUM* s,
+                          const uint8_t *         hash,
+                          size_t                  hash_len,
+                          const pgp_ecc_pubkey_t *pubkey);
+
+
+int pgp_eddsa_sign_hash(BIGNUM* r,
+                        BIGNUM* s,
+                        const uint8_t *hash,
+                        size_t         hash_len,
+                        const pgp_ecc_seckey_t *,
+                        const pgp_ecc_pubkey_t *);
+
+
+#endif

--- a/src/lib/elgamal.c
+++ b/src/lib/elgamal.c
@@ -78,7 +78,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-
+#include "bn.h"
 #include "crypto.h"
 
 #define FAIL(str)                                                                      \

--- a/src/lib/elgamal.c
+++ b/src/lib/elgamal.c
@@ -78,8 +78,8 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include "elgamal.h"
 #include "bn.h"
-#include "crypto.h"
 
 #define FAIL(str)                                                                      \
     do {                                                                               \

--- a/src/lib/elgamal.h
+++ b/src/lib/elgamal.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * This code is originally derived from software contributed to
+ * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
+ * carried further by Ribose Inc (https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RNP_ELG_H_
+#define RNP_ELG_H_
+
+#include <stdint.h>
+#include "packet.h"
+
+/*
+ * Performs ElGamal encryption
+ * Result of an encryption is composed of two parts - g2k and encm
+ *
+ * @param g2k [out] buffer stores first part of encryption (g^k % p)
+ * @param encm [out] buffer stores second part of encryption (y^k * in % p)
+ * @param in plaintext to be encrypted
+ * @param length length of an input
+ * @param pubkey public key to be used for encryption
+ *
+ * @pre g2k size must be at least equal to byte size of prime `p'
+ * @pre encm size must be at least equal to byte size of prime `p'
+ *
+ * @return     on success - number of bytes written to g2k and encm
+ *            on failure -1
+ */
+int pgp_elgamal_public_encrypt_pkcs1(uint8_t *                   g2k,
+                                     uint8_t *                   encm,
+                                     const uint8_t *             in,
+                                     size_t                      length,
+                                     const pgp_elgamal_pubkey_t *pubkey);
+
+/*
+ * Performs ElGamal decryption
+ *
+ * @param out [out] decrypted plaintext
+ * @param g2k buffer stores first part of encryption (g^k % p)
+ * @param encm buffer stores second part of encryption (y^k * in % p)
+ * @param length length of g2k or in (must be equal to byte size of prime `p')
+ * @param seckey private part of a key used for decryption
+ * @param pubkey public domain parameters (p,g) used for decryption
+ *
+ * @pre g2k size must be at least equal to byte size of prime `p'
+ * @pre encm size must be at least equal to byte size of prime `p'
+ * @pre byte-size of `g2k' must be equal to `encm'
+ *
+ * @return     on success - number of bytes written to g2k and encm
+ *            on failure -1
+ */
+int pgp_elgamal_private_decrypt_pkcs1(uint8_t *                   out,
+                                      const uint8_t *             g2k,
+                                      const uint8_t *             in,
+                                      size_t                      length,
+                                      const pgp_elgamal_seckey_t *seckey,
+                                      const pgp_elgamal_pubkey_t *pubkey);
+
+#endif

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -1040,3 +1040,17 @@ rnp_strcasecmp(const char *s1, const char *s2)
     }
     return n;
 }
+
+/* return the hexdump as a string */
+char *
+rnp_strhexdump(char *dest, const uint8_t *src, size_t length, const char *sep)
+{
+    unsigned i;
+    int      n;
+
+    for (n = 0, i = 0; i < length; i += 2) {
+        n += snprintf(&dest[n], 3, "%02x", *src++);
+        n += snprintf(&dest[n], 10, "%02x%s", *src++, sep);
+    }
+    return dest;
+}

--- a/src/lib/packet-key.c
+++ b/src/lib/packet-key.c
@@ -471,7 +471,7 @@ pgp_add_subpacket(pgp_key_t *keydata, const pgp_subpacket_t *packet)
 \return 1 if OK; else 0
 */
 unsigned
-pgp_add_selfsigned_userid(pgp_key_t *key, uint8_t *userid)
+pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
 {
     struct pgp_create_sig_t *sig;
     pgp_subpacket_t          sigpacket;

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -1209,8 +1209,9 @@ pgp_pubkey_free(pgp_pubkey_t *p)
         break;
 
     case PGP_PKA_EDDSA:
-        free(&p->key.ecc.oid);
+        free(p->key.ecc.oid);
         free_BN(&p->key.ecc.point);
+        break;
 
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
@@ -1296,6 +1297,7 @@ parse_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
           return 0;
        if (c == 0 || c == 0xFF)
           return 0; // reserved values
+       key->key.ecc.oid_len = c;
        key->key.ecc.oid = malloc(c);
        if (!limread(key->key.ecc.oid, c, region, stream))
           return 0;

--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -215,6 +215,7 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_RESERVED_ECDSA, "Reserved for ECDSA"},
   {PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN, "Reserved (formerly Elgamal Encrypt or Sign"},
   {PGP_PKA_RESERVED_DH, "Reserved for Diffie-Hellman (X9.42)"},
+  {PGP_PKA_EDDSA,     "EdDSA"},
   {PGP_PKA_PRIVATE00, "Private/Experimental"},
   {PGP_PKA_PRIVATE01, "Private/Experimental"},
   {PGP_PKA_PRIVATE02, "Private/Experimental"},

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -348,14 +348,13 @@ typedef enum {
                                            * \see RFC4880 13.5) */
     PGP_PKA_ELGAMAL = 16,                 /* Elgamal (Encrypt-Only) */
     PGP_PKA_DSA = 17,                     /* DSA (Digital Signature Algorithm) */
-    PGP_PKA_RESERVED_ELLIPTIC_CURVE = 18, /* Reserved for Elliptic
-                                           * Curve */
-    PGP_PKA_RESERVED_ECDSA = 19,          /* Reserved for ECDSA */
+    PGP_PKA_RESERVED_ELLIPTIC_CURVE = 18, /* ECDH (RFC 6637) */
+    PGP_PKA_RESERVED_ECDSA = 19,          /* ECDSA (RFC 6637) */
     PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN = 20, /* Deprecated. */
     PGP_PKA_RESERVED_DH = 21,             /* Reserved for Diffie-Hellman
                                            * (X9.42, as defined for
                                            * IETF-S/MIME) */
-    PGP_PKA_EDDSA = 22,                   /* EdDSA */
+    PGP_PKA_EDDSA = 22,                   /* EdDSA from draft-ietf-openpgp-rfc4880bis */
     PGP_PKA_PRIVATE00 = 100,              /* Private/Experimental Algorithm */
     PGP_PKA_PRIVATE01 = 101,              /* Private/Experimental Algorithm */
     PGP_PKA_PRIVATE02 = 102,              /* Private/Experimental Algorithm */

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -355,6 +355,7 @@ typedef enum {
     PGP_PKA_RESERVED_DH = 21,             /* Reserved for Diffie-Hellman
                                            * (X9.42, as defined for
                                            * IETF-S/MIME) */
+    PGP_PKA_EDDSA = 22,                   /* EdDSA */
     PGP_PKA_PRIVATE00 = 100,              /* Private/Experimental Algorithm */
     PGP_PKA_PRIVATE01 = 101,              /* Private/Experimental Algorithm */
     PGP_PKA_PRIVATE02 = 102,              /* Private/Experimental Algorithm */
@@ -400,6 +401,17 @@ typedef struct {
                 * with x being the secret) */
 } pgp_elgamal_pubkey_t;
 
+/** Structure to hold an ECC public key params.
+ *
+ * \see RFC 6637
+ */
+typedef struct {
+    uint8_t oid_len;
+    uint8_t *oid;
+    BIGNUM *point; /* octet string encoded as MPI */
+} pgp_ecc_pubkey_t;
+
+
 /** Version.
  * OpenPGP has two different protocol versions: version 3 and version 4.
  *
@@ -426,6 +438,7 @@ typedef struct {
         pgp_dsa_pubkey_t     dsa;     /* A DSA public key */
         pgp_rsa_pubkey_t     rsa;     /* An RSA public key */
         pgp_elgamal_pubkey_t elgamal; /* An ElGamal public key */
+        pgp_ecc_pubkey_t     ecc;     /* An ECC public key */
     } key;                            /* Public Key Parameters */
 } pgp_pubkey_t;
 
@@ -447,6 +460,11 @@ typedef struct {
 typedef struct {
     BIGNUM *x;
 } pgp_elgamal_seckey_t;
+
+/** pgp_ecc_seckey_t */
+typedef struct {
+    BIGNUM *x;
+} pgp_ecc_seckey_t;
 
 /** s2k_usage_t
  */
@@ -520,6 +538,7 @@ typedef struct pgp_seckey_t {
         pgp_rsa_seckey_t     rsa;
         pgp_dsa_seckey_t     dsa;
         pgp_elgamal_seckey_t elgamal;
+        pgp_ecc_seckey_t ecc;
     } key;
     unsigned checksum;
     uint8_t *checkhash;
@@ -582,6 +601,12 @@ typedef struct pgp_elgamal_sig_t {
     BIGNUM *s;
 } pgp_elgamal_sig_t;
 
+/** pgp_ecc_signature_t */
+typedef struct pgp_ecc_sig_t {
+    BIGNUM *r;
+    BIGNUM *s;
+} pgp_ecc_sig_t;
+
 #define PGP_KEY_ID_SIZE 8
 #define PGP_FINGERPRINT_SIZE 20
 
@@ -603,6 +628,7 @@ typedef struct pgp_sig_info_t {
         pgp_rsa_sig_t     rsa;     /* An RSA Signature */
         pgp_dsa_sig_t     dsa;     /* A DSA Signature */
         pgp_elgamal_sig_t elgamal; /* deprecated */
+        pgp_ecc_sig_t     ecc;     /* An ECDSA or EdDSA signature */
         pgp_data_t        unknown; /* private or experimental */
     } sig;                         /* signature params */
     size_t   v4_hashlen;

--- a/src/lib/pem.c
+++ b/src/lib/pem.c
@@ -84,6 +84,7 @@
 
 #include "crypto.h"
 #include "rnpdefs.h"
+#include "bn.h"
 
 int
 read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1250,7 +1250,7 @@ rnp_generate_key(rnp_t *rnp, char *id, int numbits)
     pgp_key_t *    key;
     pgp_io_t *     io;
     uint8_t *      uid;
-    char           passphrase[128] = { 0 };
+    char           passphrase[MAX_PASSPHRASE_LENGTH] = { 0 };
     char           newid[1024] = { 0 };
     char           filename[MAXPATHLEN] = { 0 };
     char           dir[MAXPATHLEN] = { 0 };

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1254,7 +1254,7 @@ rnp_generate_key(rnp_t *rnp, char *id, int numbits)
     char           newid[1024] = { 0 };
     char           filename[MAXPATHLEN] = { 0 };
     char           dir[MAXPATHLEN] = { 0 };
-    char           keyid[2*PGP_KEY_ID_SIZE] = { 0 };
+    char           keyid[2*PGP_KEY_ID_SIZE + 1] = { 0 };
     char *         cp = NULL;
     char *         ringfile;
     char *         numtries;

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1275,8 +1275,9 @@ rnp_generate_key(rnp_t *rnp, char *id, int numbits)
           newid, sizeof(newid), "RSA %d-bit key <%s@localhost>", numbits, getenv("LOGNAME"));
     }
     uid = (uint8_t *) newid;
-    key = pgp_rsa_new_selfsign_key(
-      numbits, 65537UL, uid, rnp_getvar(rnp, "hash"), rnp_getvar(rnp, "cipher"));
+    key = pgp_generate_keypair(PGP_PKA_RSA, numbits, uid,
+                               rnp_getvar(rnp, "hash"), rnp_getvar(rnp, "cipher"));
+
     if (key == NULL) {
         (void) fprintf(io->errs, "cannot generate key\n");
         return 0;

--- a/src/lib/rnpsdk.h
+++ b/src/lib/rnpsdk.h
@@ -71,4 +71,6 @@ void rnp_log(const char *, ...) __printflike(1, 2);
 int   rnp_strcasecmp(const char *, const char *);
 char *rnp_strdup(const char *);
 
+char * rnp_strhexdump(char *dest, const uint8_t *src, size_t length, const char *sep);
+
 #endif

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -84,6 +84,8 @@
 #include "rnpdefs.h"
 #include "s2k.h"
 #include "packet-key.h"
+#include "bn.h"
+
 #include "../common/utils.h"
 /**
    \ingroup Core_Crypto

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -300,6 +300,23 @@ int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits)
    botan_rng_t     rng = NULL;
    int ret = 0;
 
+   seckey->pubkey.key.rsa.n = BN_new();
+   seckey->pubkey.key.rsa.e = BN_new();
+   seckey->key.rsa.p = BN_new();
+   seckey->key.rsa.q = BN_new();
+   seckey->key.rsa.d = BN_new();
+   seckey->key.rsa.u = BN_new();
+
+   if(!seckey->pubkey.key.rsa.n ||
+      !seckey->pubkey.key.rsa.e ||
+      !seckey->key.rsa.p ||
+      !seckey->key.rsa.q ||
+      !seckey->key.rsa.d ||
+      !seckey->key.rsa.u)
+      {
+      goto end;
+      }
+
    if (botan_rng_init(&rng, NULL) != 0)
       goto end;
 
@@ -310,13 +327,6 @@ int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits)
       goto end;
 
    /* Calls below never fail as calls above were OK */
-   seckey->pubkey.key.rsa.n = BN_new();
-   seckey->pubkey.key.rsa.e = BN_new();
-   seckey->key.rsa.p = BN_new();
-   seckey->key.rsa.q = BN_new();
-   seckey->key.rsa.d = BN_new();
-   seckey->key.rsa.u = BN_new();
-
    (void) botan_privkey_rsa_get_n(seckey->pubkey.key.rsa.n->mp, rsa_key);
    (void) botan_privkey_rsa_get_e(seckey->pubkey.key.rsa.e->mp, rsa_key);
    (void) botan_privkey_rsa_get_d(seckey->key.rsa.d->mp, rsa_key);

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -298,7 +298,7 @@ int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits)
    {
    botan_privkey_t rsa_key = NULL;
    botan_rng_t     rng = NULL;
-   int ret = -1;
+   int ret = 0;
 
    if (botan_rng_init(&rng, NULL) != 0)
       goto end;

--- a/src/lib/rsa.h
+++ b/src/lib/rsa.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * This code is originally derived from software contributed to
+ * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
+ * carried further by Ribose Inc (https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RNP_RSA_H_
+#define RNP_RSA_H_
+
+#include <stdint.h>
+#include "packet.h"
+
+/*
+ * RSA encrypt/decrypt
+ */
+
+int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits);
+
+int pgp_rsa_encrypt_pkcs1(uint8_t *               out,
+                          size_t                  out_len,
+                          const uint8_t *         key,
+                          size_t                  key_len,
+                          const pgp_rsa_pubkey_t *pubkey);
+
+int pgp_rsa_decrypt_pkcs1(uint8_t *               out,
+                          size_t                  out_len,
+                          const uint8_t *         key,
+                          size_t                  key_len,
+                          const pgp_rsa_seckey_t *privkey,
+                          const pgp_rsa_pubkey_t *pubkey);
+
+/*
+ * RSA signature generation and verification
+ */
+
+/*
+ * Returns 1 for valid 0 for invalid/error
+ */
+int pgp_rsa_pkcs1_verify_hash(const uint8_t *         sig_buf,
+                              size_t                  sig_buf_size,
+                              pgp_hash_alg_t          hash_alg,
+                              const uint8_t *         hash,
+                              size_t                  hash_len,
+                              const pgp_rsa_pubkey_t *pubkey);
+
+/*
+ * Returns # bytes written to sig_buf on success, 0 on error
+ */
+int pgp_rsa_pkcs1_sign_hash(uint8_t *      sig_buf,
+                            size_t         sig_buf_size,
+                            pgp_hash_alg_t hash_alg,
+                            const uint8_t *hash,
+                            size_t         hash_len,
+                            const pgp_rsa_seckey_t *,
+                            const pgp_rsa_pubkey_t *);
+
+#endif

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -239,7 +239,7 @@ eddsa_verify(const uint8_t *         hash,
              const pgp_ecc_sig_t *   sig,
              const pgp_ecc_pubkey_t *pubecc)
 {
-return 0;
+    return pgp_eddsa_verify_hash(sig->r, sig->s, hash, hash_length, pubecc);
 }
 
 static unsigned

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -78,7 +78,9 @@ __RCSID("$NetBSD: signature.c,v 1.34 2012/03/05 02:20:18 christos Exp $");
 
 #include "bn.h"
 #include "signature.h"
-#include "crypto.h"
+#include "rsa.h"
+#include "dsa.h"
+#include "eddsa.h"
 #include "create.h"
 #include "rnpsdk.h"
 #include "readerwriter.h"

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -51,9 +51,7 @@
 #ifndef TYPES_H_
 #define TYPES_H_
 
-#ifdef HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
+#include <stdint.h>
 
 typedef struct pgp_io_t {
     void *outs; /* output file stream */

--- a/src/rnpv/libverify.c
+++ b/src/rnpv/libverify.c
@@ -52,6 +52,8 @@
 #include "../common/constants.h"
 
 #include "crypto.h"
+#include "rsa.h"
+#include "dsa.h"
 
 #include "array.h"
 #include "b64.h"


### PR DESCRIPTION
#109 

Currently keygen works by requesting a 255 bit key. It would be nice to clean this up by adding an algorithm identifier to `rnp_generate_key`. The underlying API `pgp_generate_keypair` does take an alg id now.

EdDSA keys are actually stored the same as ECC keys, so this helps towards #27 also.

Splits apart `crypto.h` a bit - adding `rsa.h`, `dsa.h`, `elgamal.h`, `eddsa.h`

Also extracts the function `rnp_strhexdump` out of `packet-print.c` because it's needed in `rnp.c` also now. Previously this function printed the key info then extracted the keyid at the expected offset in the string - this broke as soon as something other than RSA was used.

Tested by generating a key with `rnpkeys`, singing a file, exporting the public key to `gpg`, verifying the signature.
