### PR TITLE
Introduces --expert flag for rnpkeys (ex #241) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Upcoming supported platforms:
 
 ## Generating an RSA Private Key
 
-Only RSA key supported right now.
+By default ``rnpkeys  --generate-key`` will generate 2048-bit RSA key.
 
 ``` sh
 export keydir=/tmp
@@ -50,6 +50,36 @@ rnpkeys: generated keys in directory ${keydir}/6ed2d908150b82e7
 ```
 
 In case you're curious, `6ed2d...` is the key fingerprint.
+
+In order to use fully featured key pair generation ``--expert`` flag should be used. With this flag added to  ``rnpkeys --generate-key`` user has a possibility to generate keypair for any supported algorithm and/or key size.
+
+Example:
+
+``` sh
+> export keydir=/tmp
+> rnpkeys --generate-key --expert --homedir=${keydir}
+
+Please select what kind of key you want:
+    (1)  RSA (Encrypt or Sign)
+    (19) ECDSA
+    (22) EDDSA
+> 19
+
+Please select which elliptic curve you want:
+    (1) NIST P-256
+    (2) NIST P-384
+    (3) NIST P-521
+> 2
+
+Generating a new key...
+signature  384/ECDSA d45592277b75ada1 2017-06-21
+Key fingerprint: 4244 2969 07ca 42f7 b6d8 1636 d455 9227 7b75 ada1
+uid              ECDSA 384-bit key <flowher@localhost>
+rnp: generated keys in directory /tmp/.rnp
+Enter passphrase for d45592277b75ada1:
+Repeat passphrase for d45592277b75ada1:
+>
+```
 
 
 ## Listing Keys

--- a/include/rnp.h
+++ b/include/rnp.h
@@ -32,9 +32,7 @@
 #define RNP_H_
 
 #include <stddef.h>
-#include <sys/types.h>
-#include <packet.h>
-#include <symmetric.h>
+#include "packet.h"
 
 #ifndef __BEGIN_DECLS
 #if defined(__cplusplus)
@@ -75,6 +73,9 @@ typedef struct rnp_t {
     rnp_ctx_t ctx;     /* current operation context */
 
     enum keyring_format_t keyring_format; /* keyring format */
+    union {
+        rnp_keygen_desc_t generate_key_ctx;
+    } action;
 } rnp_t;
 
 /* begin and end */
@@ -97,6 +98,7 @@ int   rnp_setvar(rnp_t *, const char *, const char *);
 char *rnp_getvar(rnp_t *, const char *);
 int   rnp_incvar(rnp_t *, const char *, const int);
 int   rnp_unsetvar(rnp_t *, const char *);
+int findvar(rnp_t *rnp, const char *name);
 
 /* set keyring format information */
 int rnp_set_keyring_format(rnp_t *, char *);
@@ -112,7 +114,7 @@ int   rnp_find_key(rnp_t *, char *);
 char *rnp_get_key(rnp_t *, const char *, const char *);
 char *rnp_export_key(rnp_t *, char *);
 int   rnp_import_key(rnp_t *, char *);
-int   rnp_generate_key(rnp_t *, char *, int);
+int   rnp_generate_key(rnp_t *, const char *);
 
 /* file management */
 int rnp_encrypt_file(rnp_t *, const char *, const char *, char *);

--- a/src/cmocka/rnp_tests_cipher.c
+++ b/src/cmocka/rnp_tests_cipher.c
@@ -143,7 +143,12 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_pubkey_t *pub_rsa;
     const pgp_rsa_seckey_t *sec_rsa;
 
-    pgp_key = pgp_generate_keypair(PGP_PKA_RSA, 1024, NULL, "SHA-256", "AES-128");
+    const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_RSA,
+                                        .hash_alg = PGP_HASH_SHA256,
+                                        .sym_alg = PGP_SA_AES_128,
+                                        .rsa = {.modulus_bit_len = 1024}};
+    pgp_key = pgp_generate_keypair(&key_desc, NULL);
+
     assert_true(pgp_key != NULL);
     sec_key = pgp_get_seckey(pgp_key);
     pub_key = pgp_get_pubkey(pgp_key);
@@ -197,7 +202,9 @@ pkcs1_rsa_test_success(void **state)
 void
 rnp_test_eddsa(void **state)
 {
-    pgp_key_t *pgp_key = pgp_generate_keypair(PGP_PKA_EDDSA, 255, NULL, "SHA-256", "AES-128");
+    const rnp_keygen_desc_t key_desc = {
+      .key_alg = PGP_PKA_EDDSA, .hash_alg = PGP_HASH_SHA256, .sym_alg = PGP_SA_AES_128};
+    pgp_key_t *pgp_key = pgp_generate_keypair(&key_desc, NULL);
     assert_non_null(pgp_key);
 
     const uint8_t hash[32] = {0};
@@ -316,8 +323,13 @@ ECDSA_signverify_success(void **state)
     uint8_t       message[32];
     pgp_ecc_sig_t sig = {NULL, NULL};
 
-    pgp_key_t *pgp_key1 = pgp_generate_keypair(PGP_PKA_ECDSA, 256, NULL, "SHA256", "AES-128");
-    pgp_key_t *pgp_key2 = pgp_generate_keypair(PGP_PKA_ECDSA, 256, NULL, "SHA256", "AES-128");
+    const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_ECDSA,
+                                        .hash_alg = PGP_HASH_SHA256,
+                                        .sym_alg = PGP_SA_AES_128,
+                                        .ecc = {.curve = PGP_CURVE_NIST_P_256}};
+
+    pgp_key_t *pgp_key1 = pgp_generate_keypair(&key_desc, NULL);
+    pgp_key_t *pgp_key2 = pgp_generate_keypair(&key_desc, NULL);
     assert_int_not_equal(pgp_key1, NULL);
     assert_int_not_equal(pgp_key2, NULL);
 

--- a/src/cmocka/rnp_tests_exportkey.c
+++ b/src/cmocka/rnp_tests_exportkey.c
@@ -36,11 +36,10 @@ rnpkeys_exportkey_verifyUserId(void **state)
      * key
      * Verify the key was generated with the correct UserId.
      */
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
-    char *    exportedkey = NULL;
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
+    char *exportedkey = NULL;
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -58,7 +57,10 @@ rnpkeys_exportkey_verifyUserId(void **state)
     int retVal = rnp_init(&rnp);
     assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-    retVal = rnp_generate_key(&rnp, NULL, numbits);
+    rnp.action.generate_key_ctx.key_alg = PGP_PKA_RSA;
+    rnp.action.generate_key_ctx.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    rnp.action.generate_key_ctx.rsa.modulus_bit_len = 1024;
+    retVal = rnp_generate_key(&rnp, NULL);
     assert_int_equal(retVal, 1); // Ensure the key was generated.
 
     /*Load the newly generated rnp key*/

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -26,6 +26,15 @@
 
 #include <rnp.h>
 #include <rnp_tests_support.h>
+#include "symmetric.h"
+
+static void
+set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc)
+{
+    key_desc->key_alg = PGP_PKA_RSA;
+    key_desc->sym_alg = PGP_SA_DEFAULT_CIPHER;
+    key_desc->rsa.modulus_bit_len = 1024;
+}
 
 void
 rnpkeys_generatekey_testSignature(void **state)
@@ -37,12 +46,11 @@ rnpkeys_generatekey_testSignature(void **state)
      * key
      * Sign a message, then verify it
      */
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    char *    fdptr;
-    int       pipefd[2];
-    int       retVal;
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    char *fdptr;
+    int   pipefd[2];
+    int   retVal;
 
     char memToSign[] = "A simple test message";
     char signatureBuf[4096] = {0};
@@ -62,7 +70,8 @@ rnpkeys_generatekey_testSignature(void **state)
         strcpy(userId, "sigtest_");
         strcat(userId, hashAlg[i]);
 
-        retVal = rnp_generate_key(&rnp, userId, numbits);
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+        retVal = rnp_generate_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
         /*Load the newly generated rnp key*/
@@ -149,12 +158,11 @@ rnpkeys_generatekey_testEncryption(void **state)
                                "Camellia256",
                                NULL};
 
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    char *    fdptr;
-    int       pipefd[2];
-    int       retVal;
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    char *fdptr;
+    int   pipefd[2];
+    int   retVal;
 
     char memToEncrypt[] = "A simple test message";
     char ciphertextBuf[4096] = {0};
@@ -168,7 +176,8 @@ rnpkeys_generatekey_testEncryption(void **state)
 
     strcpy(userId, "ciphertest");
 
-    retVal = rnp_generate_key(&rnp, userId, numbits);
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+    retVal = rnp_generate_key(&rnp, userId);
     assert_int_equal(retVal, 1); // Ensure the key was generated
 
     /*Load the newly generated rnp key*/
@@ -236,10 +245,9 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
      * Execute the Generate-key command to generate a new pair of private/public
      * key
      * Verify the key was generated with the correct UserId.*/
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -258,7 +266,8 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
         int retVal = rnp_init(&rnp);
         assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-        retVal = rnp_generate_key(&rnp, NULL, numbits);
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+        retVal = rnp_generate_key(&rnp, NULL);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
         /*Load the newly generated rnp key*/
@@ -288,10 +297,9 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
      * Execute the Generate-key command to generate a new pair of private/public
      * key
      * Verify the key was generated with the correct UserId.*/
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -313,7 +321,8 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
         int retVal = rnp_init(&rnp);
         assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-        retVal = rnp_generate_key(&rnp, userId, numbits);
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+        retVal = rnp_generate_key(&rnp, userId);
         assert_int_equal(retVal, 1); // Ensure the key was generated
 
         /*Load the newly generated rnp key*/
@@ -335,10 +344,9 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
      * Execute the Generate-key command to generate a new pair of private/public
      * key
      * Verify the key was generated with the correct UserId.*/
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -360,7 +368,8 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     assert_false(path_file_exists(ourdir, ".rnp/secring.gpg", NULL));
 
     // Ensure the key was generated.
-    assert_int_equal(1, rnp_generate_key(&rnp, NULL, numbits));
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+    assert_int_equal(1, rnp_generate_key(&rnp, NULL));
 
     // pubring and secring should now exist
     assert_true(path_file_exists(ourdir, ".rnp/pubring.gpg", NULL));
@@ -395,7 +404,8 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     assert_false(path_file_exists(newhome, ".rnp/secring.gpg", NULL));
 
     // Ensure the key was generated.
-    assert_int_equal(1, rnp_generate_key(&rnp, "newhomekey", numbits));
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+    assert_int_equal(1, rnp_generate_key(&rnp, "newhomekey"));
 
     // pubring and secring should now exist
     assert_true(path_file_exists(newhome, ".rnp/pubring.gpg", NULL));
@@ -417,7 +427,6 @@ void
 rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
 {
     const char *ourdir = (char *) *state;
-    const int   numbits = 1024;
     char        passfd[4] = {0};
     int         pipefd[2];
     rnp_t       rnp;
@@ -458,7 +467,8 @@ rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
     rnp_setvar(&rnp, "pass-fd", uint_to_string(passfd, 4, pipefd[0], 10));
     assert_int_equal(1, rnp_init(&rnp));
     rnp_setvar(&rnp, "homedir", fakedir);
-    assert_int_equal(0, rnp_generate_key(&rnp, NULL, numbits));
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+    assert_int_equal(0, rnp_generate_key(&rnp, NULL));
     rnp_end(&rnp);
 }
 
@@ -471,10 +481,9 @@ rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state)
     paths_concat(nopermsdir, sizeof(nopermsdir), ourdir, "noperms", NULL);
     path_mkdir(0000, nopermsdir, NULL);
 
-    rnp_t     rnp;
-    const int numbits = 1024;
-    char      passfd[4] = {0};
-    int       pipefd[2];
+    rnp_t rnp;
+    char  passfd[4] = {0};
+    int   pipefd[2];
 
     /* Setup the pass phrase fd to avoid user-input*/
     assert_int_equal(setupPassphrasefd(pipefd), 1);
@@ -498,7 +507,8 @@ rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state)
     retVal = rnp_init(&rnp);
     assert_int_equal(retVal, 1); // Ensure the rnp core structure is correctly initialized.
 
-    retVal = rnp_generate_key(&rnp, NULL, numbits);
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
+    retVal = rnp_generate_key(&rnp, NULL);
     assert_int_equal(retVal, 0); // Ensure the key was NOT generated as the
                                  // directory has only list read permissions.
 

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -26,6 +26,7 @@
 #ifndef __RNP__UTILS_H__
 #define __RNP__UTILS_H__
 
+#define RNP_MSG(msg) (void) fprintf(stdout, msg);
 #define RNP_LOG(msg) (void) fprintf(stderr, "%s:%d:%s " msg "\n", __FILE__, __LINE__, __func__)
 
 #define CHECK(exp, val, err)                          \
@@ -36,5 +37,7 @@
             goto end;                                 \
         }                                             \
     } while (false)
+
+#define BITS_TO_BYTES(b) (((b) + (CHAR_BIT - 1)) / CHAR_BIT)
 
 #endif

--- a/src/lib/bn.c
+++ b/src/lib/bn.c
@@ -181,7 +181,7 @@ PGPV_BN_div(PGPV_BIGNUM *      dv,
             const PGPV_BIGNUM *d,
             PGPV_BN_CTX *      ctx)
 {
-    if ( (dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
+    if ((dv == NULL) || (rem == NULL) || (a == NULL) || (d == NULL)) {
         return 0;
     }
     USE_ARG(ctx);

--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -222,11 +222,9 @@ write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
         return pgp_write_mpi(output, key->key.dsa.p) &&
                pgp_write_mpi(output, key->key.dsa.q) &&
                pgp_write_mpi(output, key->key.dsa.g) && pgp_write_mpi(output, key->key.dsa.y);
-
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
         return (ec_serialize_pubkey(output, &key->key.ecc) == PGP_E_OK);
-
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -86,6 +86,31 @@ __RCSID("$NetBSD: crypto.c,v 1.36 2014/02/17 07:39:19 agc Exp $");
 #include "../common/utils.h"
 
 /**
+ * EC Curves definition used by implementation
+ *
+ * \see RFC4880 bis01 - 9.2. ECC Curve OID
+ *
+ * Order of the elements in this array corresponds to
+ * values in pgp_curve_t enum.
+ */
+// TODO: Check size of this array against PGP_CURVE_MAX with static assert
+const ec_curve_desc_t ec_curves[] = {
+  {PGP_CURVE_NIST_P_256,
+   256,
+   {0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07},
+   8,
+   "secp256r1",
+   "NIST P-256"},
+  {PGP_CURVE_NIST_P_384, 384, {0x2B, 0x81, 0x04, 0x00, 0x22}, 5, "secp384r1", "NIST P-384"},
+  {PGP_CURVE_NIST_P_521, 521, {0x2B, 0x81, 0x04, 0x00, 0x23}, 5, "secp521r1", "NIST P-521"},
+  {PGP_CURVE_ED25519,
+   255,
+   {0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01},
+   9,
+   "Ed25519",
+   "Curve 25519"}};
+
+/**
 \ingroup Core_MPI
 \brief Decrypt and unencode MPI
 \param buf Buffer in which to write decrypted unencoded MPI
@@ -200,11 +225,7 @@ pgp_elgamal_encrypt_mpi(const uint8_t *          encoded_m_buf,
 }
 
 pgp_key_t *
-pgp_generate_keypair(pgp_pubkey_alg_t alg,
-                     const int        alg_params,
-                     const uint8_t *  userid,
-                     const char *     hashalg,
-                     const char *     cipher)
+pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
 {
     pgp_seckey_t *seckey = NULL;
     pgp_output_t *output = NULL;
@@ -225,33 +246,19 @@ pgp_generate_keypair(pgp_pubkey_alg_t alg,
     seckey->pubkey.version = PGP_V4;
     seckey->pubkey.birthtime = time(NULL);
     seckey->pubkey.days_valid = 0;
-    seckey->pubkey.alg = alg;
-
-    if ((seckey->hash_alg = pgp_str_to_hash_alg(hashalg)) == PGP_HASH_UNKNOWN) {
-        // TODO: Shouldn't it be PGP_DEFAULT_HASH_ALGORITHM ?
-        seckey->hash_alg = PGP_HASH_SHA1;
-    }
+    seckey->pubkey.alg = key_desc->key_alg;
+    seckey->hash_alg =
+      (PGP_HASH_UNKNOWN == key_desc->hash_alg) ? PGP_HASH_SHA1 : key_desc->hash_alg;
 
     if (seckey->pubkey.alg == PGP_PKA_RSA || seckey->pubkey.alg == PGP_PKA_RSA_ENCRYPT_ONLY ||
         seckey->pubkey.alg == PGP_PKA_RSA_SIGN_ONLY) {
-        if (pgp_genkey_rsa(seckey, alg_params) != 1)
+        if (pgp_genkey_rsa(seckey, key_desc->rsa.modulus_bit_len) != 1)
             goto end;
     } else if (seckey->pubkey.alg == PGP_PKA_EDDSA) {
-        if (pgp_genkey_eddsa(seckey, alg_params) != 1)
+        if (pgp_genkey_eddsa(seckey, ec_curves[PGP_CURVE_ED25519].bitlen) != 1)
             goto end;
     } else if (seckey->pubkey.alg == PGP_PKA_ECDSA) {
-        // TODO: To be refactored with #130
-        seckey->pubkey.key.ecc.curve =
-          (alg_params == 256) ?
-            PGP_CURVE_NIST_P_256 :
-            (alg_params == 384) ? PGP_CURVE_NIST_P_384 : PGP_CURVE_NIST_P_521;
-
-        const pgp_curve_t curve = seckey->pubkey.key.ecc.curve;
-        seckey->hash_alg = (curve == PGP_CURVE_NIST_P_256) ?
-                             PGP_HASH_SHA256 :
-                             (curve == PGP_CURVE_NIST_P_384) ?
-                             PGP_HASH_SHA384 :
-                             /*(curve == PGP_CURVE_NIST_P_256 )*/ PGP_HASH_SHA512;
+        seckey->pubkey.key.ecc.curve = key_desc->ecc.curve;
         if (pgp_ecdsa_genkeypair(seckey, seckey->pubkey.key.ecc.curve) != PGP_E_OK)
             goto end;
     } else {
@@ -261,8 +268,8 @@ pgp_generate_keypair(pgp_pubkey_alg_t alg,
     seckey->s2k_usage = PGP_S2KU_ENCRYPTED_AND_HASHED;
     seckey->s2k_specifier = PGP_S2KS_ITERATED_AND_SALTED;
     seckey->s2k_iterations = pgp_s2k_round_iterations(65536);
-    seckey->alg = pgp_str_to_cipher(cipher);
-    pgp_random(&seckey->iv[0], pgp_block_size(seckey->alg));    
+    seckey->alg = key_desc->sym_alg;
+    pgp_random(&seckey->iv[0], pgp_block_size(seckey->alg));
     seckey->checksum = 0;
 
     if (pgp_keyid(

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -66,21 +66,15 @@
 #include "bn.h"
 
 #define PGP_MIN_HASH_SIZE 16
+#define MAX_CURVE_BYTELEN BITS_TO_BYTES(521) /* Length of NIST P-521 */
 
-#define BITS_TO_BYTES(b) (((b) + (CHAR_BIT - 1)) / CHAR_BIT)
-
-#define MAX_CURVE_BYTELEN BITS_TO_BYTES(521)  /* Length of NIST P-521 */
+#define NTAGS 0x100 /* == 256 */
 
 void pgp_crypto_finish(void);
 
 /* Key generation */
 
-pgp_key_t*
-pgp_generate_keypair(pgp_pubkey_alg_t   alg,
-                     const int          alg_params,
-                     const uint8_t*     userid,
-                     const char*        hashalg,
-                     const char*        cipher);
+pgp_key_t *pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);
@@ -172,7 +166,17 @@ typedef struct {
     uint8_t    keyid[PGP_KEY_ID_SIZE];
 } pgp_hashtype_t;
 
-#define NTAGS 0x100 /* == 256 */
+/**
+ * Structure holds description of elliptic curve
+ */
+typedef struct ec_curve_desc_t {
+    const pgp_curve_t rnp_curve_id;
+    const size_t      bitlen;
+    const uint8_t     OIDhex[MAX_CURVE_OID_HEX_LEN];
+    const size_t      OIDhex_len;
+    const char *      botan_name;
+    const char *      pgp_name;
+} ec_curve_desc_t;
 
 /** \brief Structure to hold information about a packet parse.
  *
@@ -195,7 +199,7 @@ typedef struct {
  *
  *  It has a linked list of errors.
  */
-
+// TODO: Shouldn't this be in some other place than crypto.h?
 struct pgp_stream_t {
     uint8_t ss_raw[NTAGS / 8];
     /* 1 bit / sig-subpkt type; set to get raw data */
@@ -219,5 +223,33 @@ struct pgp_stream_t {
     unsigned virtualoff;
     uint8_t *virtualpkt;
 };
+
+/* -----------------------------------------------------------------------------
+ * @brief   Finds curve ID by hex representation of OID
+ *
+ * @param   oid       buffer with OID in hex
+ * @param   oid_len   length of oid buffer
+ *
+ * @returns success curve ID
+ *          failure PGP_CURVE_MAX is returned
+ *
+ * @remarks see RFC 4880 bis 01 - 9.2 ECC Curve OID
+-------------------------------------------------------------------------------- */
+pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
+
+/* -----------------------------------------------------------------------------
+ * @brief   Serialize EC public to octet string
+ *
+ * @param   output      generated output
+ * @param   pubkey      initialized ECDSA public key
+ *
+ * @pre     output      must be not null
+ * @pre     pubkey      must be not null
+ *
+ * @returns success PGP_E_OK, error code otherwise
+ *
+ * @remarks see RFC 4880 bis 01 - 5.5.2 Public-Key Packet Formats
+-------------------------------------------------------------------------------- */
+pgp_errcode_t ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
 
 #endif /* CRYPTO_H_ */

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -36,28 +36,7 @@
 #include "rnpdefs.h"
 #include "../common/utils.h"
 
-/**
- * EC Curves definition used by implementation
- *
- * \see RFC4880 bis01 - 9.2. ECC Curve OID
- *
- * Order of the elements in this array corresponds to
- * values in pgp_curve_t enum.
- */
-// TODO: Check size of this array against PGP_CURVE_MAX with static assert
-const ec_curve_desc_t ec_curves[] = {
-  {PGP_CURVE_NIST_P_256,
-   256,
-   {0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07},
-   8,
-   "secp256r1"},
-  {PGP_CURVE_NIST_P_384, 384, {0x2B, 0x81, 0x04, 0x00, 0x22}, 5, "secp384r1"},
-  {PGP_CURVE_NIST_P_521, 521, {0x2B, 0x81, 0x04, 0x00, 0x23}, 5, "secp521r1"},
-  {PGP_CURVE_ED25519,
-   255,
-   {0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01},
-   9,
-   "Ed25519"}};
+extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
 
 pgp_curve_t
 find_curve_by_OID(const uint8_t *oid, size_t oid_len)
@@ -70,20 +49,6 @@ find_curve_by_OID(const uint8_t *oid, size_t oid_len)
     }
 
     return PGP_CURVE_MAX;
-}
-
-pgp_errcode_t
-ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
-{
-    const ec_curve_desc_t *curve = &ec_curves[pubkey->curve];
-
-    if (pgp_write_scalar(output, curve->OIDhex_len, 1) &&
-        pgp_write(output, curve->OIDhex, curve->OIDhex_len) &&
-        pgp_write_mpi(output, pubkey->point)) {
-        return PGP_E_OK;
-    }
-
-    return PGP_E_W_WRITE_FAILED;
 }
 
 pgp_errcode_t
@@ -301,4 +266,18 @@ end:
     botan_pubkey_destroy(pub);
     botan_pk_op_verify_destroy(verifier);
     return ret;
+}
+
+pgp_errcode_t
+ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
+{
+    const ec_curve_desc_t *curve = &ec_curves[pubkey->curve];
+
+    if (pgp_write_scalar(output, curve->OIDhex_len, 1) &&
+        pgp_write(output, curve->OIDhex, curve->OIDhex_len) &&
+        pgp_write_mpi(output, pubkey->point)) {
+        return PGP_E_OK;
+    }
+
+    return PGP_E_W_WRITE_FAILED;
 }

--- a/src/lib/ecdsa.h
+++ b/src/lib/ecdsa.h
@@ -34,34 +34,6 @@
 #include "packet.h"
 
 /* -----------------------------------------------------------------------------
- * @brief   Finds curve ID by hex representation of OID
- *
- * @param   oid       buffer with OID in hex
- * @param   oid_len   length of oid buffer
- *
- * @returns success curve ID
- *          failure PGP_CURVE_MAX is returned
- *
- * @remarks see RFC 4880 bis 01 - 9.2 ECC Curve OID
--------------------------------------------------------------------------------- */
-pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
-
-/* -----------------------------------------------------------------------------
- * @brief   Serialize ECDSA public to octet string
- *
- * @param   output      generated output
- * @param   pubkey      initialized ECDSA public key
- *
- * @pre     output      must be not null
- * @pre     pubkey      must be not null
- *
- * @returns success PGP_E_OK, error code otherwise
- *
- * @remarks see RFC 4880 bis 01 - 5.5.2 Public-Key Packet Formats
--------------------------------------------------------------------------------- */
-pgp_errcode_t ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
-
-/* -----------------------------------------------------------------------------
  * @brief   Generate ECDSA keypair
  *
  * @param   seckey[out] private part of the key

--- a/src/lib/eddsa.h
+++ b/src/lib/eddsa.h
@@ -37,23 +37,21 @@
 * curve_len must be 255 currently (for Ed25519)
 * If Ed448 was supported in the future curve_len=448 would also be allowed.
 */
-int pgp_genkey_eddsa(pgp_seckey_t* seckey, size_t numbits);
+int pgp_genkey_eddsa(pgp_seckey_t *seckey, size_t numbits);
 
 typedef struct DSA_SIG_st DSA_SIG;
 
-int pgp_eddsa_verify_hash(const BIGNUM* r,
-                          const BIGNUM* s,
+int pgp_eddsa_verify_hash(const BIGNUM *          r,
+                          const BIGNUM *          s,
                           const uint8_t *         hash,
                           size_t                  hash_len,
                           const pgp_ecc_pubkey_t *pubkey);
 
-
-int pgp_eddsa_sign_hash(BIGNUM* r,
-                        BIGNUM* s,
+int pgp_eddsa_sign_hash(BIGNUM *       r,
+                        BIGNUM *       s,
                         const uint8_t *hash,
                         size_t         hash_len,
                         const pgp_ecc_seckey_t *,
                         const pgp_ecc_pubkey_t *);
-
 
 #endif

--- a/src/lib/hash.h
+++ b/src/lib/hash.h
@@ -34,6 +34,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include "../common/utils.h"
 
 /** Hashing Algorithm Numbers.
  * OpenPGP assigns a unique Algorithm Number to each algorithm that is
@@ -44,10 +45,10 @@
  * \see RFC4880 9.4
  */
 typedef enum {
-    PGP_HASH_UNKNOWN = -1, /* used to indicate errors */
-    PGP_HASH_MD5 = 1,      /* MD5 */
-    PGP_HASH_SHA1 = 2,     /* SHA-1 */
-    PGP_HASH_RIPEMD = 3,   /* RIPEMD160 */
+    PGP_HASH_UNKNOWN = 0, /* used to indicate errors */
+    PGP_HASH_MD5 = 1,     /* MD5 */
+    PGP_HASH_SHA1 = 2,    /* SHA-1 */
+    PGP_HASH_RIPEMD = 3,  /* RIPEMD160 */
 
     PGP_HASH_SHA256 = 8,  /* SHA256 */
     PGP_HASH_SHA384 = 9,  /* SHA384 */

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -92,7 +92,6 @@ __RCSID("$NetBSD: packet-parse.c,v 1.51 2012/03/05 02:20:18 christos Exp $");
 #include "crypto.h"
 #include "rnpdigest.h"
 #include "s2k.h"
-#include "ecdsa.h"
 #include "../common/utils.h"
 
 #define ERRP(cbinfo, cont, err)                    \

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -354,7 +354,7 @@ numkeybits(const pgp_pubkey_t *pubkey)
         return ec_curves[pubkey->key.ecc.curve].bitlen;
 
     default:
-        (void)fprintf(stderr, "Unknown public key alg in numkeybits\n");
+        (void) fprintf(stderr, "Unknown public key alg in numkeybits\n");
         return -1;
     }
 }
@@ -623,7 +623,8 @@ pgp_sprint_keydata(pgp_io_t *             io,
 
     rnp_strhexdump(keyid, key->sigid, PGP_KEY_ID_SIZE, "");
 
-    rnp_strhexdump(fingerprint, key->sigfingerprint.fingerprint, key->sigfingerprint.length, " ");
+    rnp_strhexdump(
+      fingerprint, key->sigfingerprint.fingerprint, key->sigfingerprint.length, " ");
 
     ptimestr(birthtime, sizeof(birthtime), pubkey->birthtime);
 
@@ -726,9 +727,9 @@ pgp_sprint_json(pgp_io_t *             io,
                   subsigc_arr,
                   json_object_new_string((const char *) pgp_show_pka(key->enckey.alg)));
 
-                json_object_array_add(
-                  subsigc_arr,
-                  json_object_new_string(rnp_strhexdump(keyid, key->encid, PGP_KEY_ID_SIZE, "")));
+                json_object_array_add(subsigc_arr,
+                                      json_object_new_string(rnp_strhexdump(
+                                        keyid, key->encid, PGP_KEY_ID_SIZE, "")));
 
                 json_object_array_add(subsigc_arr,
                                       json_object_new_int((int64_t) key->enckey.birthtime));
@@ -807,23 +808,25 @@ pgp_hkp_sprint_keydata(pgp_io_t *             io,
               io, keyring, key->subsigs[j].sig.info.signer_id, &from, NULL);
             if (key->subsigs[j].sig.info.version == 4 &&
                 key->subsigs[j].sig.info.type == PGP_SIG_SUBKEY) {
-                n += snprintf(
-                  &uidbuf[n],
-                  sizeof(uidbuf) - n,
-                  "sub:%d:%d:%s:%lld:%lld\n",
-                  numkeybits(pubkey),
-                  key->subsigs[j].sig.info.key_alg,
-                  rnp_strhexdump(keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
-                  (long long) (key->subsigs[j].sig.info.birthtime),
-                  (long long) pubkey->duration);
+                n +=
+                  snprintf(&uidbuf[n],
+                           sizeof(uidbuf) - n,
+                           "sub:%d:%d:%s:%lld:%lld\n",
+                           numkeybits(pubkey),
+                           key->subsigs[j].sig.info.key_alg,
+                           rnp_strhexdump(
+                             keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
+                           (long long) (key->subsigs[j].sig.info.birthtime),
+                           (long long) pubkey->duration);
             } else {
-                n += snprintf(
-                  &uidbuf[n],
-                  sizeof(uidbuf) - n,
-                  "sig:%s:%lld:%s\n",
-                  rnp_strhexdump(keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
-                  (long long) key->subsigs[j].sig.info.birthtime,
-                  (trustkey) ? (char *) trustkey->uids[trustkey->uid0] : "");
+                n +=
+                  snprintf(&uidbuf[n],
+                           sizeof(uidbuf) - n,
+                           "sig:%s:%lld:%s\n",
+                           rnp_strhexdump(
+                             keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
+                           (long long) key->subsigs[j].sig.info.birthtime,
+                           (trustkey) ? (char *) trustkey->uids[trustkey->uid0] : "");
             }
         }
     }
@@ -904,8 +907,7 @@ pgp_print_pubkey(const pgp_pubkey_t *pubkey)
         print_bn(0, "y", pubkey->key.elgamal.y);
         break;
     case PGP_PKA_ECDSA:
-        print_string(0, "curve",
-            ec_curves[pubkey->key.ecc.curve].botan_name);
+        print_string(0, "curve", ec_curves[pubkey->key.ecc.curve].botan_name);
         print_bn(0, "public point", pubkey->key.ecc.point);
         break;
 
@@ -922,15 +924,16 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
     char fp[(PGP_FINGERPRINT_SIZE * 3) + 1];
     int  cc;
 
-    cc = snprintf(out,
-                  outsize,
-                  "key=%s\nname=%s\ncreation=%lld\nexpiry=%lld\nversion=%d\nalg=%d\n",
-                  rnp_strhexdump(fp, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE, ""),
-                  key->uids[key->uid0],
-                  (long long) key->key.pubkey.birthtime,
-                  (long long) key->key.pubkey.days_valid,
-                  key->key.pubkey.version,
-                  key->key.pubkey.alg);
+    cc =
+      snprintf(out,
+               outsize,
+               "key=%s\nname=%s\ncreation=%lld\nexpiry=%lld\nversion=%d\nalg=%d\n",
+               rnp_strhexdump(fp, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE, ""),
+               key->uids[key->uid0],
+               (long long) key->key.pubkey.birthtime,
+               (long long) key->key.pubkey.days_valid,
+               key->key.pubkey.version,
+               key->key.pubkey.alg);
     switch (key->key.pubkey.alg) {
     case PGP_PKA_DSA:
         cc += snprintf(&out[cc],
@@ -1726,7 +1729,7 @@ pgp_export_key(pgp_io_t *io, const pgp_key_t *keydata, uint8_t *passphrase)
     }
 
     const size_t mem_len = pgp_mem_len(mem) + 1;
-    if ((cp = (char *)malloc(mem_len)) == NULL){
+    if ((cp = (char *) malloc(mem_len)) == NULL) {
         pgp_teardown_memory_write(output, mem);
         return NULL;
     }

--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -215,7 +215,7 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_ECDSA, "ECDSA"},
   {PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN, "Reserved (formerly Elgamal Encrypt or Sign"},
   {PGP_PKA_RESERVED_DH, "Reserved for Diffie-Hellman (X9.42)"},
-  {PGP_PKA_EDDSA,     "EdDSA"},
+  {PGP_PKA_EDDSA, "EdDSA"},
   {PGP_PKA_PRIVATE00, "Private/Experimental"},
   {PGP_PKA_PRIVATE01, "Private/Experimental"},
   {PGP_PKA_PRIVATE02, "Private/Experimental"},

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1005,15 +1005,22 @@ typedef struct pgp_key_t {
     pgp_revoke_t      revocation;     /* revocation reason */
 } pgp_key_t;
 
-/**
- * Structure holds description of elliptic curve
- */
-typedef struct ec_curve_desc_t {
-    const pgp_curve_t rnp_curve_id;
-    const size_t      bitlen;
-    const uint8_t     OIDhex[MAX_CURVE_OID_HEX_LEN];
-    const size_t      OIDhex_len;
-    const char *      botan_name;
-} ec_curve_desc_t;
+/* structure used to hold context of key generation */
+typedef struct rnp_keygen_desc_t {
+    // Asymmteric algorithm that user requesed key for
+    pgp_pubkey_alg_t key_alg;
+    // Hash to be used for key signature
+    pgp_hash_alg_t hash_alg;
+    // Symmetric algorithm to be used for secret key encryption
+    pgp_symm_alg_t sym_alg;
+    union {
+        struct ecc_t {
+            pgp_curve_t curve;
+        } ecc;
+        struct rsa_t {
+            uint32_t modulus_bit_len;
+        } rsa;
+    };
+} rnp_keygen_desc_t;
 
 #endif /* PACKET_H_ */

--- a/src/lib/rsa.c
+++ b/src/lib/rsa.c
@@ -294,57 +294,51 @@ done:
     return retval;
 }
 
-int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits)
-   {
-   botan_privkey_t rsa_key = NULL;
-   botan_rng_t     rng = NULL;
-   int ret = 0;
+int
+pgp_genkey_rsa(pgp_seckey_t *seckey, size_t numbits)
+{
+    botan_privkey_t rsa_key = NULL;
+    botan_rng_t     rng = NULL;
+    int             ret = 0;
 
-   seckey->pubkey.key.rsa.n = BN_new();
-   seckey->pubkey.key.rsa.e = BN_new();
-   seckey->key.rsa.p = BN_new();
-   seckey->key.rsa.q = BN_new();
-   seckey->key.rsa.d = BN_new();
-   seckey->key.rsa.u = BN_new();
+    seckey->pubkey.key.rsa.n = BN_new();
+    seckey->pubkey.key.rsa.e = BN_new();
+    seckey->key.rsa.p = BN_new();
+    seckey->key.rsa.q = BN_new();
+    seckey->key.rsa.d = BN_new();
+    seckey->key.rsa.u = BN_new();
 
-   if(!seckey->pubkey.key.rsa.n ||
-      !seckey->pubkey.key.rsa.e ||
-      !seckey->key.rsa.p ||
-      !seckey->key.rsa.q ||
-      !seckey->key.rsa.d ||
-      !seckey->key.rsa.u)
-      {
-      goto end;
-      }
+    if (!seckey->pubkey.key.rsa.n || !seckey->pubkey.key.rsa.e || !seckey->key.rsa.p ||
+        !seckey->key.rsa.q || !seckey->key.rsa.d || !seckey->key.rsa.u) {
+        goto end;
+    }
 
-   if (botan_rng_init(&rng, NULL) != 0)
-      goto end;
+    if (botan_rng_init(&rng, NULL) != 0)
+        goto end;
 
-   if (botan_privkey_create_rsa(&rsa_key, rng, numbits) != 0)
-      goto end;
+    if (botan_privkey_create_rsa(&rsa_key, rng, numbits) != 0)
+        goto end;
 
-   if (botan_privkey_check_key(rsa_key, rng, 1) != 0)
-      goto end;
+    if (botan_privkey_check_key(rsa_key, rng, 1) != 0)
+        goto end;
 
-   /* Calls below never fail as calls above were OK */
-   (void) botan_privkey_rsa_get_n(seckey->pubkey.key.rsa.n->mp, rsa_key);
-   (void) botan_privkey_rsa_get_e(seckey->pubkey.key.rsa.e->mp, rsa_key);
-   (void) botan_privkey_rsa_get_d(seckey->key.rsa.d->mp, rsa_key);
-   (void) botan_privkey_rsa_get_p(seckey->key.rsa.p->mp, rsa_key);
-   (void) botan_privkey_rsa_get_q(seckey->key.rsa.q->mp, rsa_key);
+    /* Calls below never fail as calls above were OK */
+    (void) botan_privkey_rsa_get_n(seckey->pubkey.key.rsa.n->mp, rsa_key);
+    (void) botan_privkey_rsa_get_e(seckey->pubkey.key.rsa.e->mp, rsa_key);
+    (void) botan_privkey_rsa_get_d(seckey->key.rsa.d->mp, rsa_key);
+    (void) botan_privkey_rsa_get_p(seckey->key.rsa.p->mp, rsa_key);
+    (void) botan_privkey_rsa_get_q(seckey->key.rsa.q->mp, rsa_key);
 
-   if (botan_mp_mod_inverse(seckey->key.rsa.u->mp,
-                            seckey->key.rsa.p->mp,
-                            seckey->key.rsa.q->mp) != 0)
-      {
-      RNP_LOG("Error computing RSA u param");
-      goto end;
-      }
+    if (botan_mp_mod_inverse(
+          seckey->key.rsa.u->mp, seckey->key.rsa.p->mp, seckey->key.rsa.q->mp) != 0) {
+        RNP_LOG("Error computing RSA u param");
+        goto end;
+    }
 
-   ret = 1;
+    ret = 1;
 
-   end:
-   botan_privkey_destroy(rsa_key);
-   botan_rng_destroy(rng);
-   return ret;
-   }
+end:
+    botan_privkey_destroy(rsa_key);
+    botan_rng_destroy(rng);
+    return ret;
+}

--- a/src/lib/rsa.h
+++ b/src/lib/rsa.h
@@ -38,7 +38,7 @@
  * RSA encrypt/decrypt
  */
 
-int pgp_genkey_rsa(pgp_seckey_t* seckey, size_t numbits);
+int pgp_genkey_rsa(pgp_seckey_t *seckey, size_t numbits);
 
 int pgp_rsa_encrypt_pkcs1(uint8_t *               out,
                           size_t                  out_len,

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -223,7 +223,8 @@ ecdsa_sign(pgp_hash_t *            hash,
     pgp_ecc_sig_t sig = {NULL, NULL};
 
     const size_t curve_byte_size = BITS_TO_BYTES(ec_curves[pub_key->curve].bitlen);
-    if (curve_byte_size > pgp_hash_output_length(hash)) {
+    // "-2" because ECDSA on P-521 must work with SHA-512 digest
+    if (curve_byte_size - 2 > pgp_hash_output_length(hash)) {
         RNP_LOG("Message hash to small");
         return 0;
     }

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,8 @@ AM_CFLAGS		= $(WARNCFLAGS)
 
 bin_PROGRAMS		= rnpkeys
 
-rnpkeys_SOURCES	= rnpkeys.c
+rnpkeys_SOURCES	=   rnpkeys.c \
+                    tui.c
 
 rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include
 

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -1,0 +1,164 @@
+#include <stdbool.h>
+#include <crypto.h>
+
+extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
+
+/* -----------------------------------------------------------------------------
+ * @brief   Reads input from file pointer and converts it securelly to ints
+ *          Partially based on ERR34-C from SEI CERT C Coding Standarad
+ *
+ * @param   fp          pointer to opened pipe
+ * @param   result[out] result read from file pointer and converted to int
+ *
+ * @returns true and value in result if integer was parsed correctly,
+ *          otherwise false
+ *
+-------------------------------------------------------------------------------- */
+static bool
+rnp_secure_get_long_from_fd(const FILE *fp, long *result)
+{
+    char  buff[BUFSIZ];
+    char *end_ptr;
+    long  num_long;
+    bool  ret = false;
+
+    if (!result) {
+        goto end;
+    }
+
+    if (fgets(buff, sizeof(buff), stdin) == NULL) {
+        RNP_LOG("EOF or read error");
+        goto end;
+    } else {
+        errno = 0;
+        num_long = strtol(buff, &end_ptr, 10);
+
+        if (ERANGE == errno) {
+            RNP_LOG("Number out of range");
+            goto end;
+        } else if (end_ptr == buff) {
+            RNP_LOG("Invalid number");
+            goto end;
+        } else if ('\n' != *end_ptr && '\0' != *end_ptr) {
+            RNP_LOG("Unexpected end of line");
+            goto end;
+        }
+    }
+
+    *result = num_long;
+    ret = true;
+
+end:
+    return ret;
+}
+
+static bool
+is_rsa_keysize_supported(uint32_t keysize)
+{
+    return ((keysize >= 1024) && (keysize <= 4096) && !(keysize % 8));
+}
+
+static bool
+is_keygen_supported_for_alg(pgp_pubkey_alg_t id)
+{
+    switch (id) {
+    case PGP_PKA_RSA:
+    case PGP_PKA_ECDSA:
+    case PGP_PKA_EDDSA:
+        // Not yet really supported (at least key generation)
+        //
+        // case PGP_PKA_ECDH:
+        // case PGP_PKA_ELGAMAL:
+        // case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
+        // case PGP_PKA_DSA:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static long
+ask_curve()
+{
+    long result = 0;
+    bool ok = false;
+    do {
+        printf("Please select which elliptic curve you want:\n");
+        for (int i = 0; (i < PGP_CURVE_MAX) && (i != PGP_CURVE_ED25519); i++) {
+            printf("\t(%u) %s\n", i + 1, ec_curves[i].pgp_name);
+        }
+        printf("> ");
+        ok = rnp_secure_get_long_from_fd(stdin, &result);
+        ok &= (result > 0) && (result < PGP_CURVE_MAX);
+    } while (!ok);
+
+    return result - 1;
+}
+
+static long
+ask_algorithm()
+{
+    long result = 0;
+    do {
+        printf("Please select what kind of key you want:\n"
+               "\t(1)  RSA (Encrypt or Sign)\n"
+               // "\t(18) ECDH\n"
+               "\t(19) ECDSA\n"
+               "\t(22) EDDSA\n"
+               "> ");
+
+    } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
+             !is_keygen_supported_for_alg(result));
+    return result;
+}
+
+static long
+ask_bitlen()
+{
+    long result = 0;
+    do {
+        printf("Please provide bit length of the key (between 1024 and 4096):\n> ");
+    } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
+             !is_rsa_keysize_supported(result));
+    return result;
+}
+
+/* -----------------------------------------------------------------------------
+ * @brief   Asks user for details needed for the key to be generated (currently
+ *          key type and key length only)
+ *          This function should explicitly ask user for all details (not use
+ *          rnp_getvar or getenv).
+ *
+ * @param   rnp [in]  Initialized rnp_t struture.
+ *              [out] Function fills corresponding to key type and length
+ *
+ * @returns PGP_E_OK on success
+ *          PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG algorithm not supported
+ *
+-------------------------------------------------------------------------------- */
+pgp_errcode_t
+rnp_generate_key_expert_mode(rnp_t *rnp)
+{
+    rnp->action.generate_key_ctx.key_alg = (pgp_pubkey_alg_t) ask_algorithm();
+
+    // get more details about the key
+    switch (rnp->action.generate_key_ctx.key_alg) {
+    case PGP_PKA_RSA:
+        // Those algorithms must _NOT_ be supported
+        //  case PGP_PKA_RSA_ENCRYPT_ONLY:
+        //  case PGP_PKA_RSA_SIGN_ONLY:
+        rnp->action.generate_key_ctx.rsa.modulus_bit_len = ask_bitlen();
+        break;
+    case PGP_PKA_ECDH:
+    case PGP_PKA_ECDSA:
+        rnp->action.generate_key_ctx.ecc.curve = (pgp_curve_t) ask_curve();
+        break;
+    case PGP_PKA_EDDSA:
+        rnp->action.generate_key_ctx.ecc.curve = PGP_CURVE_ED25519;
+        break;
+    default:
+        return PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG;
+    }
+
+    return PGP_E_OK;
+}


### PR DESCRIPTION
Introduces --expert flag for rnpkeys. This flag can be used if user want's to generate key different than default (RSA/2048). In such case rnpkeys will ask user for kind of key/size he wants to generate. Currently only RSA, ECDSA and EDDSA is supported.

I propose we introduce structure that can be used for passing complete set of parameters needed for key generation (currently this structure is used to pass number of bits or curve name).

Patch contains also some small improvements for EC key generation (moves some function from ecdsa.c to crypto.c)

#130