### PR TITLE
Changed pgp_add_time to use enum instead of char* parameter.

### DIFF
--- a/src/lib/packet-key.c
+++ b/src/lib/packet-key.c
@@ -490,8 +490,9 @@ pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
 
     /* create sig for this pkt */
     sig = pgp_create_sig_new();
-    pgp_sig_start_key_sig(sig, &key->key.seckey.pubkey, userid, PGP_CERT_POSITIVE, key->key.seckey.hash_alg);
-    pgp_add_time(sig, (int64_t) time(NULL), "birth");
+    pgp_sig_start_key_sig(
+      sig, &key->key.seckey.pubkey, userid, PGP_CERT_POSITIVE, key->key.seckey.hash_alg);
+    pgp_add_time(sig, (int64_t) time(NULL), PGP_PTAG_SS_CREATION_TIME);
     pgp_add_issuer_keyid(sig, key->sigid);
     pgp_add_primary_userid(sig, 1);
     pgp_end_hashed_subpkts(sig);

--- a/src/lib/signature.h
+++ b/src/lib/signature.h
@@ -88,11 +88,8 @@ unsigned pgp_check_direct_sig(const pgp_pubkey_t *,
                               const pgp_pubkey_t *,
                               const uint8_t *);
 unsigned pgp_check_hash_sig(pgp_hash_t *, const pgp_sig_t *, const pgp_pubkey_t *);
-void     pgp_sig_start_key_sig(pgp_create_sig_t *,
-                           const pgp_pubkey_t *,
-                           const uint8_t *,
-                           pgp_sig_type_t,
-                           pgp_hash_alg_t);
+void     pgp_sig_start_key_sig(
+  pgp_create_sig_t *, const pgp_pubkey_t *, const uint8_t *, pgp_sig_type_t, pgp_hash_alg_t);
 void pgp_sig_start_subkey_sig(pgp_create_sig_t *,
                               const pgp_pubkey_t *,
                               const pgp_pubkey_t *,
@@ -110,7 +107,7 @@ unsigned    pgp_write_sig(pgp_output_t *,
                        pgp_create_sig_t *,
                        const pgp_pubkey_t *,
                        const pgp_seckey_t *);
-unsigned pgp_add_time(pgp_create_sig_t *, int64_t, const char *);
+unsigned pgp_add_time(pgp_create_sig_t *, int64_t, pgp_content_enum);
 unsigned pgp_add_issuer_keyid(pgp_create_sig_t *, const uint8_t *);
 void     pgp_add_primary_userid(pgp_create_sig_t *, unsigned);
 


### PR DESCRIPTION
Fixes #219 , mostly for better code readability.