### PR TITLE
Add support for SM4

### DIFF
--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -239,10 +239,11 @@ static pgp_map_t symm_alg_map[] = {
   {PGP_SA_AES_128, "AES (128-bit key)"},
   {PGP_SA_AES_192, "AES (192-bit key)"},
   {PGP_SA_AES_256, "AES (256-bit key)"},
-  {PGP_SA_TWOFISH, "Twofish(256-bit key)"},
+  {PGP_SA_TWOFISH, "Twofish (256-bit key)"},
   {PGP_SA_CAMELLIA_128, "Camellia (128-bit key)"},
   {PGP_SA_CAMELLIA_192, "Camellia (192-bit key)"},
   {PGP_SA_CAMELLIA_256, "Camellia (256-bit key)"},
+  {PGP_SA_SM4, "SM4"},
   {0x00, NULL}, /* this is the end-of-array marker */
 };
 

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -499,9 +499,11 @@ typedef enum {
     PGP_SA_AES_192 = 8,        /* AES with 192-bit key */
     PGP_SA_AES_256 = 9,        /* AES with 256-bit key */
     PGP_SA_TWOFISH = 10,       /* Twofish with 256-bit key (TWOFISH) */
-    PGP_SA_CAMELLIA_128 = 100, /* Camellia with 128-bit key (CAMELLIA) */
-    PGP_SA_CAMELLIA_192 = 101, /* Camellia with 192-bit key */
-    PGP_SA_CAMELLIA_256 = 102  /* Camellia with 256-bit key */
+    PGP_SA_CAMELLIA_128 = 11,  /* Camellia with 128-bit key (CAMELLIA) */
+    PGP_SA_CAMELLIA_192 = 12,  /* Camellia with 192-bit key */
+    PGP_SA_CAMELLIA_256 = 13,  /* Camellia with 256-bit key */
+
+    PGP_SA_SM4          = 105  /* RNP extension - SM4 */
 } pgp_symm_alg_t;
 
 #define PGP_SA_DEFAULT_CIPHER PGP_SA_CAST5

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -170,6 +170,7 @@ static str2cipher_t str2cipher[] = {{"cast5", PGP_SA_CAST5},
                                     {"idea", PGP_SA_IDEA},
                                     {"blowfish", PGP_SA_BLOWFISH},
                                     {"twofish", PGP_SA_TWOFISH},
+                                    {"sm4", PGP_SA_SM4},
                                     {"aes128", PGP_SA_AES_128},
                                     {"aes192", PGP_SA_AES_192},
                                     {"aes256", PGP_SA_AES_256},
@@ -224,6 +225,11 @@ pgp_sa_to_botan_string(pgp_symm_alg_t alg)
         return "AES-192";
     case PGP_SA_AES_256:
         return "AES-256";
+#endif
+
+#if defined(BOTAN_HAS_SM4)
+    case PGP_SA_SM4:
+        return "SM4";
 #endif
 
 #if defined(BOTAN_HAS_TWOFISH)
@@ -286,6 +292,7 @@ pgp_block_size(pgp_symm_alg_t alg)
     case PGP_SA_CAMELLIA_128:
     case PGP_SA_CAMELLIA_192:
     case PGP_SA_CAMELLIA_256:
+    case PGP_SA_SM4:
         return 16;
 
     default:
@@ -303,6 +310,7 @@ pgp_key_size(pgp_symm_alg_t alg)
     case PGP_SA_BLOWFISH:
     case PGP_SA_AES_128:
     case PGP_SA_CAMELLIA_128:
+    case PGP_SA_SM4:
         return 16;
 
     case PGP_SA_TRIPLEDES:


### PR DESCRIPTION
SM4 support is not quite landed in Botan master yet but will shortly. This allows it to be used for bulk encryption when available.

Also renumbers Camellia ciphers to use the values from RFC 5581. I looked and Camellia was assigned to the experimental/private range in the original NetPGP import I guess because the support in NetPGP predated the RFC.