### PR TITLE
Introduces --expert flag for rnpkeys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - CMOCKA_INSTALL="$HOME/builds/cmocka-install"
     - JSON_C_INSTALL="$HOME/builds/json-c-install"
     - LOGNAME="Travis"
+    - CLANG_FORMAT_DIFF="clang-format-diff-4.0"
 
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created via
     # the "travis encrypt" command using the project repo's public key
@@ -29,6 +30,13 @@ matrix:
       compiler: clang
     - env: BUILD_MODE=coverage
       compiler: gcc
+    - env: BUILD_MODE=style-check
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-format-4.0
   allow_failures:
     - env: BUILD_MODE=sanitize-leaks
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Upcoming supported platforms:
 
 ## Generating an RSA Private Key
 
-Only RSA key supported right now.
+By default ``rnpkeys  --generate-key`` will generate 2048-bit RSA key.
 
 ``` sh
 export keydir=/tmp
@@ -50,6 +50,36 @@ rnpkeys: generated keys in directory ${keydir}/6ed2d908150b82e7
 ```
 
 In case you're curious, `6ed2d...` is the key fingerprint.
+
+In order to use fully featured key pair generation ``--expert`` flag should be used. With this flag added to  ``rnpkeys --generate-key`` user has a possibility to generate keypair for any supported algorithm and/or key size.
+
+Example:
+
+``` sh
+> export keydir=/tmp
+> rnpkeys --generate-key --expert --homedir=${keydir}
+
+Please select what kind of key you want:
+    (1)  RSA (Encrypt or Sign)
+    (19) ECDSA
+    (22) EDDSA
+> 19
+
+Please select which elliptic curve you want:
+    (1) NIST P-256
+    (2) NIST P-384
+    (3) NIST P-521
+> 2
+
+Generating a new key...
+signature  384/ECDSA d45592277b75ada1 2017-06-21
+Key fingerprint: 4244 2969 07ca 42f7 b6d8 1636 d455 9227 7b75 ada1
+uid              ECDSA 384-bit key <flowher@localhost>
+rnp: generated keys in directory /tmp/.rnp
+Enter passphrase for d45592277b75ada1:
+Repeat passphrase for d45592277b75ada1:
+>
+```
 
 
 ## Listing Keys

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu
 
+[ "$BUILD_MODE" = "style-check" ] && exit 0
+
 CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
 
 # botan

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux
 
+[ "$BUILD_MODE" = "style-check" ] && exec ci/style-check.sh
+
 CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
 
 LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSON_C_INSTALL}/lib"

--- a/ci/style-check.sh
+++ b/ci/style-check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu
+
+echo Evaluating changes:
+git diff -U0 "$TRAVIS_COMMIT_RANGE"
+echo
+
+diffs=$(git diff -U0 --no-color "$TRAVIS_COMMIT_RANGE" | "$CLANG_FORMAT_DIFF" -p1 -iregex '.*\.[ch]$')
+if [ "$diffs" != "" ]; then
+  echo ==== Style changes required ====
+  echo "$diffs"
+  exit 1
+fi
+

--- a/include/rnp.h
+++ b/include/rnp.h
@@ -32,9 +32,7 @@
 #define RNP_H_
 
 #include <stddef.h>
-#include <sys/types.h>
-#include <packet.h>
-#include <symmetric.h>
+#include "packet.h"
 
 #ifndef __BEGIN_DECLS
 #if defined(__cplusplus)
@@ -75,6 +73,9 @@ typedef struct rnp_t {
     rnp_ctx_t ctx;     /* current operation context */
 
     enum keyring_format_t keyring_format; /* keyring format */
+    union {
+        generate_key_ctx_t generate_key_ctx;
+    } action;
 } rnp_t;
 
 /* begin and end */
@@ -97,6 +98,7 @@ int   rnp_setvar(rnp_t *, const char *, const char *);
 char *rnp_getvar(rnp_t *, const char *);
 int   rnp_incvar(rnp_t *, const char *, const int);
 int   rnp_unsetvar(rnp_t *, const char *);
+int findvar(rnp_t *rnp, const char *name);
 
 /* set keyring format information */
 int rnp_set_keyring_format(rnp_t *, char *);
@@ -112,7 +114,7 @@ int   rnp_find_key(rnp_t *, char *);
 char *rnp_get_key(rnp_t *, const char *, const char *);
 char *rnp_export_key(rnp_t *, char *);
 int   rnp_import_key(rnp_t *, char *);
-int   rnp_generate_key(rnp_t *, char *, int);
+int   rnp_generate_key(rnp_t *, const char *);
 
 /* file management */
 int rnp_encrypt_file(rnp_t *, const char *, const char *, char *);

--- a/include/rnp.h
+++ b/include/rnp.h
@@ -74,7 +74,7 @@ typedef struct rnp_t {
 
     enum keyring_format_t keyring_format; /* keyring format */
     union {
-        generate_key_ctx_t generate_key_ctx;
+        rnp_keygen_desc_t generate_key_ctx;
     } action;
 } rnp_t;
 

--- a/include/rnp.h
+++ b/include/rnp.h
@@ -32,6 +32,9 @@
 #define RNP_H_
 
 #include <stddef.h>
+#include <sys/types.h>
+#include <packet.h>
+#include <symmetric.h>
 
 #ifndef __BEGIN_DECLS
 #if defined(__cplusplus)
@@ -47,16 +50,29 @@ __BEGIN_DECLS
 
 enum keyring_format_t { GPG_KEYRING, SSH_KEYRING };
 
+/* rnp operation context : contains additional data about the currently ongoing operation */
+typedef struct rnp_ctx_t {
+    char *         filename;  /* name of the input file to store in literal data packet */
+    int64_t        filemtime; /* file modification time to store in literal data packet */
+    int            halg;      /* hash algorithm */
+    pgp_symm_alg_t ealg;      /* encryption algorithm */
+    int            zalg;      /* compression algorithm used */
+    int            zlevel;    /* compression level */
+    int            overwrite; /* allow to overwrite output file if exists */
+    int            armour;    /* use ASCII armour on output */
+} rnp_ctx_t;
+
 /* structure used to hold (key,value) pair information */
 typedef struct rnp_t {
-    unsigned c;       /* # of elements used */
-    unsigned size;    /* size of array */
-    char **  name;    /* key names */
-    char **  value;   /* value information */
-    void *   pubring; /* public key ring */
-    void *   secring; /* s3kr1t key ring */
-    void *   io;      /* the io struct for results/errs */
-    void *   passfp;  /* file pointer for password input */
+    unsigned  c;       /* # of elements used */
+    unsigned  size;    /* size of array */
+    char **   name;    /* key names */
+    char **   value;   /* value information */
+    void *    pubring; /* public key ring */
+    void *    secring; /* s3kr1t key ring */
+    void *    io;      /* the io struct for results/errs */
+    void *    passfp;  /* file pointer for password input */
+    rnp_ctx_t ctx;     /* current operation context */
 
     enum keyring_format_t keyring_format; /* keyring format */
 } rnp_t;
@@ -64,6 +80,11 @@ typedef struct rnp_t {
 /* begin and end */
 int rnp_init(rnp_t *);
 int rnp_end(rnp_t *);
+
+/* init, reset and free rnp operation context */
+int  rnp_ctx_init(rnp_ctx_t *);
+void rnp_ctx_reset(rnp_ctx_t *);
+void rnp_ctx_free(rnp_ctx_t *);
 
 /* debugging, reflection and information */
 int         rnp_set_debug(const char *);
@@ -94,16 +115,15 @@ int   rnp_import_key(rnp_t *, char *);
 int   rnp_generate_key(rnp_t *, char *, int);
 
 /* file management */
-int rnp_encrypt_file(rnp_t *, const char *, const char *, char *, int);
+int rnp_encrypt_file(rnp_t *, const char *, const char *, char *);
 int rnp_decrypt_file(rnp_t *, const char *, char *, int);
-int rnp_sign_file(rnp_t *, const char *, const char *, char *, int, int, int);
+int rnp_sign_file(rnp_t *, const char *, const char *, char *, int, int);
 int rnp_verify_file(rnp_t *, const char *, const char *, int);
 
 /* memory signing and encryption */
-int rnp_sign_memory(
-  rnp_t *, const char *, char *, size_t, char *, size_t, const unsigned, const unsigned);
+int rnp_sign_memory(rnp_t *, const char *, char *, size_t, char *, size_t, const unsigned);
 int rnp_verify_memory(rnp_t *, const void *, const size_t, void *, size_t, const int);
-int rnp_encrypt_memory(rnp_t *, const char *, void *, const size_t, char *, size_t, int);
+int rnp_encrypt_memory(rnp_t *, const char *, void *, const size_t, char *, size_t);
 int rnp_decrypt_memory(rnp_t *, const void *, const size_t, char *, size_t, const int);
 
 /* match and hkp-related functions */

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -143,11 +143,10 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_pubkey_t *pub_rsa;
     const pgp_rsa_seckey_t *sec_rsa;
 
-    rnp_keygen_desc_t key_desc = {0};
-    key_desc.key_alg = PGP_PKA_RSA;
-    key_desc.hash_alg = PGP_HASH_SHA256;
-    key_desc.sym_alg = PGP_SA_AES_128;
-    key_desc.rsa.modulus_bit_len = 1024;
+    const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_RSA,
+                                        .hash_alg = PGP_HASH_SHA256,
+                                        .sym_alg = PGP_SA_AES_128,
+                                        .rsa = {.modulus_bit_len = 1024}};
     pgp_key = pgp_generate_keypair(&key_desc, NULL);
 
     assert_true(pgp_key != NULL);
@@ -203,11 +202,8 @@ pkcs1_rsa_test_success(void **state)
 void
 rnp_test_eddsa(void **state)
 {
-    rnp_keygen_desc_t key_desc = {0};
-    key_desc.key_alg = PGP_PKA_EDDSA;
-    key_desc.hash_alg = PGP_HASH_SHA256;
-    key_desc.sym_alg = PGP_SA_AES_128;
-
+    const rnp_keygen_desc_t key_desc = {
+      .key_alg = PGP_PKA_EDDSA, .hash_alg = PGP_HASH_SHA256, .sym_alg = PGP_SA_AES_128};
     pgp_key_t *pgp_key = pgp_generate_keypair(&key_desc, NULL);
     assert_non_null(pgp_key);
 
@@ -327,10 +323,10 @@ ECDSA_signverify_success(void **state)
     uint8_t       message[32];
     pgp_ecc_sig_t sig = {NULL, NULL};
 
-    rnp_keygen_desc_t key_desc = {0};
-    key_desc.key_alg = PGP_PKA_ECDSA;
-    key_desc.hash_alg = PGP_HASH_SHA256;
-    key_desc.sym_alg = PGP_SA_AES_128;
+    const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_ECDSA,
+                                        .hash_alg = PGP_HASH_SHA256,
+                                        .sym_alg = PGP_SA_AES_128,
+                                        .ecc = {.curve = PGP_CURVE_NIST_P_256}};
 
     pgp_key_t *pgp_key1 = pgp_generate_keypair(&key_desc, NULL);
     pgp_key_t *pgp_key2 = pgp_generate_keypair(&key_desc, NULL);

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -143,7 +143,7 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_pubkey_t *pub_rsa;
     const pgp_rsa_seckey_t *sec_rsa;
 
-    generate_key_ctx_t key_desc = {0};
+    rnp_keygen_desc_t key_desc = {0};
     key_desc.key_alg = PGP_PKA_RSA;
     key_desc.hash_alg = PGP_HASH_SHA256;
     key_desc.sym_alg = PGP_SA_AES_128;
@@ -203,7 +203,7 @@ pkcs1_rsa_test_success(void **state)
 void
 rnp_test_eddsa(void **state)
 {
-    generate_key_ctx_t key_desc = {0};
+    rnp_keygen_desc_t key_desc = {0};
     key_desc.key_alg = PGP_PKA_EDDSA;
     key_desc.hash_alg = PGP_HASH_SHA256;
     key_desc.sym_alg = PGP_SA_AES_128;
@@ -327,7 +327,7 @@ ECDSA_signverify_success(void **state)
     uint8_t       message[32];
     pgp_ecc_sig_t sig = {NULL, NULL};
 
-    generate_key_ctx_t key_desc = {0};
+    rnp_keygen_desc_t key_desc = {0};
     key_desc.key_alg = PGP_PKA_ECDSA;
     key_desc.hash_alg = PGP_HASH_SHA256;
     key_desc.sym_alg = PGP_SA_AES_128;

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -143,7 +143,13 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_pubkey_t *pub_rsa;
     const pgp_rsa_seckey_t *sec_rsa;
 
-    pgp_key = pgp_generate_keypair(PGP_PKA_RSA, 1024, NULL, "SHA-256", "AES-128");
+    generate_key_ctx_t key_desc = {0};
+    key_desc.key_alg = PGP_PKA_RSA;
+    key_desc.hash_alg = PGP_HASH_SHA256;
+    key_desc.sym_alg = PGP_SA_AES_128;
+    key_desc.rsa.modulus_bit_len = 1024;
+    pgp_key = pgp_generate_keypair(&key_desc, NULL);
+
     assert_true(pgp_key != NULL);
     sec_key = pgp_get_seckey(pgp_key);
     pub_key = pgp_get_pubkey(pgp_key);
@@ -197,7 +203,12 @@ pkcs1_rsa_test_success(void **state)
 void
 rnp_test_eddsa(void **state)
 {
-    pgp_key_t *pgp_key = pgp_generate_keypair(PGP_PKA_EDDSA, 255, NULL, "SHA-256", "AES-128");
+    generate_key_ctx_t key_desc = {0};
+    key_desc.key_alg = PGP_PKA_EDDSA;
+    key_desc.hash_alg = PGP_HASH_SHA256;
+    key_desc.sym_alg = PGP_SA_AES_128;
+
+    pgp_key_t *pgp_key = pgp_generate_keypair(&key_desc, NULL);
     assert_non_null(pgp_key);
 
     const uint8_t hash[32] = {0};
@@ -316,8 +327,13 @@ ECDSA_signverify_success(void **state)
     uint8_t       message[32];
     pgp_ecc_sig_t sig = {NULL, NULL};
 
-    pgp_key_t *pgp_key1 = pgp_generate_keypair(PGP_PKA_ECDSA, 256, NULL, "SHA256", "AES-128");
-    pgp_key_t *pgp_key2 = pgp_generate_keypair(PGP_PKA_ECDSA, 256, NULL, "SHA256", "AES-128");
+    generate_key_ctx_t key_desc = {0};
+    key_desc.key_alg = PGP_PKA_ECDSA;
+    key_desc.hash_alg = PGP_HASH_SHA256;
+    key_desc.sym_alg = PGP_SA_AES_128;
+
+    pgp_key_t *pgp_key1 = pgp_generate_keypair(&key_desc, NULL);
+    pgp_key_t *pgp_key2 = pgp_generate_keypair(&key_desc, NULL);
     assert_int_not_equal(pgp_key1, NULL);
     assert_int_not_equal(pgp_key2, NULL);
 

--- a/src/cmocka/rnp_tests_exportkey.c
+++ b/src/cmocka/rnp_tests_exportkey.c
@@ -36,11 +36,10 @@ rnpkeys_exportkey_verifyUserId(void **state)
      * key
      * Verify the key was generated with the correct UserId.
      */
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
-    char *    exportedkey = NULL;
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
+    char *exportedkey = NULL;
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -58,7 +57,10 @@ rnpkeys_exportkey_verifyUserId(void **state)
     int retVal = rnp_init(&rnp);
     assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-    retVal = rnp_generate_key(&rnp, NULL, numbits);
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    retVal = rnp_generate_key(&rnp, NULL);
     assert_int_equal(retVal, 1); // Ensure the key was generated.
 
     /*Load the newly generated rnp key*/

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -40,7 +40,9 @@ rnpkeys_generatekey_testSignature(void **state)
     rnp_t     rnp;
     const int numbits = 1024;
     char      passfd[4] = {0};
+    char *    fdptr;
     int       pipefd[2];
+    int       retVal;
 
     char memToSign[] = "A simple test message";
     char signatureBuf[4096] = {0};
@@ -51,18 +53,10 @@ rnpkeys_generatekey_testSignature(void **state)
     assert_int_equal(setupPassphrasefd(pipefd), 1);
 
     for (int i = 0; hashAlg[i] != NULL; i++) {
-        /*Initialize the basic RNP structure. */
-        memset(&rnp, '\0', sizeof(rnp));
-        /*Set the default parameters*/
-        rnp_setvar(&rnp, "sshkeydir", "/etc/ssh");
-        rnp_setvar(&rnp, "res", "<stdout>");
-
-        rnp_setvar(&rnp, "format", "human");
-        rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 16));
-        rnp_setvar(&rnp, "need seckey", "true");
-
-        int retVal = rnp_init(&rnp);
-        assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
+        /* Setup passphrase input and rnp structure */
+        assert_int_equal(setupPassphrasefd(pipefd), 1);
+        fdptr = uint_to_string(passfd, 4, pipefd[0], 16);
+        setup_rnp_common(&rnp, fdptr);
 
         memset(userId, 0, sizeof(userId));
         strcpy(userId, "sigtest_");
@@ -78,6 +72,9 @@ rnpkeys_generatekey_testSignature(void **state)
         retVal = rnp_find_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key can be found with the userId
 
+        close(pipefd[0]);
+        rnp_end(&rnp);
+
         for (unsigned int cleartext = 0; cleartext <= 1; ++cleartext) {
             for (unsigned int armored = 0; armored <= 1; ++armored) {
                 const int skip_null = (cleartext == 1) ? 1 : 0;
@@ -87,43 +84,53 @@ rnpkeys_generatekey_testSignature(void **state)
                     continue;
                 }
 
-                close(pipefd[0]);
-                /* Setup the pass phrase fd to avoid user-input*/
+                /* Setup passphrase input and rnp structure */
                 assert_int_equal(setupPassphrasefd(pipefd), 1);
+                fdptr = uint_to_string(passfd, 4, pipefd[0], 16);
+                setup_rnp_common(&rnp, fdptr);
+                retVal = rnp_load_keys(&rnp);
+                assert_int_equal(retVal, 1); // Ensure the keyring is loaded.
 
-                rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 16));
+                rnp.ctx.armour = armored;
                 assert_int_equal(rnp_setvar(&rnp, "hash", hashAlg[i]), 1);
 
+                /* Signing the memory */
                 retVal = rnp_sign_memory(&rnp,
                                          userId,
                                          memToSign,
                                          strlen(memToSign) - skip_null,
                                          signatureBuf,
                                          sizeof(signatureBuf),
-                                         armored,
                                          cleartext);
 
                 assert_int_not_equal(retVal, 0); // Ensure signature operation succeeded
-
                 const int sigLen = retVal;
+                close(pipefd[0]);
+                rnp_end(&rnp);
 
+                /* Setup rnp again and load keyring. Passphrase is not needed */
+                setup_rnp_common(&rnp, NULL);
+                retVal = rnp_load_keys(&rnp);
+                assert_int_equal(retVal, 1); // Ensure the keyring is loaded.
+
+                /* Verify the memory */
                 retVal = rnp_verify_memory(
                   &rnp, signatureBuf, sigLen, recoveredSig, sizeof(recoveredSig), armored);
-                // Ensure signature verification passed
+                /* Ensure signature verification passed */
                 assert_int_equal(retVal, strlen(memToSign) - (skip_null ? 1 : 0));
                 assert_string_equal(recoveredSig, memToSign);
 
-                // TODO be smarter about this
-                signatureBuf[50] ^= 0x0C; // corrupt the signature
+                /* Corrupt te signature */
+                /* TODO be smarter about this */
+                signatureBuf[50] ^= 0x0C;
 
                 retVal = rnp_verify_memory(
                   &rnp, signatureBuf, sigLen, recoveredSig, sizeof(recoveredSig), armored);
-                assert_int_equal(retVal,
-                                 0); // Ensure signature verification fails for invalid sig
+                /* Ensure that signature verification fails */
+                assert_int_equal(retVal, 0);
+                rnp_end(&rnp);
             }
         }
-
-        rnp_end(&rnp); // Free memory and other allocated resources.
     }
 }
 
@@ -145,7 +152,9 @@ rnpkeys_generatekey_testEncryption(void **state)
     rnp_t     rnp;
     const int numbits = 1024;
     char      passfd[4] = {0};
+    char *    fdptr;
     int       pipefd[2];
+    int       retVal;
 
     char memToEncrypt[] = "A simple test message";
     char ciphertextBuf[4096] = {0};
@@ -154,20 +163,8 @@ rnpkeys_generatekey_testEncryption(void **state)
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
-
-    /*Initialize the basic RNP structure. */
-    memset(&rnp, '\0', sizeof(rnp));
-
-    /*Set the default parameters*/
-    rnp_setvar(&rnp, "sshkeydir", "/etc/ssh");
-    rnp_setvar(&rnp, "res", "<stdout>");
-
-    rnp_setvar(&rnp, "format", "human");
-    rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 16));
-    rnp_setvar(&rnp, "need seckey", "true");
-
-    int retVal = rnp_init(&rnp);
-    assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
+    fdptr = uint_to_string(passfd, 4, pipefd[0], 16);
+    setup_rnp_common(&rnp, fdptr);
 
     strcpy(userId, "ciphertest");
 
@@ -181,34 +178,46 @@ rnpkeys_generatekey_testEncryption(void **state)
     retVal = rnp_find_key(&rnp, userId);
     assert_int_equal(retVal, 1); // Ensure the key can be found with the userId
 
+    rnp_end(&rnp);
+
     for (int i = 0; cipherAlg[i] != NULL; i++) {
         for (unsigned int armored = 0; armored <= 1; ++armored) {
-            rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 16));
+            /* setting up rnp and encrypting memory */
+            setup_rnp_common(&rnp, NULL);
+            retVal = rnp_load_keys(&rnp);
+            assert_int_equal(retVal, 1); // Ensure the keyring is loaded.
+            /* setting the cipher and armored flags */
             assert_int_equal(rnp_setvar(&rnp, "cipher", cipherAlg[i]), 1);
+            rnp.ctx.armour = armored;
+            rnp.ctx.ealg = pgp_str_to_cipher(cipherAlg[i]);
 
             retVal = rnp_encrypt_memory(&rnp,
                                         userId,
                                         memToEncrypt,
                                         strlen(memToEncrypt),
                                         ciphertextBuf,
-                                        sizeof(ciphertextBuf),
-                                        armored);
-            assert_int_not_equal(retVal, 0); // Ensure signature operation succeeded
-
+                                        sizeof(ciphertextBuf));
+            assert_int_not_equal(retVal, 0); // Ensure encryption operation succeeded
             const int ctextLen = retVal;
+            rnp_end(&rnp);
 
-            close(pipefd[0]);
-            /* Setup the pass phrase fd to avoid user-input*/
+            /* setting up rnp again and decrypting memory */
             assert_int_equal(setupPassphrasefd(pipefd), 1);
+            fdptr = uint_to_string(passfd, 4, pipefd[0], 16);
+            setup_rnp_common(&rnp, fdptr);
+            retVal = rnp_load_keys(&rnp);
+            assert_int_equal(retVal, 1); // Ensure the keyring is loaded.
+
             retVal = rnp_decrypt_memory(
               &rnp, ciphertextBuf, ctextLen, plaintextBuf, sizeof(plaintextBuf), armored);
 
-            // Ensure plaintext recovered
+            /* Ensure plaintext recovered */
             assert_int_equal(retVal, strlen(memToEncrypt));
             assert_string_equal(memToEncrypt, plaintextBuf);
+            close(pipefd[0]);
+            rnp_end(&rnp);
         }
     }
-    rnp_end(&rnp); // Free memory and other allocated resources.
 }
 
 void

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -38,7 +38,6 @@ rnpkeys_generatekey_testSignature(void **state)
      * Sign a message, then verify it
      */
     rnp_t     rnp;
-    const int numbits = 1024;
     char      passfd[4] = {0};
     char *    fdptr;
     int       pipefd[2];
@@ -62,7 +61,10 @@ rnpkeys_generatekey_testSignature(void **state)
         strcpy(userId, "sigtest_");
         strcat(userId, hashAlg[i]);
 
-        retVal = rnp_generate_key(&rnp, userId, numbits);
+        rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+        rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+        rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+        retVal = rnp_generate_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
         /*Load the newly generated rnp key*/
@@ -150,7 +152,6 @@ rnpkeys_generatekey_testEncryption(void **state)
                                NULL};
 
     rnp_t     rnp;
-    const int numbits = 1024;
     char      passfd[4] = {0};
     char *    fdptr;
     int       pipefd[2];
@@ -168,7 +169,10 @@ rnpkeys_generatekey_testEncryption(void **state)
 
     strcpy(userId, "ciphertest");
 
-    retVal = rnp_generate_key(&rnp, userId, numbits);
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    retVal = rnp_generate_key(&rnp, userId);
     assert_int_equal(retVal, 1); // Ensure the key was generated
 
     /*Load the newly generated rnp key*/
@@ -236,10 +240,9 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
      * Execute the Generate-key command to generate a new pair of private/public
      * key
      * Verify the key was generated with the correct UserId.*/
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -258,7 +261,10 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
         int retVal = rnp_init(&rnp);
         assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-        retVal = rnp_generate_key(&rnp, NULL, numbits);
+        rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+        rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+        rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+        retVal = rnp_generate_key(&rnp, NULL);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
         /*Load the newly generated rnp key*/
@@ -288,10 +294,9 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
      * Execute the Generate-key command to generate a new pair of private/public
      * key
      * Verify the key was generated with the correct UserId.*/
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -313,7 +318,10 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
         int retVal = rnp_init(&rnp);
         assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-        retVal = rnp_generate_key(&rnp, userId, numbits);
+        rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+        rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+        rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+        retVal = rnp_generate_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
         /*Load the newly generated rnp key*/
@@ -335,10 +343,9 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
      * Execute the Generate-key command to generate a new pair of private/public
      * key
      * Verify the key was generated with the correct UserId.*/
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -360,7 +367,10 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     assert_false(path_file_exists(ourdir, ".rnp/secring.gpg", NULL));
 
     // Ensure the key was generated.
-    assert_int_equal(1, rnp_generate_key(&rnp, NULL, numbits));
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    assert_int_equal(1, rnp_generate_key(&rnp, NULL));
 
     // pubring and secring should now exist
     assert_true(path_file_exists(ourdir, ".rnp/pubring.gpg", NULL));
@@ -395,7 +405,10 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     assert_false(path_file_exists(newhome, ".rnp/secring.gpg", NULL));
 
     // Ensure the key was generated.
-    assert_int_equal(1, rnp_generate_key(&rnp, "newhomekey", numbits));
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    assert_int_equal(1, rnp_generate_key(&rnp, "newhomekey"));
 
     // pubring and secring should now exist
     assert_true(path_file_exists(newhome, ".rnp/pubring.gpg", NULL));
@@ -417,7 +430,6 @@ void
 rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
 {
     const char *ourdir = (char *) *state;
-    const int   numbits = 1024;
     char        passfd[4] = {0};
     int         pipefd[2];
     rnp_t       rnp;
@@ -458,7 +470,10 @@ rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
     rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 10));
     assert_int_equal(1, rnp_init(&rnp));
     rnp_setvar(&rnp, "homedir", fakedir);
-    assert_int_equal(0, rnp_generate_key(&rnp, NULL, numbits));
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    assert_int_equal(0, rnp_generate_key(&rnp, NULL));
     rnp_end(&rnp);
 }
 
@@ -471,10 +486,9 @@ rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state)
     paths_concat(nopermsdir, sizeof(nopermsdir), ourdir, "noperms", NULL);
     path_mkdir(0000, nopermsdir, NULL);
 
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -498,7 +512,10 @@ rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state)
     retVal = rnp_init(&rnp);
     assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-    retVal = rnp_generate_key(&rnp, NULL, numbits);
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    retVal = rnp_generate_key(&rnp, NULL);
     assert_int_equal(retVal, 0); // Ensure the key was NOT generated as the
                                  // directory has only list read permissions.
 

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -26,6 +26,7 @@
 
 #include <rnp.h>
 #include <rnp_tests_support.h>
+#include "symmetric.h"
 
 void
 rnpkeys_generatekey_testSignature(void **state)

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -28,6 +28,14 @@
 #include <rnp_tests_support.h>
 #include "symmetric.h"
 
+static void
+set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc)
+{
+    key_desc->key_alg = PGP_PKA_RSA;
+    key_desc->sym_alg = PGP_SA_DEFAULT_CIPHER;
+    key_desc->rsa.modulus_bit_len = 1024;
+}
+
 void
 rnpkeys_generatekey_testSignature(void **state)
 {
@@ -62,9 +70,7 @@ rnpkeys_generatekey_testSignature(void **state)
         strcpy(userId, "sigtest_");
         strcat(userId, hashAlg[i]);
 
-        rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-        rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-        rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
         retVal = rnp_generate_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
@@ -170,9 +176,7 @@ rnpkeys_generatekey_testEncryption(void **state)
 
     strcpy(userId, "ciphertest");
 
-    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
     retVal = rnp_generate_key(&rnp, userId);
     assert_int_equal(retVal, 1); // Ensure the key was generated
 
@@ -262,9 +266,7 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
         int retVal = rnp_init(&rnp);
         assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-        rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-        rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-        rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
         retVal = rnp_generate_key(&rnp, NULL);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
@@ -319,9 +321,7 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
         int retVal = rnp_init(&rnp);
         assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-        rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-        rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-        rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
         retVal = rnp_generate_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
@@ -368,9 +368,7 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     assert_false(path_file_exists(ourdir, ".rnp/secring.gpg", NULL));
 
     // Ensure the key was generated.
-    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
     assert_int_equal(1, rnp_generate_key(&rnp, NULL));
 
     // pubring and secring should now exist
@@ -406,9 +404,7 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     assert_false(path_file_exists(newhome, ".rnp/secring.gpg", NULL));
 
     // Ensure the key was generated.
-    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
     assert_int_equal(1, rnp_generate_key(&rnp, "newhomekey"));
 
     // pubring and secring should now exist
@@ -471,9 +467,7 @@ rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
     rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 10));
     assert_int_equal(1, rnp_init(&rnp));
     rnp_setvar(&rnp, "homedir", fakedir);
-    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
     assert_int_equal(0, rnp_generate_key(&rnp, NULL));
     rnp_end(&rnp);
 }
@@ -513,9 +507,7 @@ rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state)
     retVal = rnp_init(&rnp);
     assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
-    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
-    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
     retVal = rnp_generate_key(&rnp, NULL);
     assert_int_equal(retVal, 0); // Ensure the key was NOT generated as the
                                  // directory has only list read permissions.

--- a/src/cmocka/rnp_tests_support.c
+++ b/src/cmocka/rnp_tests_support.c
@@ -244,3 +244,20 @@ setupPassphrasefd(int *pipefd)
     close(pipefd[1]);
     return 1;
 }
+
+void
+setup_rnp_common(rnp_t *rnp, char *passfd)
+{
+    /*Initialize the basic RNP structure. */
+    memset(rnp, '\0', sizeof(*rnp));
+    /*Set the default parameters*/
+    rnp_setvar(rnp, "sshkeydir", "/etc/ssh");
+    rnp_setvar(rnp, "res", "<stdout>");
+    rnp_setvar(rnp, "format", "human");
+    if (passfd) {
+        rnp_setvar(rnp, "pass-fd", passfd);
+        rnp_setvar(rnp, "need seckey", "true");
+    }
+    int retVal = rnp_init(rnp);
+    assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
+}

--- a/src/cmocka/rnp_tests_support.h
+++ b/src/cmocka/rnp_tests_support.h
@@ -36,6 +36,7 @@
 #include <ftw.h>
 #include <sys/stat.h>
 #include <cmocka.h>
+#include <rnp.h>
 
 /* Check if a file exists.
  * Use with assert_true and assert_false.
@@ -101,3 +102,7 @@ char *uint_to_string(char *buff, const int buffsize, unsigned int num, int base)
 /*
  */
 int setupPassphrasefd(int *pipefd);
+
+/*
+ */
+void setup_rnp_common(rnp_t *rnp, char *passfd);

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -26,6 +26,7 @@
 #ifndef __RNP__UTILS_H__
 #define __RNP__UTILS_H__
 
+#define RNP_MSG(msg) (void) fprintf(stdout, msg);
 #define RNP_LOG(msg) (void) fprintf(stderr, "%s:%d:%s " msg "\n", __FILE__, __LINE__, __func__)
 
 #define CHECK(exp, val, err)                          \
@@ -36,5 +37,7 @@
             goto end;                                 \
         }                                             \
     } while (false)
+
+#define BITS_TO_BYTES(b) (((b) + (CHAR_BIT - 1)) / CHAR_BIT)
 
 #endif

--- a/src/lib/bn.c
+++ b/src/lib/bn.c
@@ -181,7 +181,7 @@ PGPV_BN_div(PGPV_BIGNUM *      dv,
             const PGPV_BIGNUM *d,
             PGPV_BN_CTX *      ctx)
 {
-    if ( (dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
+    if ((dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
         return 0;
     }
     USE_ARG(ctx);

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -224,7 +224,7 @@ write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
                pgp_write_mpi(output, key->key.dsa.g) && pgp_write_mpi(output, key->key.dsa.y);
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
-        return (ecdsa_serialize_pubkey(output, &key->key.ecc) == PGP_E_OK);
+        return (ec_serialize_pubkey(output, &key->key.ecc) == PGP_E_OK);
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -222,11 +222,9 @@ write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
         return pgp_write_mpi(output, key->key.dsa.p) &&
                pgp_write_mpi(output, key->key.dsa.q) &&
                pgp_write_mpi(output, key->key.dsa.g) && pgp_write_mpi(output, key->key.dsa.y);
-
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
-        return (ec_serialize_pubkey(output, &key->key.ecc) == PGP_E_OK);
-
+        return (ecdsa_serialize_pubkey(output, &key->key.ecc) == PGP_E_OK);
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:

--- a/src/lib/create.h
+++ b/src/lib/create.h
@@ -69,6 +69,7 @@
 struct pgp_output_t {
     pgp_writer_t writer;
     pgp_error_t *errors; /* error stack */
+    rnp_ctx_t *  ctx;    /* current operation context */
 };
 
 pgp_output_t *pgp_output_new(void);
@@ -88,7 +89,7 @@ unsigned pgp_write_one_pass_sig(pgp_output_t *,
                                 const pgp_hash_alg_t,
                                 const pgp_sig_type_t);
 unsigned pgp_write_litdata(pgp_output_t *, const uint8_t *, const int, const pgp_litdata_enum);
-pgp_pk_sesskey_t *pgp_create_pk_sesskey(const pgp_key_t *, const char *);
+pgp_pk_sesskey_t *pgp_create_pk_sesskey(const pgp_key_t *, pgp_symm_alg_t);
 unsigned          pgp_write_pk_sesskey(pgp_output_t *, pgp_pk_sesskey_t *);
 unsigned          pgp_write_xfer_pubkey(pgp_output_t *,
                                const pgp_key_t *,

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -225,7 +225,7 @@ pgp_elgamal_encrypt_mpi(const uint8_t *          encoded_m_buf,
 }
 
 pgp_key_t *
-pgp_generate_keypair(const generate_key_ctx_t *key_desc, const uint8_t *userid)
+pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
 {
     pgp_seckey_t *seckey = NULL;
     pgp_output_t *output = NULL;

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -74,7 +74,7 @@ void pgp_crypto_finish(void);
 
 /* Key generation */
 
-pgp_key_t *pgp_generate_keypair(const generate_key_ctx_t *key_desc, const uint8_t *userid);
+pgp_key_t *pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -66,20 +66,15 @@
 #include "bn.h"
 
 #define PGP_MIN_HASH_SIZE 16
-
-#define BITS_TO_BYTES(b) (((b) + (CHAR_BIT - 1)) / CHAR_BIT)
-
 #define MAX_CURVE_BYTELEN BITS_TO_BYTES(521) /* Length of NIST P-521 */
+
+#define NTAGS 0x100 /* == 256 */
 
 void pgp_crypto_finish(void);
 
 /* Key generation */
 
-pgp_key_t *pgp_generate_keypair(pgp_pubkey_alg_t alg,
-                                const int        alg_params,
-                                const uint8_t *  userid,
-                                const char *     hashalg,
-                                const char *     cipher);
+pgp_key_t *pgp_generate_keypair(const generate_key_ctx_t *key_desc, const uint8_t *userid);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);
@@ -171,7 +166,17 @@ typedef struct {
     uint8_t    keyid[PGP_KEY_ID_SIZE];
 } pgp_hashtype_t;
 
-#define NTAGS 0x100 /* == 256 */
+/**
+ * Structure holds description of elliptic curve
+ */
+typedef struct ec_curve_desc_t {
+    const pgp_curve_t rnp_curve_id;
+    const size_t      bitlen;
+    const uint8_t     OIDhex[MAX_CURVE_OID_HEX_LEN];
+    const size_t      OIDhex_len;
+    const char *      botan_name;
+    const char *      pgp_name;
+} ec_curve_desc_t;
 
 /** \brief Structure to hold information about a packet parse.
  *
@@ -194,7 +199,7 @@ typedef struct {
  *
  *  It has a linked list of errors.
  */
-
+// TODO: Shouldn't this be in some other place than crypto.h?
 struct pgp_stream_t {
     uint8_t ss_raw[NTAGS / 8];
     /* 1 bit / sig-subpkt type; set to get raw data */
@@ -218,5 +223,18 @@ struct pgp_stream_t {
     unsigned virtualoff;
     uint8_t *virtualpkt;
 };
+
+/* -----------------------------------------------------------------------------
+ * @brief   Finds curve ID by hex representation of OID
+ *
+ * @param   oid       buffer with OID in hex
+ * @param   oid_len   length of oid buffer
+ *
+ * @returns success curve ID
+ *          failure PGP_CURVE_MAX is returned
+ *
+ * @remarks see RFC 4880 bis 01 - 9.2 ECC Curve OID
+-------------------------------------------------------------------------------- */
+pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
 
 #endif /* CRYPTO_H_ */

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -69,18 +69,17 @@
 
 #define BITS_TO_BYTES(b) (((b) + (CHAR_BIT - 1)) / CHAR_BIT)
 
-#define MAX_CURVE_BYTELEN BITS_TO_BYTES(521)  /* Length of NIST P-521 */
+#define MAX_CURVE_BYTELEN BITS_TO_BYTES(521) /* Length of NIST P-521 */
 
 void pgp_crypto_finish(void);
 
 /* Key generation */
 
-pgp_key_t*
-pgp_generate_keypair(pgp_pubkey_alg_t   alg,
-                     const int          alg_params,
-                     const uint8_t*     userid,
-                     const char*        hashalg,
-                     const char*        cipher);
+pgp_key_t *pgp_generate_keypair(pgp_pubkey_alg_t alg,
+                                const int        alg_params,
+                                const uint8_t *  userid,
+                                const char *     hashalg,
+                                const char *     cipher);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -237,4 +237,19 @@ struct pgp_stream_t {
 -------------------------------------------------------------------------------- */
 pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
 
+/* -----------------------------------------------------------------------------
+ * @brief   Serialize EC public to octet string
+ *
+ * @param   output      generated output
+ * @param   pubkey      initialized ECDSA public key
+ *
+ * @pre     output      must be not null
+ * @pre     pubkey      must be not null
+ *
+ * @returns success PGP_E_OK, error code otherwise
+ *
+ * @remarks see RFC 4880 bis 01 - 5.5.2 Public-Key Packet Formats
+-------------------------------------------------------------------------------- */
+pgp_errcode_t ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
+
 #endif /* CRYPTO_H_ */

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -96,13 +96,8 @@ int pgp_decrypt_decode_mpi(
 struct pgp_key_data;
 void pgp_writer_push_encrypt(pgp_output_t *, const struct pgp_key_data *);
 
-unsigned pgp_encrypt_file(pgp_io_t *,
-                          const char *,
-                          const char *,
-                          const pgp_key_t *,
-                          const unsigned,
-                          const unsigned,
-                          const char *);
+unsigned pgp_encrypt_file(
+  rnp_ctx_t *, pgp_io_t *, const char *, const char *, const pgp_key_t *);
 unsigned pgp_decrypt_file(pgp_io_t *,
                           const char *,
                           const char *,
@@ -116,7 +111,7 @@ unsigned pgp_decrypt_file(pgp_io_t *,
                           pgp_cbfunc_t *);
 
 pgp_memory_t *pgp_encrypt_buf(
-  pgp_io_t *, const void *, const size_t, const pgp_key_t *, const unsigned, const char *);
+  rnp_ctx_t *, pgp_io_t *, const void *, const size_t, const pgp_key_t *);
 pgp_memory_t *pgp_decrypt_buf(pgp_io_t *,
                               const void *,
                               const size_t,

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -52,20 +52,6 @@ find_curve_by_OID(const uint8_t *oid, size_t oid_len)
 }
 
 pgp_errcode_t
-ecdsa_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
-{
-    const ec_curve_desc_t *curve = &ec_curves[pubkey->curve];
-
-    if (pgp_write_scalar(output, curve->OIDhex_len, 1) &&
-        pgp_write(output, curve->OIDhex, curve->OIDhex_len) &&
-        pgp_write_mpi(output, pubkey->point)) {
-        return PGP_E_OK;
-    }
-
-    return PGP_E_W_WRITE_FAILED;
-}
-
-pgp_errcode_t
 pgp_ecdsa_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve)
 {
     /**
@@ -280,4 +266,18 @@ end:
     botan_pubkey_destroy(pub);
     botan_pk_op_verify_destroy(verifier);
     return ret;
+}
+
+pgp_errcode_t
+ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
+{
+    const ec_curve_desc_t *curve = &ec_curves[pubkey->curve];
+
+    if (pgp_write_scalar(output, curve->OIDhex_len, 1) &&
+        pgp_write(output, curve->OIDhex, curve->OIDhex_len) &&
+        pgp_write_mpi(output, pubkey->point)) {
+        return PGP_E_OK;
+    }
+
+    return PGP_E_W_WRITE_FAILED;
 }

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -36,28 +36,7 @@
 #include "rnpdefs.h"
 #include "../common/utils.h"
 
-/**
- * EC Curves definition used by implementation
- *
- * \see RFC4880 bis01 - 9.2. ECC Curve OID
- *
- * Order of the elements in this array corresponds to
- * values in pgp_curve_t enum.
- */
-// TODO: Check size of this array against PGP_CURVE_MAX with static assert
-const ec_curve_desc_t ec_curves[] = {
-  {PGP_CURVE_NIST_P_256,
-   256,
-   {0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07},
-   8,
-   "secp256r1"},
-  {PGP_CURVE_NIST_P_384, 384, {0x2B, 0x81, 0x04, 0x00, 0x22}, 5, "secp384r1"},
-  {PGP_CURVE_NIST_P_521, 521, {0x2B, 0x81, 0x04, 0x00, 0x23}, 5, "secp521r1"},
-  {PGP_CURVE_ED25519,
-   255,
-   {0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01},
-   9,
-   "Ed25519"}};
+extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
 
 pgp_curve_t
 find_curve_by_OID(const uint8_t *oid, size_t oid_len)
@@ -73,7 +52,7 @@ find_curve_by_OID(const uint8_t *oid, size_t oid_len)
 }
 
 pgp_errcode_t
-ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
+ecdsa_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
 {
     const ec_curve_desc_t *curve = &ec_curves[pubkey->curve];
 

--- a/src/lib/ecdsa.h
+++ b/src/lib/ecdsa.h
@@ -34,19 +34,6 @@
 #include "packet.h"
 
 /* -----------------------------------------------------------------------------
- * @brief   Finds curve ID by hex representation of OID
- *
- * @param   oid       buffer with OID in hex
- * @param   oid_len   length of oid buffer
- *
- * @returns success curve ID
- *          failure PGP_CURVE_MAX is returned
- *
- * @remarks see RFC 4880 bis 01 - 9.2 ECC Curve OID
--------------------------------------------------------------------------------- */
-pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
-
-/* -----------------------------------------------------------------------------
  * @brief   Serialize ECDSA public to octet string
  *
  * @param   output      generated output
@@ -59,7 +46,7 @@ pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
  *
  * @remarks see RFC 4880 bis 01 - 5.5.2 Public-Key Packet Formats
 -------------------------------------------------------------------------------- */
-pgp_errcode_t ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
+pgp_errcode_t ecdsa_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
 
 /* -----------------------------------------------------------------------------
  * @brief   Generate ECDSA keypair

--- a/src/lib/ecdsa.h
+++ b/src/lib/ecdsa.h
@@ -34,21 +34,6 @@
 #include "packet.h"
 
 /* -----------------------------------------------------------------------------
- * @brief   Serialize ECDSA public to octet string
- *
- * @param   output      generated output
- * @param   pubkey      initialized ECDSA public key
- *
- * @pre     output      must be not null
- * @pre     pubkey      must be not null
- *
- * @returns success PGP_E_OK, error code otherwise
- *
- * @remarks see RFC 4880 bis 01 - 5.5.2 Public-Key Packet Formats
--------------------------------------------------------------------------------- */
-pgp_errcode_t ecdsa_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
-
-/* -----------------------------------------------------------------------------
  * @brief   Generate ECDSA keypair
  *
  * @param   seckey[out] private part of the key

--- a/src/lib/eddsa.h
+++ b/src/lib/eddsa.h
@@ -37,23 +37,21 @@
 * curve_len must be 255 currently (for Ed25519)
 * If Ed448 was supported in the future curve_len=448 would also be allowed.
 */
-int pgp_genkey_eddsa(pgp_seckey_t* seckey, size_t numbits);
+int pgp_genkey_eddsa(pgp_seckey_t *seckey, size_t numbits);
 
 typedef struct DSA_SIG_st DSA_SIG;
 
-int pgp_eddsa_verify_hash(const BIGNUM* r,
-                          const BIGNUM* s,
+int pgp_eddsa_verify_hash(const BIGNUM *          r,
+                          const BIGNUM *          s,
                           const uint8_t *         hash,
                           size_t                  hash_len,
                           const pgp_ecc_pubkey_t *pubkey);
 
-
-int pgp_eddsa_sign_hash(BIGNUM* r,
-                        BIGNUM* s,
+int pgp_eddsa_sign_hash(BIGNUM *       r,
+                        BIGNUM *       s,
                         const uint8_t *hash,
                         size_t         hash_len,
                         const pgp_ecc_seckey_t *,
                         const pgp_ecc_pubkey_t *);
-
 
 #endif

--- a/src/lib/hash.h
+++ b/src/lib/hash.h
@@ -34,6 +34,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include "../common/utils.h"
 
 /** Hashing Algorithm Numbers.
  * OpenPGP assigns a unique Algorithm Number to each algorithm that is
@@ -44,10 +45,10 @@
  * \see RFC4880 9.4
  */
 typedef enum {
-    PGP_HASH_UNKNOWN = -1, /* used to indicate errors */
-    PGP_HASH_MD5 = 1,      /* MD5 */
-    PGP_HASH_SHA1 = 2,     /* SHA-1 */
-    PGP_HASH_RIPEMD = 3,   /* RIPEMD160 */
+    PGP_HASH_UNKNOWN = 0, /* used to indicate errors */
+    PGP_HASH_MD5 = 1,     /* MD5 */
+    PGP_HASH_SHA1 = 2,    /* SHA-1 */
+    PGP_HASH_RIPEMD = 3,  /* RIPEMD160 */
 
     PGP_HASH_SHA256 = 8,  /* SHA256 */
     PGP_HASH_SHA384 = 9,  /* SHA384 */

--- a/src/lib/key_store.h
+++ b/src/lib/key_store.h
@@ -31,11 +31,9 @@
 #ifndef KEY_STORE_H_
 #define KEY_STORE_H_
 
-#include <rnp.h>
-#include <json.h>
-
 #include <stdint.h>
-
+#include "rnp.h"
+#include "json.h"
 #include "packet.h"
 #include "memory.h"
 

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -382,7 +382,7 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key, pgp_hash_alg_t h
 
     if (key->version == 2 || key->version == 3) {
         if (key->alg != PGP_PKA_RSA && key->alg != PGP_PKA_RSA_ENCRYPT_ONLY &&
-                key->alg != PGP_PKA_RSA_SIGN_ONLY) {
+            key->alg != PGP_PKA_RSA_SIGN_ONLY) {
             (void) fprintf(stderr, "pgp_fingerprint: bad algorithm\n");
             return 0;
         }
@@ -404,18 +404,18 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key, pgp_hash_alg_t h
         type = (key->alg == PGP_PKA_RSA) ? "ssh-rsa" : "ssh-dss";
         hash_string(&hash, (const uint8_t *) (const void *) type, (unsigned) strlen(type));
         switch (key->alg) {
-            case PGP_PKA_RSA:
-                hash_bignum(&hash, key->key.rsa.e);
-                hash_bignum(&hash, key->key.rsa.n);
-                break;
-            case PGP_PKA_DSA:
-                hash_bignum(&hash, key->key.dsa.p);
-                hash_bignum(&hash, key->key.dsa.q);
-                hash_bignum(&hash, key->key.dsa.g);
-                hash_bignum(&hash, key->key.dsa.y);
-                break;
-            default:
-                break;
+        case PGP_PKA_RSA:
+            hash_bignum(&hash, key->key.rsa.e);
+            hash_bignum(&hash, key->key.rsa.n);
+            break;
+        case PGP_PKA_DSA:
+            hash_bignum(&hash, key->key.dsa.p);
+            hash_bignum(&hash, key->key.dsa.q);
+            hash_bignum(&hash, key->key.dsa.g);
+            hash_bignum(&hash, key->key.dsa.y);
+            break;
+        default:
+            break;
         }
         fp->length = pgp_hash_finish(&hash, fp->fingerprint);
         if (rnp_get_debug(__FILE__)) {
@@ -1050,4 +1050,29 @@ rnp_strhexdump(char *dest, const uint8_t *src, size_t length, const char *sep)
         n += snprintf(&dest[n], 10, "%02x%s", *src++, sep);
     }
     return dest;
+}
+
+/* return the file modification time */
+int64_t
+rnp_filemtime(const char *path)
+{
+    struct stat st;
+
+    if (stat(path, &st) != 0) {
+        return 0;
+    } else {
+        return st.st_mtime;
+    }
+}
+
+/* return the filename from the given path */
+const char *
+rnp_filename(const char *path)
+{
+    char *res = strrchr(path, '/');
+    if (!res) {
+        return path;
+    } else {
+        return res + 1;
+    }
 }

--- a/src/lib/packet-key.c
+++ b/src/lib/packet-key.c
@@ -485,7 +485,7 @@ pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
      */
 
     /* create userid pkt */
-    pgp_setup_memory_write(&useridoutput, &mem_userid, 128);
+    pgp_setup_memory_write(NULL, &useridoutput, &mem_userid, 128);
     pgp_write_struct_userid(useridoutput, userid);
 
     /* create sig for this pkt */
@@ -497,7 +497,7 @@ pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
     pgp_add_primary_userid(sig, 1);
     pgp_end_hashed_subpkts(sig);
 
-    pgp_setup_memory_write(&sigoutput, &mem_sig, 128);
+    pgp_setup_memory_write(NULL, &sigoutput, &mem_sig, 128);
     pgp_write_sig(sigoutput, sig, &key->key.seckey.pubkey, &key->key.seckey);
 
     /* add this packet to key */

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -92,7 +92,6 @@ __RCSID("$NetBSD: packet-parse.c,v 1.51 2012/03/05 02:20:18 christos Exp $");
 #include "crypto.h"
 #include "rnpdigest.h"
 #include "s2k.h"
-#include "ecdsa.h"
 #include "../common/utils.h"
 
 #define ERRP(cbinfo, cont, err)                    \

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -1716,7 +1716,7 @@ pgp_export_key(pgp_io_t *io, const pgp_key_t *keydata, uint8_t *passphrase)
     char *        cp;
 
     __PGP_USED(io);
-    pgp_setup_memory_write(&output, &mem, 128);
+    pgp_setup_memory_write(NULL, &output, &mem, 128);
 
     if (keydata->type == PGP_PTAG_CT_PUBLIC_KEY) {
         pgp_write_xfer_pubkey(output, keydata, NULL, 1);

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -354,7 +354,7 @@ numkeybits(const pgp_pubkey_t *pubkey)
         return ec_curves[pubkey->key.ecc.curve].bitlen;
 
     default:
-        (void)fprintf(stderr, "Unknown public key alg in numkeybits\n");
+        (void) fprintf(stderr, "Unknown public key alg in numkeybits\n");
         return -1;
     }
 }
@@ -623,7 +623,8 @@ pgp_sprint_keydata(pgp_io_t *             io,
 
     rnp_strhexdump(keyid, key->sigid, PGP_KEY_ID_SIZE, "");
 
-    rnp_strhexdump(fingerprint, key->sigfingerprint.fingerprint, key->sigfingerprint.length, " ");
+    rnp_strhexdump(
+      fingerprint, key->sigfingerprint.fingerprint, key->sigfingerprint.length, " ");
 
     ptimestr(birthtime, sizeof(birthtime), pubkey->birthtime);
 
@@ -726,9 +727,9 @@ pgp_sprint_json(pgp_io_t *             io,
                   subsigc_arr,
                   json_object_new_string((const char *) pgp_show_pka(key->enckey.alg)));
 
-                json_object_array_add(
-                  subsigc_arr,
-                  json_object_new_string(rnp_strhexdump(keyid, key->encid, PGP_KEY_ID_SIZE, "")));
+                json_object_array_add(subsigc_arr,
+                                      json_object_new_string(rnp_strhexdump(
+                                        keyid, key->encid, PGP_KEY_ID_SIZE, "")));
 
                 json_object_array_add(subsigc_arr,
                                       json_object_new_int((int64_t) key->enckey.birthtime));
@@ -807,23 +808,25 @@ pgp_hkp_sprint_keydata(pgp_io_t *             io,
               io, keyring, key->subsigs[j].sig.info.signer_id, &from, NULL);
             if (key->subsigs[j].sig.info.version == 4 &&
                 key->subsigs[j].sig.info.type == PGP_SIG_SUBKEY) {
-                n += snprintf(
-                  &uidbuf[n],
-                  sizeof(uidbuf) - n,
-                  "sub:%d:%d:%s:%lld:%lld\n",
-                  numkeybits(pubkey),
-                  key->subsigs[j].sig.info.key_alg,
-                  rnp_strhexdump(keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
-                  (long long) (key->subsigs[j].sig.info.birthtime),
-                  (long long) pubkey->duration);
+                n +=
+                  snprintf(&uidbuf[n],
+                           sizeof(uidbuf) - n,
+                           "sub:%d:%d:%s:%lld:%lld\n",
+                           numkeybits(pubkey),
+                           key->subsigs[j].sig.info.key_alg,
+                           rnp_strhexdump(
+                             keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
+                           (long long) (key->subsigs[j].sig.info.birthtime),
+                           (long long) pubkey->duration);
             } else {
-                n += snprintf(
-                  &uidbuf[n],
-                  sizeof(uidbuf) - n,
-                  "sig:%s:%lld:%s\n",
-                  rnp_strhexdump(keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
-                  (long long) key->subsigs[j].sig.info.birthtime,
-                  (trustkey) ? (char *) trustkey->uids[trustkey->uid0] : "");
+                n +=
+                  snprintf(&uidbuf[n],
+                           sizeof(uidbuf) - n,
+                           "sig:%s:%lld:%s\n",
+                           rnp_strhexdump(
+                             keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
+                           (long long) key->subsigs[j].sig.info.birthtime,
+                           (trustkey) ? (char *) trustkey->uids[trustkey->uid0] : "");
             }
         }
     }
@@ -904,8 +907,7 @@ pgp_print_pubkey(const pgp_pubkey_t *pubkey)
         print_bn(0, "y", pubkey->key.elgamal.y);
         break;
     case PGP_PKA_ECDSA:
-        print_string(0, "curve",
-            ec_curves[pubkey->key.ecc.curve].botan_name);
+        print_string(0, "curve", ec_curves[pubkey->key.ecc.curve].botan_name);
         print_bn(0, "public point", pubkey->key.ecc.point);
         break;
 
@@ -922,15 +924,16 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
     char fp[(PGP_FINGERPRINT_SIZE * 3) + 1];
     int  cc;
 
-    cc = snprintf(out,
-                  outsize,
-                  "key=%s\nname=%s\ncreation=%lld\nexpiry=%lld\nversion=%d\nalg=%d\n",
-                  rnp_strhexdump(fp, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE, ""),
-                  key->uids[key->uid0],
-                  (long long) key->key.pubkey.birthtime,
-                  (long long) key->key.pubkey.days_valid,
-                  key->key.pubkey.version,
-                  key->key.pubkey.alg);
+    cc =
+      snprintf(out,
+               outsize,
+               "key=%s\nname=%s\ncreation=%lld\nexpiry=%lld\nversion=%d\nalg=%d\n",
+               rnp_strhexdump(fp, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE, ""),
+               key->uids[key->uid0],
+               (long long) key->key.pubkey.birthtime,
+               (long long) key->key.pubkey.days_valid,
+               key->key.pubkey.version,
+               key->key.pubkey.alg);
     switch (key->key.pubkey.alg) {
     case PGP_PKA_DSA:
         cc += snprintf(&out[cc],
@@ -1726,7 +1729,7 @@ pgp_export_key(pgp_io_t *io, const pgp_key_t *keydata, uint8_t *passphrase)
     }
 
     const size_t mem_len = pgp_mem_len(mem) + 1;
-    if ((cp = (char *)malloc(mem_len)) == NULL){
+    if ((cp = (char *) malloc(mem_len)) == NULL) {
         pgp_teardown_memory_write(output, mem);
         return NULL;
     }

--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -215,7 +215,7 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_ECDSA, "ECDSA"},
   {PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN, "Reserved (formerly Elgamal Encrypt or Sign"},
   {PGP_PKA_RESERVED_DH, "Reserved for Diffie-Hellman (X9.42)"},
-  {PGP_PKA_EDDSA,     "EdDSA"},
+  {PGP_PKA_EDDSA, "EdDSA"},
   {PGP_PKA_PRIVATE00, "Private/Experimental"},
   {PGP_PKA_PRIVATE01, "Private/Experimental"},
   {PGP_PKA_PRIVATE02, "Private/Experimental"},

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1006,7 +1006,7 @@ typedef struct pgp_key_t {
 } pgp_key_t;
 
 /* structure used to hold context of key generation */
-typedef struct generate_key_ctx_t {
+typedef struct rnp_keygen_desc_t {
     // Asymmteric algorithm that user requesed key for
     pgp_pubkey_alg_t key_alg;
     // Hash to be used for key signature
@@ -1021,6 +1021,6 @@ typedef struct generate_key_ctx_t {
             uint32_t modulus_bit_len;
         } rsa;
     };
-} generate_key_ctx_t;
+} rnp_keygen_desc_t;
 
 #endif /* PACKET_H_ */

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -349,32 +349,33 @@ typedef struct {
  * \see RFC4880 9.1
  */
 typedef enum {
-    PGP_PKA_NOTHING = 0,                  /* No PKA */
-    PGP_PKA_RSA = 1,                      /* RSA (Encrypt or Sign) */
-    PGP_PKA_RSA_ENCRYPT_ONLY = 2,         /* RSA Encrypt-Only (deprecated -
-                                           * \see RFC4880 13.5) */
-    PGP_PKA_RSA_SIGN_ONLY = 3,            /* RSA Sign-Only (deprecated -
-                                           * \see RFC4880 13.5) */
-    PGP_PKA_ELGAMAL = 16,                 /* Elgamal (Encrypt-Only) */
-    PGP_PKA_DSA = 17,                     /* DSA (Digital Signature Algorithm) */
-    PGP_PKA_ECDH = 18,                    /* ECDH public key algorithm */
-    PGP_PKA_ECDSA = 19,                   /* ECDSA public key algorithm [FIPS186-3] */
-    PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN = 20, /* Deprecated. Reserved (formerly Elgamal Encrypt or Sign) */
-    PGP_PKA_RESERVED_DH = 21,             /* Reserved for Diffie-Hellman
-                                           * (X9.42, as defined for
-                                           * IETF-S/MIME) */
-    PGP_PKA_EDDSA = 22,                   /* EdDSA from draft-ietf-openpgp-rfc4880bis */
-    PGP_PKA_PRIVATE00 = 100,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE01 = 101,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE02 = 102,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE03 = 103,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE04 = 104,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE05 = 105,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE06 = 106,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE07 = 107,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE08 = 108,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE09 = 109,              /* Private/Experimental Algorithm */
-    PGP_PKA_PRIVATE10 = 110               /* Private/Experimental Algorithm */
+    PGP_PKA_NOTHING = 0,          /* No PKA */
+    PGP_PKA_RSA = 1,              /* RSA (Encrypt or Sign) */
+    PGP_PKA_RSA_ENCRYPT_ONLY = 2, /* RSA Encrypt-Only (deprecated -
+                                   * \see RFC4880 13.5) */
+    PGP_PKA_RSA_SIGN_ONLY = 3,    /* RSA Sign-Only (deprecated -
+                                   * \see RFC4880 13.5) */
+    PGP_PKA_ELGAMAL = 16,         /* Elgamal (Encrypt-Only) */
+    PGP_PKA_DSA = 17,             /* DSA (Digital Signature Algorithm) */
+    PGP_PKA_ECDH = 18,            /* ECDH public key algorithm */
+    PGP_PKA_ECDSA = 19,           /* ECDSA public key algorithm [FIPS186-3] */
+    PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN =
+      20,                     /* Deprecated. Reserved (formerly Elgamal Encrypt or Sign) */
+    PGP_PKA_RESERVED_DH = 21, /* Reserved for Diffie-Hellman
+                               * (X9.42, as defined for
+                               * IETF-S/MIME) */
+    PGP_PKA_EDDSA = 22,       /* EdDSA from draft-ietf-openpgp-rfc4880bis */
+    PGP_PKA_PRIVATE00 = 100,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE01 = 101,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE02 = 102,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE03 = 103,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE04 = 104,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE05 = 105,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE06 = 106,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE07 = 107,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE08 = 108,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE09 = 109,  /* Private/Experimental Algorithm */
+    PGP_PKA_PRIVATE10 = 110   /* Private/Experimental Algorithm */
 } pgp_pubkey_alg_t;
 
 /**
@@ -432,7 +433,7 @@ typedef struct {
  */
 typedef struct {
     pgp_curve_t curve;
-    BIGNUM *point; /* octet string encoded as MPI */
+    BIGNUM *    point; /* octet string encoded as MPI */
 } pgp_ecc_pubkey_t;
 
 /** Version.
@@ -504,7 +505,6 @@ typedef enum {
     PGP_S2KS_ITERATED_AND_SALTED = 3
 } pgp_s2k_specifier_t;
 
-
 /** Symmetric Key Algorithm Numbers.
  * OpenPGP assigns a unique Algorithm Number to each algorithm that is
  * part of OpenPGP.
@@ -514,20 +514,20 @@ typedef enum {
  * \see RFC4880 9.2
  */
 typedef enum {
-    PGP_SA_PLAINTEXT = 0,      /* Plaintext or unencrypted data */
-    PGP_SA_IDEA = 1,           /* IDEA */
-    PGP_SA_TRIPLEDES = 2,      /* TripleDES */
-    PGP_SA_CAST5 = 3,          /* CAST5 */
-    PGP_SA_BLOWFISH = 4,       /* Blowfish */
-    PGP_SA_AES_128 = 7,        /* AES with 128-bit key (AES) */
-    PGP_SA_AES_192 = 8,        /* AES with 192-bit key */
-    PGP_SA_AES_256 = 9,        /* AES with 256-bit key */
-    PGP_SA_TWOFISH = 10,       /* Twofish with 256-bit key (TWOFISH) */
-    PGP_SA_CAMELLIA_128 = 11,  /* Camellia with 128-bit key (CAMELLIA) */
-    PGP_SA_CAMELLIA_192 = 12,  /* Camellia with 192-bit key */
-    PGP_SA_CAMELLIA_256 = 13,  /* Camellia with 256-bit key */
+    PGP_SA_PLAINTEXT = 0,     /* Plaintext or unencrypted data */
+    PGP_SA_IDEA = 1,          /* IDEA */
+    PGP_SA_TRIPLEDES = 2,     /* TripleDES */
+    PGP_SA_CAST5 = 3,         /* CAST5 */
+    PGP_SA_BLOWFISH = 4,      /* Blowfish */
+    PGP_SA_AES_128 = 7,       /* AES with 128-bit key (AES) */
+    PGP_SA_AES_192 = 8,       /* AES with 192-bit key */
+    PGP_SA_AES_256 = 9,       /* AES with 256-bit key */
+    PGP_SA_TWOFISH = 10,      /* Twofish with 256-bit key (TWOFISH) */
+    PGP_SA_CAMELLIA_128 = 11, /* Camellia with 128-bit key (CAMELLIA) */
+    PGP_SA_CAMELLIA_192 = 12, /* Camellia with 192-bit key */
+    PGP_SA_CAMELLIA_256 = 13, /* Camellia with 256-bit key */
 
-    PGP_SA_SM4          = 105  /* RNP extension - SM4 */
+    PGP_SA_SM4 = 105 /* RNP extension - SM4 */
 } pgp_symm_alg_t;
 
 #define PGP_SA_DEFAULT_CIPHER PGP_SA_CAST5
@@ -644,7 +644,7 @@ typedef struct pgp_sig_info_t {
         pgp_rsa_sig_t     rsa;     /* An RSA Signature */
         pgp_dsa_sig_t     dsa;     /* A DSA Signature */
         pgp_elgamal_sig_t elgamal; /* deprecated */
-        pgp_ecc_sig_t     ecc;   /* An ECDSA or EdDSA signature */
+        pgp_ecc_sig_t     ecc;     /* An ECDSA or EdDSA signature */
         pgp_ecc_sig_t     ecdsa;   /* A ECDSA signature */
         pgp_data_t        unknown; /* private or experimental */
     } sig;                         /* signature params */
@@ -1010,10 +1010,10 @@ typedef struct pgp_key_t {
  */
 typedef struct ec_curve_desc_t {
     const pgp_curve_t rnp_curve_id;
-    const size_t bitlen;
-    const uint8_t OIDhex[MAX_CURVE_OID_HEX_LEN];
-    const size_t OIDhex_len;
-    const char *botan_name;
+    const size_t      bitlen;
+    const uint8_t     OIDhex[MAX_CURVE_OID_HEX_LEN];
+    const size_t      OIDhex_len;
+    const char *      botan_name;
 } ec_curve_desc_t;
 
 #endif /* PACKET_H_ */

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1005,15 +1005,22 @@ typedef struct pgp_key_t {
     pgp_revoke_t      revocation;     /* revocation reason */
 } pgp_key_t;
 
-/**
- * Structure holds description of elliptic curve
- */
-typedef struct ec_curve_desc_t {
-    const pgp_curve_t rnp_curve_id;
-    const size_t      bitlen;
-    const uint8_t     OIDhex[MAX_CURVE_OID_HEX_LEN];
-    const size_t      OIDhex_len;
-    const char *      botan_name;
-} ec_curve_desc_t;
+/* structure used to hold context of key generation */
+typedef struct generate_key_ctx_t {
+    // Asymmteric algorithm that user requesed key for
+    pgp_pubkey_alg_t key_alg;
+    // Hash to be used for key signature
+    pgp_hash_alg_t hash_alg;
+    // Symmetric algorithm to be used for secret key encryption
+    pgp_symm_alg_t sym_alg;
+    union {
+        struct ecc_t {
+            pgp_curve_t curve;
+        } ecc;
+        struct rsa_t {
+            uint32_t modulus_bit_len;
+        } rsa;
+    };
+} generate_key_ctx_t;
 
 #endif /* PACKET_H_ */

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -1827,6 +1827,7 @@ pgp_reader_set_memory(pgp_stream_t *stream, const void *buffer, size_t length)
 /**
  \ingroup Core_Writers
  \brief Create and initialise output and mem; Set for writing to mem
+ \param ctx Operation context, may be NULL
  \param output Address where new output pointer will be set
  \param mem Address when new mem pointer will be set
  \param bufsz Initial buffer size (will automatically be increased when necessary)
@@ -1834,7 +1835,7 @@ pgp_reader_set_memory(pgp_stream_t *stream, const void *buffer, size_t length)
  \sa pgp_teardown_memory_write()
 */
 void
-pgp_setup_memory_write(pgp_output_t **output, pgp_memory_t **mem, size_t bufsz)
+pgp_setup_memory_write(rnp_ctx_t *ctx, pgp_output_t **output, pgp_memory_t **mem, size_t bufsz)
 {
     /*
      * initialise needed structures for writing to memory
@@ -1843,8 +1844,8 @@ pgp_setup_memory_write(pgp_output_t **output, pgp_memory_t **mem, size_t bufsz)
     *output = pgp_output_new();
     *mem = pgp_memory_new();
 
+    (*output)->ctx = ctx;
     pgp_memory_init(*mem, bufsz);
-
     pgp_writer_set_memory(*output, *mem);
 }
 
@@ -1911,6 +1912,7 @@ pgp_teardown_memory_read(pgp_stream_t *stream, pgp_memory_t *mem)
 /**
  \ingroup Core_Writers
  \brief Create and initialise output and mem; Set for writing to file
+ \param ctx Operation context, may be null
  \param output Address where new output pointer will be set
  \param filename File to write to
  \param allow_overwrite Allows file to be overwritten, if set.
@@ -1919,7 +1921,10 @@ pgp_teardown_memory_read(pgp_stream_t *stream, pgp_memory_t *mem)
  \sa pgp_teardown_file_write()
 */
 int
-pgp_setup_file_write(pgp_output_t **output, const char *filename, unsigned allow_overwrite)
+pgp_setup_file_write(rnp_ctx_t *    ctx,
+                     pgp_output_t **output,
+                     const char *   filename,
+                     unsigned       allow_overwrite)
 {
     int fd = 0;
     int flags = 0;
@@ -1945,7 +1950,9 @@ pgp_setup_file_write(pgp_output_t **output, const char *filename, unsigned allow
             return fd;
         }
     }
+
     *output = pgp_output_new();
+    (*output)->ctx = ctx;
     pgp_writer_set_fd(*output, fd);
     return fd;
 }
@@ -1969,7 +1976,7 @@ pgp_teardown_file_write(pgp_output_t *output, int fd)
    \brief As pgp_setup_file_write, but appends to file
 */
 int
-pgp_setup_file_append(pgp_output_t **output, const char *filename)
+pgp_setup_file_append(rnp_ctx_t *ctx, pgp_output_t **output, const char *filename)
 {
     int fd;
 
@@ -1983,6 +1990,7 @@ pgp_setup_file_append(pgp_output_t **output, const char *filename)
 #endif
     if (fd >= 0) {
         *output = pgp_output_new();
+        (*output)->ctx = ctx;
         pgp_writer_set_fd(*output, fd);
     }
     return fd;

--- a/src/lib/readerwriter.h
+++ b/src/lib/readerwriter.h
@@ -77,14 +77,14 @@ unsigned pgp_write_se_ip_pktset(pgp_output_t *,
                                 const unsigned,
                                 pgp_crypt_t *);
 void pgp_push_enc_crypt(pgp_output_t *, pgp_crypt_t *);
-int  pgp_push_enc_se_ip(pgp_output_t *, const pgp_key_t *, const char *);
+int  pgp_push_enc_se_ip(pgp_output_t *, const pgp_key_t *, pgp_symm_alg_t);
 
 /* Secret Key checksum */
 void     pgp_push_checksum_writer(pgp_output_t *, pgp_seckey_t *);
 unsigned pgp_pop_skey_checksum_writer(pgp_output_t *);
 
 /* memory writing */
-void pgp_setup_memory_write(pgp_output_t **, pgp_memory_t **, size_t);
+void pgp_setup_memory_write(rnp_ctx_t *, pgp_output_t **, pgp_memory_t **, size_t);
 void pgp_teardown_memory_write(pgp_output_t *, pgp_memory_t *);
 
 /* memory reading */
@@ -97,11 +97,11 @@ void pgp_setup_memory_read(pgp_io_t *,
 void pgp_teardown_memory_read(pgp_stream_t *, pgp_memory_t *);
 
 /* file writing */
-int  pgp_setup_file_write(pgp_output_t **, const char *, unsigned);
+int  pgp_setup_file_write(rnp_ctx_t *, pgp_output_t **, const char *, unsigned);
 void pgp_teardown_file_write(pgp_output_t *, int);
 
 /* file appending */
-int  pgp_setup_file_append(pgp_output_t **, const char *);
+int  pgp_setup_file_append(rnp_ctx_t *, pgp_output_t **, const char *);
 void pgp_teardown_file_append(pgp_output_t *, int);
 
 /* file reading */

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -250,7 +250,7 @@ keydir(rnp_t *rnp, char *buffer, size_t buffer_size)
 }
 
 /* find the name in the array */
-static int
+int
 findvar(rnp_t *rnp, const char *name)
 {
     unsigned i;
@@ -1269,11 +1269,17 @@ rnp_import_key(rnp_t *rnp, char *f)
     return rnp_key_store_list(io, rnp->pubring, 0);
 }
 
+static uint32_t get_numbits(const rnp_t* rnp) {
+    return 0;
+}
+
 /* generate a new key */
 /* TODO: Does this need to take into account SSH keys? */
 int
-rnp_generate_key(rnp_t *rnp, char *id, int numbits)
+rnp_generate_key(rnp_t *rnp, const char *id)
 {
+    RNP_MSG("Generating a new key...\n");
+
     pgp_output_t * create;
     const unsigned noarmor = 0;
     pgp_key_t *    key;
@@ -1295,23 +1301,18 @@ rnp_generate_key(rnp_t *rnp, char *id, int numbits)
 
     io = rnp->io;
 
-    const pgp_pubkey_alg_t alg = ((numbits == 256) || (numbits == 384) || (numbits == 521)) ?
-                                   PGP_PKA_ECDSA :
-                                   (numbits == 255) ? PGP_PKA_EDDSA : PGP_PKA_RSA;
-
     /* generate a new key */
     if (id) {
         snprintf(newid, sizeof(newid), "%s", id);
     } else {
         snprintf(
           newid, sizeof(newid), "%s %d-bit key <%s@localhost>",
-          pgp_show_pka(alg), numbits, getenv("LOGNAME"));
+          pgp_show_pka(rnp->action.generate_key_ctx.key_alg),
+          get_numbits(rnp), getenv("LOGNAME"));
     }
     uid = (uint8_t *) newid;
 
-    key = pgp_generate_keypair(
-      alg, numbits, uid, rnp_getvar(rnp, "hash"), rnp_getvar(rnp, "cipher"));
-
+    key = pgp_generate_keypair(&rnp->action.generate_key_ctx, uid);
     if (key == NULL) {
         (void) fprintf(io->errs, "cannot generate key\n");
         return 0;
@@ -1345,7 +1346,7 @@ rnp_generate_key(rnp_t *rnp, char *id, int numbits)
         (void) fprintf(io->errs, "cannot write pubkey to '%s'\n", ringfile);
         goto out;
     }
-    if (rnp->pubring != NULL) {
+    if (rnp->pubring) {
         rnp_key_store_free(rnp->pubring);
         free(rnp->pubring);
         rnp->pubring = NULL;

--- a/src/lib/rnpsdk.h
+++ b/src/lib/rnpsdk.h
@@ -71,6 +71,10 @@ void rnp_log(const char *, ...) __printflike(1, 2);
 int   rnp_strcasecmp(const char *, const char *);
 char *rnp_strdup(const char *);
 
-char * rnp_strhexdump(char *dest, const uint8_t *src, size_t length, const char *sep);
+char *rnp_strhexdump(char *dest, const uint8_t *src, size_t length, const char *sep);
+
+int64_t rnp_filemtime(const char *path);
+
+const char *rnp_filename(const char *path);
 
 #endif

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -294,57 +294,51 @@ done:
     return retval;
 }
 
-int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits)
-   {
-   botan_privkey_t rsa_key = NULL;
-   botan_rng_t     rng = NULL;
-   int ret = 0;
+int
+pgp_genkey_rsa(pgp_seckey_t *seckey, size_t numbits)
+{
+    botan_privkey_t rsa_key = NULL;
+    botan_rng_t     rng = NULL;
+    int             ret = 0;
 
-   seckey->pubkey.key.rsa.n = BN_new();
-   seckey->pubkey.key.rsa.e = BN_new();
-   seckey->key.rsa.p = BN_new();
-   seckey->key.rsa.q = BN_new();
-   seckey->key.rsa.d = BN_new();
-   seckey->key.rsa.u = BN_new();
+    seckey->pubkey.key.rsa.n = BN_new();
+    seckey->pubkey.key.rsa.e = BN_new();
+    seckey->key.rsa.p = BN_new();
+    seckey->key.rsa.q = BN_new();
+    seckey->key.rsa.d = BN_new();
+    seckey->key.rsa.u = BN_new();
 
-   if(!seckey->pubkey.key.rsa.n ||
-      !seckey->pubkey.key.rsa.e ||
-      !seckey->key.rsa.p ||
-      !seckey->key.rsa.q ||
-      !seckey->key.rsa.d ||
-      !seckey->key.rsa.u)
-      {
-      goto end;
-      }
+    if (!seckey->pubkey.key.rsa.n || !seckey->pubkey.key.rsa.e || !seckey->key.rsa.p ||
+        !seckey->key.rsa.q || !seckey->key.rsa.d || !seckey->key.rsa.u) {
+        goto end;
+    }
 
-   if (botan_rng_init(&rng, NULL) != 0)
-      goto end;
+    if (botan_rng_init(&rng, NULL) != 0)
+        goto end;
 
-   if (botan_privkey_create_rsa(&rsa_key, rng, numbits) != 0)
-      goto end;
+    if (botan_privkey_create_rsa(&rsa_key, rng, numbits) != 0)
+        goto end;
 
-   if (botan_privkey_check_key(rsa_key, rng, 1) != 0)
-      goto end;
+    if (botan_privkey_check_key(rsa_key, rng, 1) != 0)
+        goto end;
 
-   /* Calls below never fail as calls above were OK */
-   (void) botan_privkey_rsa_get_n(seckey->pubkey.key.rsa.n->mp, rsa_key);
-   (void) botan_privkey_rsa_get_e(seckey->pubkey.key.rsa.e->mp, rsa_key);
-   (void) botan_privkey_rsa_get_d(seckey->key.rsa.d->mp, rsa_key);
-   (void) botan_privkey_rsa_get_p(seckey->key.rsa.p->mp, rsa_key);
-   (void) botan_privkey_rsa_get_q(seckey->key.rsa.q->mp, rsa_key);
+    /* Calls below never fail as calls above were OK */
+    (void) botan_privkey_rsa_get_n(seckey->pubkey.key.rsa.n->mp, rsa_key);
+    (void) botan_privkey_rsa_get_e(seckey->pubkey.key.rsa.e->mp, rsa_key);
+    (void) botan_privkey_rsa_get_d(seckey->key.rsa.d->mp, rsa_key);
+    (void) botan_privkey_rsa_get_p(seckey->key.rsa.p->mp, rsa_key);
+    (void) botan_privkey_rsa_get_q(seckey->key.rsa.q->mp, rsa_key);
 
-   if (botan_mp_mod_inverse(seckey->key.rsa.u->mp,
-                            seckey->key.rsa.p->mp,
-                            seckey->key.rsa.q->mp) != 0)
-      {
-      RNP_LOG("Error computing RSA u param");
-      goto end;
-      }
+    if (botan_mp_mod_inverse(
+          seckey->key.rsa.u->mp, seckey->key.rsa.p->mp, seckey->key.rsa.q->mp) != 0) {
+        RNP_LOG("Error computing RSA u param");
+        goto end;
+    }
 
-   ret = 1;
+    ret = 1;
 
-   end:
-   botan_privkey_destroy(rsa_key);
-   botan_rng_destroy(rng);
-   return ret;
-   }
+end:
+    botan_privkey_destroy(rsa_key);
+    botan_rng_destroy(rng);
+    return ret;
+}

--- a/src/lib/rsa.h
+++ b/src/lib/rsa.h
@@ -38,7 +38,7 @@
  * RSA encrypt/decrypt
  */
 
-int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits);
+int pgp_genkey_rsa(pgp_seckey_t *seckey, size_t numbits);
 
 int pgp_rsa_encrypt_pkcs1(uint8_t *               out,
                           size_t                  out_len,

--- a/src/lib/signature.h
+++ b/src/lib/signature.h
@@ -112,26 +112,24 @@ unsigned pgp_add_issuer_keyid(pgp_create_sig_t *, const uint8_t *);
 void     pgp_add_primary_userid(pgp_create_sig_t *, unsigned);
 
 /* Standard Interface */
-unsigned pgp_sign_file(pgp_io_t *,
+unsigned pgp_sign_file(rnp_ctx_t *,
+                       pgp_io_t *,
                        const char *,
                        const char *,
                        const pgp_seckey_t *,
                        const char *,
                        const int64_t,
                        const uint64_t,
-                       const unsigned,
-                       const unsigned,
                        const unsigned);
 
-int pgp_sign_detached(pgp_io_t *,
+int pgp_sign_detached(rnp_ctx_t *,
+                      pgp_io_t *,
                       const char *,
                       char *,
                       pgp_seckey_t *,
                       const char *,
                       const int64_t,
-                      const uint64_t,
-                      const unsigned,
-                      const unsigned);
+                      const uint64_t);
 
 /* armoured stuff */
 unsigned pgp_crc24(unsigned, uint8_t);
@@ -157,14 +155,14 @@ unsigned pgp_writer_use_armored_sig(pgp_output_t *);
 
 void pgp_writer_push_armoured(pgp_output_t *, pgp_armor_type_t);
 
-pgp_memory_t *pgp_sign_buf(pgp_io_t *,
+pgp_memory_t *pgp_sign_buf(rnp_ctx_t *,
+                           pgp_io_t *,
                            const void *,
                            const size_t,
                            const pgp_seckey_t *,
                            const int64_t,
                            const uint64_t,
                            const char *,
-                           const unsigned,
                            const unsigned);
 
 #endif /* SIGNATURE_H_ */

--- a/src/lib/writer.h
+++ b/src/lib/writer.h
@@ -79,6 +79,7 @@ struct pgp_writer_t {
     void *                  arg;       /* writer-specific argument */
     pgp_writer_t *          next;      /* next writer in the stack */
     pgp_io_t *              io;        /* IO for errors and output */
+    rnp_ctx_t *             ctx;       /* Operation context */
 };
 
 void *pgp_writer_get_arg(pgp_writer_t *);
@@ -108,6 +109,6 @@ unsigned pgp_write_mpi(pgp_output_t *, const BIGNUM *);
 void     pgp_writer_info_delete(pgp_writer_t *);
 unsigned pgp_writer_info_finalise(pgp_error_t **, pgp_writer_t *);
 
-void pgp_push_stream_enc_se_ip(pgp_output_t *, const pgp_key_t *, const char *);
+void pgp_push_stream_enc_se_ip(pgp_output_t *, const pgp_key_t *, pgp_symm_alg_t);
 
 #endif /* WRITER_H_ */

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,8 @@ AM_CFLAGS		= $(WARNCFLAGS)
 
 bin_PROGRAMS		= rnpkeys
 
-rnpkeys_SOURCES	= rnpkeys.c
+rnpkeys_SOURCES	=   rnpkeys.c \
+                    tui.c
 
 rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include
 

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -243,7 +243,7 @@ rnp_cmd(rnp_t *rnp, prog_t *p, char *f)
         return rnp_import_key(rnp, f);
     case GENERATE_KEY:
         key = f ? f : rnp_getvar(rnp, "userid");
-        generate_key_ctx_t *ctx = &rnp->action.generate_key_ctx;
+        rnp_keygen_desc_t *ctx = &rnp->action.generate_key_ctx;
         if (findvar(rnp, "expert") > 0) {
             (void) rnp_generate_key_expert_mode(rnp);
         } else {

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -247,9 +247,8 @@ rnp_cmd(rnp_t *rnp, prog_t *p, char *f)
         if (findvar(rnp, "expert") > 0) {
             (void) rnp_generate_key_expert_mode(rnp);
         } else {
-            // OZAPTF: remove 'numbits' option
             ctx->key_alg = PGP_PKA_RSA;
-            ctx->rsa.modulus_bit_len = DEFAULT_NUMBITS;
+            ctx->rsa.modulus_bit_len = p->numbits;
         }
 
         // Find hash algorithm to use

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -87,6 +87,7 @@ ask_curve()
         for (int i = 0; (i < PGP_CURVE_MAX) && (i != PGP_CURVE_ED25519); i++) {
             printf("\t(%u) %s\n", i + 1, ec_curves[i].pgp_name);
         }
+        printf("> ");
         ok = rnp_secure_get_long_from_fd(stdin, &result);
         ok &= (result > 0) && (result < PGP_CURVE_MAX);
     } while (!ok);
@@ -103,7 +104,8 @@ ask_algorithm()
                "\t(1)  RSA (Encrypt or Sign)\n"
                // "\t(18) ECDH\n"
                "\t(19) ECDSA\n"
-               "\t(22) EDDSA\n");
+               "\t(22) EDDSA\n"
+               "> ");
 
     } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
              !is_keygen_supported_for_alg(result));
@@ -115,7 +117,7 @@ ask_bitlen()
 {
     long result = 0;
     do {
-        printf("Please provide bit length of the key (between 1024 and 4096):\n");
+        printf("Please provide bit length of the key (between 1024 and 4096):\n> ");
     } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
              !is_rsa_keysize_supported(result));
     return result;

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -1,0 +1,162 @@
+#include <stdbool.h>
+#include <crypto.h>
+
+extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
+
+/* -----------------------------------------------------------------------------
+ * @brief   Reads input from file pointer and converts it securelly to ints
+ *          Partially based on ERR34-C from SEI CERT C Coding Standarad
+ *
+ * @param   fp          pointer to opened pipe
+ * @param   result[out] result read from file pointer and converted to int
+ *
+ * @returns true and value in result if integer was parsed correctly,
+ *          otherwise false
+ *
+-------------------------------------------------------------------------------- */
+static bool
+rnp_secure_get_long_from_fd(const FILE *fp, long *result)
+{
+    char  buff[BUFSIZ];
+    char *end_ptr;
+    long  num_long;
+    bool  ret = false;
+
+    if (!result) {
+        goto end;
+    }
+
+    if (fgets(buff, sizeof(buff), stdin) == NULL) {
+        RNP_LOG("EOF or read error");
+        goto end;
+    } else {
+        errno = 0;
+        num_long = strtol(buff, &end_ptr, 10);
+
+        if (ERANGE == errno) {
+            RNP_LOG("Number out of range");
+            goto end;
+        } else if (end_ptr == buff) {
+            RNP_LOG("Invalid number");
+            goto end;
+        } else if ('\n' != *end_ptr && '\0' != *end_ptr) {
+            RNP_LOG("Unexpected end of line");
+            goto end;
+        }
+    }
+
+    *result = num_long;
+    ret = true;
+
+end:
+    return ret;
+}
+
+static bool
+is_rsa_keysize_supported(uint32_t keysize)
+{
+    return ((keysize >= 1024) && (keysize <= 4096) && !(keysize % 8));
+}
+
+static bool
+is_keygen_supported_for_alg(pgp_pubkey_alg_t id)
+{
+    switch (id) {
+    case PGP_PKA_RSA:
+    case PGP_PKA_ECDSA:
+    case PGP_PKA_EDDSA:
+        // Not yet really supported (at least key generation)
+        //
+        // case PGP_PKA_ECDH:
+        // case PGP_PKA_ELGAMAL:
+        // case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
+        // case PGP_PKA_DSA:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static long
+ask_curve()
+{
+    long result = 0;
+    bool ok = false;
+    do {
+        printf("Please select which elliptic curve you want:\n");
+        for (int i = 0; (i < PGP_CURVE_MAX) && (i != PGP_CURVE_ED25519); i++) {
+            printf("\t(%u) %s\n", i + 1, ec_curves[i].pgp_name);
+        }
+        ok = rnp_secure_get_long_from_fd(stdin, &result);
+        ok &= (result > 0) && (result < PGP_CURVE_MAX);
+    } while (!ok);
+
+    return result - 1;
+}
+
+static long
+ask_algorithm()
+{
+    long result = 0;
+    do {
+        printf("Please select what kind of key you want:\n"
+               "\t(1)  RSA (Encrypt or Sign)\n"
+               // "\t(18) ECDH\n"
+               "\t(19) ECDSA\n"
+               "\t(22) EDDSA\n");
+
+    } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
+             !is_keygen_supported_for_alg(result));
+    return result;
+}
+
+static long
+ask_bitlen()
+{
+    long result = 0;
+    do {
+        printf("Please provide bit length of the key (between 1024 and 4096):\n");
+    } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
+             !is_rsa_keysize_supported(result));
+    return result;
+}
+
+/* -----------------------------------------------------------------------------
+ * @brief   Asks user for details needed for the key to be generated (currently
+ *          key type and key length only)
+ *          This function should explicitly ask user for all details (not use
+ *          rnp_getvar or getenv).
+ *
+ * @param   rnp [in]  Initialized rnp_t struture.
+ *              [out] Function fills corresponding to key type and length
+ *
+ * @returns PGP_E_OK on success
+ *          PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG algorithm not supported
+ *
+-------------------------------------------------------------------------------- */
+pgp_errcode_t
+rnp_generate_key_expert_mode(rnp_t *rnp)
+{
+    rnp->action.generate_key_ctx.key_alg = (pgp_pubkey_alg_t) ask_algorithm();
+
+    // get more details about the key
+    switch (rnp->action.generate_key_ctx.key_alg) {
+    case PGP_PKA_RSA:
+        // Those algorithms must _NOT_ be supported
+        //  case PGP_PKA_RSA_ENCRYPT_ONLY:
+        //  case PGP_PKA_RSA_SIGN_ONLY:
+        rnp->action.generate_key_ctx.rsa.modulus_bit_len = ask_bitlen();
+        break;
+    case PGP_PKA_ECDH:
+    case PGP_PKA_ECDSA:
+        rnp->action.generate_key_ctx.ecc.curve = (pgp_curve_t) ask_curve();
+        break;
+    case PGP_PKA_EDDSA:
+        rnp->action.generate_key_ctx.ecc.curve = PGP_CURVE_ED25519;
+        break;
+    default:
+        return PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG;
+    }
+
+    return PGP_E_OK;
+}


### PR DESCRIPTION
Introduces --expert flag for rnpkeys. This flag can be used if user want's to generate key different than default (RSA/2048). In such case rnpkeys will ask user for kind of key/size he wants to generate. Currently only RSA, ECDSA and EDDSA is supported.

 I propose we introduce structure that can be used for passing complete set of parameters needed for key generation (currently this structure is used to pass number of bits or curve name).

Patch contains also some small improvements for EC key generation (moves some function from ecdsa.c to crypto.c)

#130