### PR TITLE
Fixes bug introduced in commit 8c3031d

### DIFF
--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -94,7 +94,7 @@ ask_curve()
     } while (!ok);
 
     if (ok) {
-        result = (pgp_curve_t) val;
+        result = (pgp_curve_t) (val - 1);
     }
 
     return result;

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -94,7 +94,7 @@ ask_curve()
     } while (!ok);
 
     if (ok) {
-        result = (pgp_curve_t) (val - 1);
+        result = (pgp_curve_t)(val - 1);
     }
 
     return result;


### PR DESCRIPTION
``rnpkeys`` uses wrong curve size for generating ECDSA keys