### PR TITLE
Remove the unused BN_CTX type

### DIFF
--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -247,7 +247,6 @@ raw_elg_test_success(void **state)
     uint8_t              g_to_k[64];
     uint8_t              decryption_result[1024];
     const uint8_t        plaintext[] = {0x01, 0x02, 0x03, 0x04, 0x17};
-    BN_CTX               ctx;
 
     // Allocate needed memory
     pub_elg.p = BN_bin2bn(p512, sizeof(p512), NULL);
@@ -257,7 +256,7 @@ raw_elg_test_success(void **state)
 
     BN_set_word(pub_elg.g, 3);
     BN_set_word(sec_elg.x, 0xCAB5432);
-    BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p, &ctx);
+    BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p);
 
     // Encrypt
     unsigned ctext_size =

--- a/src/lib/bn.c
+++ b/src/lib/bn.c
@@ -174,12 +174,9 @@ PGPV_BN_mul(PGPV_BIGNUM *r, const PGPV_BIGNUM *a, const PGPV_BIGNUM *b)
 }
 
 int
-PGPV_BN_div(PGPV_BIGNUM *      dv,
-            PGPV_BIGNUM *      rem,
-            const PGPV_BIGNUM *a,
-            const PGPV_BIGNUM *d)
+PGPV_BN_div(PGPV_BIGNUM *dv, PGPV_BIGNUM *rem, const PGPV_BIGNUM *a, const PGPV_BIGNUM *d)
 {
-    if ( (dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
+    if ((dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
         return 0;
     }
     return botan_mp_div(dv->mp, rem->mp, a->mp, d->mp) == 0;
@@ -268,8 +265,7 @@ PGPV_BN_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 }
 
 int
-PGPV_BN_mod_exp(
-  PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P)
+PGPV_BN_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P)
 {
     if (Y == NULL || G == NULL || X == NULL || P == NULL) {
         return -1;
@@ -287,8 +283,7 @@ PGPV_BN_mod_inverse(PGPV_BIGNUM *r, PGPV_BIGNUM *a, const PGPV_BIGNUM *n)
 }
 
 int
-PGPV_BN_mod_mul(
-  PGPV_BIGNUM *ret, PGPV_BIGNUM *a, PGPV_BIGNUM *b, const PGPV_BIGNUM *m)
+PGPV_BN_mod_mul(PGPV_BIGNUM *ret, PGPV_BIGNUM *a, PGPV_BIGNUM *b, const PGPV_BIGNUM *m)
 {
     if (ret == NULL || a == NULL || b == NULL || m == NULL) {
         return 0;
@@ -496,7 +491,7 @@ int
 PGPV_BN_is_prime(const PGPV_BIGNUM *a,
                  int                checks,
                  void (*callback)(int, int, void *),
-                 void *       cb_arg)
+                 void *cb_arg)
 {
     int ret;
     int test_prob;

--- a/src/lib/bn.c
+++ b/src/lib/bn.c
@@ -165,12 +165,11 @@ PGPV_BN_sub(PGPV_BIGNUM *r, const PGPV_BIGNUM *a, const PGPV_BIGNUM *b)
 }
 
 int
-PGPV_BN_mul(PGPV_BIGNUM *r, const PGPV_BIGNUM *a, const PGPV_BIGNUM *b, PGPV_BN_CTX *ctx)
+PGPV_BN_mul(PGPV_BIGNUM *r, const PGPV_BIGNUM *a, const PGPV_BIGNUM *b)
 {
     if (a == NULL || b == NULL || r == NULL) {
         return 0;
     }
-    USE_ARG(ctx);
     return botan_mp_mul(r->mp, a->mp, b->mp) == 0;
 }
 
@@ -178,13 +177,11 @@ int
 PGPV_BN_div(PGPV_BIGNUM *      dv,
             PGPV_BIGNUM *      rem,
             const PGPV_BIGNUM *a,
-            const PGPV_BIGNUM *d,
-            PGPV_BN_CTX *      ctx)
+            const PGPV_BIGNUM *d)
 {
     if ( (dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
         return 0;
     }
-    USE_ARG(ctx);
     return botan_mp_div(dv->mp, rem->mp, a->mp, d->mp) == 0;
 }
 
@@ -272,19 +269,17 @@ PGPV_BN_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 
 int
 PGPV_BN_mod_exp(
-  PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P, PGPV_BN_CTX *ctx)
+  PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P)
 {
     if (Y == NULL || G == NULL || X == NULL || P == NULL) {
         return -1;
     }
-    USE_ARG(ctx);
     return botan_mp_powmod(Y->mp, G->mp, X->mp, P->mp) == 0;
 }
 
 PGPV_BIGNUM *
-PGPV_BN_mod_inverse(PGPV_BIGNUM *r, PGPV_BIGNUM *a, const PGPV_BIGNUM *n, PGPV_BN_CTX *ctx)
+PGPV_BN_mod_inverse(PGPV_BIGNUM *r, PGPV_BIGNUM *a, const PGPV_BIGNUM *n)
 {
-    USE_ARG(ctx);
     if (r == NULL || a == NULL || n == NULL) {
         return NULL;
     }
@@ -293,65 +288,12 @@ PGPV_BN_mod_inverse(PGPV_BIGNUM *r, PGPV_BIGNUM *a, const PGPV_BIGNUM *n, PGPV_B
 
 int
 PGPV_BN_mod_mul(
-  PGPV_BIGNUM *ret, PGPV_BIGNUM *a, PGPV_BIGNUM *b, const PGPV_BIGNUM *m, PGPV_BN_CTX *ctx)
+  PGPV_BIGNUM *ret, PGPV_BIGNUM *a, PGPV_BIGNUM *b, const PGPV_BIGNUM *m)
 {
-    USE_ARG(ctx);
     if (ret == NULL || a == NULL || b == NULL || m == NULL) {
         return 0;
     }
     return (botan_mp_mod_mul(ret->mp, a->mp, b->mp, m->mp) < 0) ? 0 : 1;
-}
-
-PGPV_BN_CTX *
-PGPV_BN_CTX_new(void)
-{
-    return calloc(1, sizeof(PGPV_BN_CTX));
-}
-
-void
-PGPV_BN_CTX_init(PGPV_BN_CTX *c)
-{
-    if (c != NULL) {
-        c->arraysize = 15;
-        if ((c->v = calloc(sizeof(*c->v), c->arraysize)) == NULL) {
-            c->arraysize = 0;
-        }
-    }
-}
-
-PGPV_BIGNUM *
-PGPV_BN_CTX_get(PGPV_BN_CTX *ctx)
-{
-    if (ctx == NULL || ctx->v == NULL || ctx->arraysize == 0 ||
-        ctx->count == ctx->arraysize - 1) {
-        return NULL;
-    }
-    return ctx->v[ctx->count++] = PGPV_BN_new();
-}
-
-void
-PGPV_BN_CTX_start(PGPV_BN_CTX *ctx)
-{
-    PGPV_BN_CTX_init(ctx);
-}
-
-void
-PGPV_BN_CTX_free(PGPV_BN_CTX *c)
-{
-    unsigned i;
-
-    if (c != NULL && c->v != NULL) {
-        for (i = 0; i < c->count; i++) {
-            PGPV_BN_clear_free(c->v[i]);
-        }
-        free(c->v);
-    }
-}
-
-void
-PGPV_BN_CTX_end(PGPV_BN_CTX *ctx)
-{
-    PGPV_BN_CTX_free(ctx);
 }
 
 char *
@@ -554,7 +496,6 @@ int
 PGPV_BN_is_prime(const PGPV_BIGNUM *a,
                  int                checks,
                  void (*callback)(int, int, void *),
-                 PGPV_BN_CTX *ctx,
                  void *       cb_arg)
 {
     int ret;
@@ -563,7 +504,6 @@ PGPV_BN_is_prime(const PGPV_BIGNUM *a,
     if (a == NULL || checks <= 0) {
         return -1;
     }
-    USE_ARG(ctx);
     USE_ARG(cb_arg);
     USE_ARG(callback);
 
@@ -627,9 +567,8 @@ PGPV_BN_is_bit_set(const PGPV_BIGNUM *a, int n)
 
 /* get greatest common divisor */
 int
-PGPV_BN_gcd(PGPV_BIGNUM *r, PGPV_BIGNUM *a, PGPV_BIGNUM *b, PGPV_BN_CTX *ctx)
+PGPV_BN_gcd(PGPV_BIGNUM *r, PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 {
-    USE_ARG(ctx);
     return botan_mp_gcd(r->mp, a->mp, b->mp);
 }
 

--- a/src/lib/bn.h
+++ b/src/lib/bn.h
@@ -47,7 +47,6 @@ __BEGIN_DECLS
 
 #ifdef USE_BN_INTERFACE
 #define BIGNUM PGPV_BIGNUM
-#define BN_CTX PGPV_BN_CTX
 #define BN_is_negative PGPV_BN_is_negative
 #define BN_is_zero PGPV_BN_is_zero
 #define BN_is_odd PGPV_BN_is_odd
@@ -89,12 +88,6 @@ __BEGIN_DECLS
 #define BN_mod_sub PGPV_BN_mod_sub
 #define BN_raise PGPV_BN_raise
 #define BN_factorial PGPV_BN_factorial
-#define BN_CTX_new PGPV_BN_CTX_new
-#define BN_CTX_get PGPV_BN_CTX_get
-#define BN_CTX_start PGPV_BN_CTX_start
-#define BN_CTX_end PGPV_BN_CTX_end
-#define BN_CTX_init PGPV_BN_CTX_init
-#define BN_CTX_free PGPV_BN_CTX_free
 #define BN_rand PGPV_BN_rand
 #define BN_rand_range PGPV_BN_rand_range
 #define BN_is_prime PGPV_BN_is_prime
@@ -110,13 +103,6 @@ __BEGIN_DECLS
 typedef struct PGPV_BIGNUM_st {
     botan_mp_t mp;
 } PGPV_BIGNUM;
-
-/* a "context" of mp integers - never really used */
-typedef struct bn_ctx_t {
-    size_t        count;
-    size_t        arraysize;
-    PGPV_BIGNUM **v;
-} PGPV_BN_CTX;
 
 #define MP_LT -1
 #define MP_EQ 0
@@ -162,13 +148,11 @@ int PGPV_BN_add(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, const PGPV_BIGNU
 int PGPV_BN_sub(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, const PGPV_BIGNUM * /*b*/);
 int PGPV_BN_mul(PGPV_BIGNUM * /*r*/,
                 const PGPV_BIGNUM * /*a*/,
-                const PGPV_BIGNUM * /*b*/,
-                PGPV_BN_CTX * /*ctx*/);
+                const PGPV_BIGNUM * /*b*/);
 int PGPV_BN_div(PGPV_BIGNUM * /*q*/,
                 PGPV_BIGNUM * /*r*/,
                 const PGPV_BIGNUM * /*a*/,
-                const PGPV_BIGNUM * /*b*/,
-                PGPV_BN_CTX * /*ctx*/);
+                const PGPV_BIGNUM * /*b*/);
 void PGPV_BN_swap(PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
 int  PGPV_BN_bitop(PGPV_BIGNUM * /*r*/,
                   const PGPV_BIGNUM * /*a*/,
@@ -192,24 +176,15 @@ int PGPV_BN_num_bits(const PGPV_BIGNUM * /*a*/);
 int PGPV_BN_mod_exp(PGPV_BIGNUM * /*r*/,
                     PGPV_BIGNUM * /*a*/,
                     PGPV_BIGNUM * /*p*/,
-                    PGPV_BIGNUM * /*m*/,
-                    PGPV_BN_CTX * /*ctx*/);
+                    PGPV_BIGNUM * /*m*/);
 PGPV_BIGNUM *PGPV_BN_mod_inverse(PGPV_BIGNUM * /*ret*/,
                                  PGPV_BIGNUM * /*a*/,
-                                 const PGPV_BIGNUM * /*n*/,
-                                 PGPV_BN_CTX * /*ctx*/);
+                                 const PGPV_BIGNUM * /*n*/);
+
 int PGPV_BN_mod_mul(PGPV_BIGNUM * /*ret*/,
                     PGPV_BIGNUM * /*a*/,
                     PGPV_BIGNUM * /*b*/,
-                    const PGPV_BIGNUM * /*m*/,
-                    PGPV_BN_CTX * /*ctx*/);
-
-PGPV_BN_CTX *PGPV_BN_CTX_new(void);
-PGPV_BIGNUM *PGPV_BN_CTX_get(PGPV_BN_CTX * /*ctx*/);
-void         PGPV_BN_CTX_start(PGPV_BN_CTX * /*ctx*/);
-void         PGPV_BN_CTX_end(PGPV_BN_CTX * /*ctx*/);
-void         PGPV_BN_CTX_init(PGPV_BN_CTX * /*c*/);
-void         PGPV_BN_CTX_free(PGPV_BN_CTX * /*c*/);
+                    const PGPV_BIGNUM * /*m*/);
 
 int PGPV_BN_rand(PGPV_BIGNUM * /*rnd*/, int /*bits*/, int /*top*/, int /*bottom*/);
 int PGPV_BN_rand_range(PGPV_BIGNUM * /*rnd*/, PGPV_BIGNUM * /*range*/);
@@ -217,7 +192,6 @@ int PGPV_BN_rand_range(PGPV_BIGNUM * /*rnd*/, PGPV_BIGNUM * /*range*/);
 int PGPV_BN_is_prime(const PGPV_BIGNUM * /*a*/,
                      int /*checks*/,
                      void (*callback)(int, int, void *),
-                     PGPV_BN_CTX * /*ctx*/,
                      void * /*cb_arg*/);
 
 const PGPV_BIGNUM *PGPV_BN_value_one(void);
@@ -225,8 +199,7 @@ int                PGPV_BN_is_bit_set(const PGPV_BIGNUM * /*a*/, int /*n*/);
 
 int PGPV_BN_gcd(PGPV_BIGNUM * /*r*/,
                 PGPV_BIGNUM * /*a*/,
-                PGPV_BIGNUM * /*b*/,
-                PGPV_BN_CTX * /*ctx*/);
+                PGPV_BIGNUM * /*b*/);
 
 /**
  * \brief Allocates BIGNUM and mp value assigned

--- a/src/lib/bn.h
+++ b/src/lib/bn.h
@@ -146,9 +146,7 @@ int          PGPV_BN_print_fp(FILE * /*fp*/, const PGPV_BIGNUM * /*a*/);
 
 int PGPV_BN_add(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, const PGPV_BIGNUM * /*b*/);
 int PGPV_BN_sub(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, const PGPV_BIGNUM * /*b*/);
-int PGPV_BN_mul(PGPV_BIGNUM * /*r*/,
-                const PGPV_BIGNUM * /*a*/,
-                const PGPV_BIGNUM * /*b*/);
+int PGPV_BN_mul(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, const PGPV_BIGNUM * /*b*/);
 int PGPV_BN_div(PGPV_BIGNUM * /*q*/,
                 PGPV_BIGNUM * /*r*/,
                 const PGPV_BIGNUM * /*a*/,
@@ -197,9 +195,7 @@ int PGPV_BN_is_prime(const PGPV_BIGNUM * /*a*/,
 const PGPV_BIGNUM *PGPV_BN_value_one(void);
 int                PGPV_BN_is_bit_set(const PGPV_BIGNUM * /*a*/, int /*n*/);
 
-int PGPV_BN_gcd(PGPV_BIGNUM * /*r*/,
-                PGPV_BIGNUM * /*a*/,
-                PGPV_BIGNUM * /*b*/);
+int PGPV_BN_gcd(PGPV_BIGNUM * /*r*/, PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
 
 /**
  * \brief Allocates BIGNUM and mp value assigned


### PR DESCRIPTION
Was a stub to allow OpenSSL compat, but not really used anymore.

It's kind of telling that almost no code changes were required to handle the removal of the BN_CTX args - it looks like (now that ElGamal and co are not implemented via BN) the only BN functions actually in use are `BN_bn2bin`, `BN_bin2bn`, `BN_num_bytes`, `BN_num_bits`, and maybe one or two others. So maybe there is more pruning that can occur here.