### PR TITLE
Ensure data provided in expert mode key generation are correctly parsed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - BOTAN_INSTALL="$HOME/builds/botan-install"
     - CMOCKA_INSTALL="$HOME/builds/cmocka-install"
-    - JSON_C_INSTALL="$HOME/builds/json-c-install"
+    - JSONC_INSTALL="$HOME/builds/jsonc-install"
     - LOGNAME="Travis"
     - CLANG_FORMAT_DIFF="clang-format-diff-4.0"
 
@@ -44,7 +44,7 @@ cache:
   directories:
     - "$BOTAN_INSTALL"
     - "$CMOCKA_INSTALL"
-    - "$JSON_C_INSTALL"
+    - "$JSONC_INSTALL"
 
 install:
   - ./ci/install.sh

--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -93,7 +93,7 @@ git clone https://github.com/riboseinc/rnp
 cd rnp
 export BOTAN_INSTALL="$HOME/builds/botan-install"
 export CMOCKA_INSTALL="$HOME/builds/cmocka-install"
-export JSON_C_INSTALL="$HOME/builds/json-c-install"
+export JSONC_INSTALL="$HOME/builds/json-c-install"
 export BUILD_MODE=normal
 ci/install.sh
 env CC=clang ci/main.sh

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -27,13 +27,13 @@ if [ ! -e "${CMOCKA_INSTALL}/lib/libcmocka.so" ]; then
 fi
 
 # json-c
-if [ ! -e "${JSON_C_INSTALL}/lib/libjson-c.so" ]; then
+if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ]; then
   mkdir ~/builds/json-c
   cd ~/builds/json-c
   wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz -O json-c.tar.gz
   tar xzf json-c.tar.gz --strip 1
 
-  ./configure --prefix="${JSON_C_INSTALL}"
+  ./configure --prefix="${JSONC_INSTALL}"
   make -j${CORES} install
 fi
 

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -5,9 +5,9 @@ set -eux
 
 CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
 
-LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSON_C_INSTALL}/lib"
-LDFLAGS="-L${CMOCKA_INSTALL}/lib -L${JSON_C_INSTALL}/lib -ljson-c"
-CFLAGS="-I${CMOCKA_INSTALL}/include -I${JSON_C_INSTALL}/include/json-c"
+LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib"
+LDFLAGS="-L${CMOCKA_INSTALL}/lib"
+CFLAGS="-I${CMOCKA_INSTALL}/include"
 
 [ "$BUILD_MODE" = "coverage" ] && CFLAGS+=" -O0 --coverage"
 
@@ -23,7 +23,7 @@ CFLAGS="-I${CMOCKA_INSTALL}/include -I${JSON_C_INSTALL}/include/json-c"
 export LD_LIBRARY_PATH CFLAGS LDFLAGS
 
 autoreconf -vfi
-./configure --with-botan=${BOTAN_INSTALL}
+./configure --with-botan=${BOTAN_INSTALL} --with-jsonc=${JSONC_INSTALL}
 make clean
 make -j${CORES}
 

--- a/configure.ac
+++ b/configure.ac
@@ -79,9 +79,8 @@ AC_CHECK_HEADERS([sys/cdefs.h sys/file.h sys/mman.h sys/param.h \
 AC_CHECK_HEADERS([bzlib.h],
                  [],
                  [AC_MSG_FAILURE([missing <bzlib.h>; is bzip2 installed?])])
-AC_CHECK_HEADERS([json.h],,
-  [AC_MSG_FAILURE([missing <json.h>; is json-c installed?])]
-)
+
+AX_CHECK_JSONC([], AC_MSG_ERROR([missing json-c library]))
 
 # Checks for typedefs, structures, and compiler characteristics.
 #
@@ -111,8 +110,6 @@ AX_CHECK_BOTAN_DEFINES([CFLAGS="$CFLAGS $BOTAN_INCLUDES"
 AC_SEARCH_LIBS([_cmocka_run_group_tests], [cmocka],,AC_MSG_ERROR(CMocka not found!))
 AC_SEARCH_LIBS([gzopen], [z],,AC_MSG_ERROR(libz not found!))
 AC_SEARCH_LIBS([BZ2_bzDecompress], [bz2],,AC_MSG_ERROR(Libbz2 not found!))
-AC_SEARCH_LIBS([json_object_new_object], [json-c],,AC_MSG_ERROR(json-c not found!))
-
 
 # Initialize the testsuite
 #

--- a/include/rnp.h
+++ b/include/rnp.h
@@ -79,8 +79,8 @@ typedef struct rnp_t {
 } rnp_t;
 
 /* begin and end */
-int rnp_init(rnp_t *);
-int rnp_end(rnp_t *);
+int  rnp_init(rnp_t *);
+void rnp_end(rnp_t *);
 
 /* init, reset and free rnp operation context */
 int  rnp_ctx_init(rnp_ctx_t *);

--- a/include/rnp.h
+++ b/include/rnp.h
@@ -62,15 +62,15 @@ typedef struct rnp_ctx_t {
 
 /* structure used to hold (key,value) pair information */
 typedef struct rnp_t {
-    unsigned  c;       /* # of elements used */
-    unsigned  size;    /* size of array */
-    char **   name;    /* key names */
-    char **   value;   /* value information */
-    void *    pubring; /* public key ring */
-    void *    secring; /* s3kr1t key ring */
-    void *    io;      /* the io struct for results/errs */
-    void *    passfp;  /* file pointer for password input */
-    rnp_ctx_t ctx;     /* current operation context */
+    unsigned  c;             /* # of elements used */
+    unsigned  size;          /* size of array */
+    char **   name;          /* key names */
+    char **   value;         /* value information */
+    void *    pubring;       /* public key ring */
+    void *    secring;       /* s3kr1t key ring */
+    void *    io;            /* the io struct for results/errs */
+    void *    user_input_fp; /* file pointer for password input */
+    rnp_ctx_t ctx;           /* current operation context */
 
     enum key_store_format_t key_store_format; /* keyring format */
     union {

--- a/m4/ax_check_jsonc.m4
+++ b/m4/ax_check_jsonc.m4
@@ -1,0 +1,117 @@
+# SYNOPSIS
+#
+#   AX_CHECK_JSONC([action-if-found[, action-if-not-found]])
+#
+# DESCRIPTION
+#
+#   Look for json-c in a number of default spots, or in a user-selected
+#   spot (via --with-jsonc).  Sets
+#
+#     JSONC_INCLUDES to the include directives required
+#     JSONC_LIBS to the -l directives required
+#     JSONC_LDFLAGS to the -L or -R flags required
+#
+#   and calls ACTION-IF-FOUND or ACTION-IF-NOT-FOUND appropriately
+#
+#   This macro sets JSONC_INCLUDES such that source files should include
+#   json.h like so:
+#
+#     #include <json.h>
+#
+# LICENSE
+# Based on
+#     https://www.gnu.org/software/autoconf-archive/ax_check_jsonc.html
+#
+#   Copyright (c) 2009,2010 Zmanda Inc. <http://www.zmanda.com/>
+#   Copyright (c) 2009,2010 Dustin J. Mitchell <dustin@zmanda.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+AU_ALIAS([CHECK_JSONC], [AX_CHECK_JSONC])
+AC_DEFUN([AX_CHECK_JSONC], [
+    found=false
+    AC_ARG_WITH([jsonc],
+        [AS_HELP_STRING([--with-jsonc=DIR],
+            [root of the json-c directory])],
+        [
+            case "$withval" in
+            "" | y | ye | yes | n | no)
+            AC_MSG_ERROR([Invalid --with-jsonc value])
+              ;;
+            *) jsoncdirs="$withval"
+              ;;
+            esac
+        ], [
+            # if pkg-config is installed and jsonc has installed a .pc file,
+            # then use that information and don't search jsoncdirs
+            AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
+            if test x"$PKG_CONFIG" != x""; then
+                JSONC_LDFLAGS=`$PKG_CONFIG json-c --libs-only-L 2>/dev/null`
+                if test $? = 0; then
+                    JSONC_LIBS=`$PKG_CONFIG json-c --libs-only-l 2>/dev/null`
+                    JSONC_INCLUDES=`$PKG_CONFIG json-c --cflags-only-I 2>/dev/null`
+                    found=true
+                fi
+            fi
+
+            # no such luck; use some default jsoncdirs
+            if ! $found; then
+                jsoncdirs="/usr/local/json-c /usr/lib/json-c /usr/json-c /usr/pkg /usr/local /usr"
+            fi
+        ]
+        )
+
+
+    if ! $found; then
+        JSONC_INCLUDES=
+        for jsoncdir in $jsoncdirs; do
+            AC_MSG_CHECKING([for json.h in $jsoncdir])
+            if test -f "$jsoncdir/include/json-c/json.h"; then
+                JSONC_INCLUDES="-I$jsoncdir/include/json-c"
+                JSONC_LDFLAGS="-L$jsoncdir/lib"
+                JSONC_LIBS="-ljson-c"
+                found=true
+                AC_MSG_RESULT([yes])
+                break
+            else
+                AC_MSG_RESULT([no])
+            fi
+        done
+
+        # if the file wasn't found, well, go ahead and try the link anyway -- maybe
+        # it will just work!
+    fi
+
+    # try the preprocessor and linker with our new flags,
+    # being careful not to pollute the global LIBS, LDFLAGS, and CPPFLAGS
+
+    AC_MSG_CHECKING([whether compiling and linking against json-c works])
+    echo "Trying link with JSONC_LDFLAGS=$JSONC_LDFLAGS;" \
+        "JSONC_LIBS=$JSONC_LIBS; JSONC_INCLUDES=$JSONC_INCLUDES" >&AS_MESSAGE_LOG_FD
+
+    save_LIBS="$LIBS"
+    save_LDFLAGS="$LDFLAGS"
+    save_CPPFLAGS="$CPPFLAGS"
+    LDFLAGS="$LDFLAGS $JSONC_LDFLAGS"
+    LIBS="$JSONC_LIBS $LIBS"
+    CPPFLAGS="$JSONC_INCLUDES $CPPFLAGS"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([#include <json.h>], [json_object_new_object()])],
+        [
+            AC_MSG_RESULT([yes])
+            $1
+        ], [
+            AC_MSG_RESULT([no])
+            $2
+        ])
+    CPPFLAGS="$save_CPPFLAGS"
+    LDFLAGS="$save_LDFLAGS"
+    LIBS="$save_LIBS"
+
+    AC_SUBST([JSONC_INCLUDES])
+    AC_SUBST([JSONC_LIBS])
+    AC_SUBST([JSONC_LDFLAGS])
+])

--- a/src/cmocka/Makefile.am
+++ b/src/cmocka/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS		    = $(WARNCFLAGS)
 bin_PROGRAMS		= rnp_tests
-rnp_tests_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+rnp_tests_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
 rnp_tests_LDADD		= ../lib/librnp.la ../rnpkeys/librnpkeys.la $(JSON_LIBS)
 rnp_tests_SOURCES   = \
     rnp_tests_support.c \

--- a/src/cmocka/Makefile.am
+++ b/src/cmocka/Makefile.am
@@ -1,9 +1,10 @@
-AM_CFLAGS		= $(WARNCFLAGS)
-
+AM_CFLAGS		    = $(WARNCFLAGS)
 bin_PROGRAMS		= rnp_tests
-
-rnp_tests_SOURCES		= rnp_tests_support.c rnp_tests_cipher.c rnp_tests_generatekey.c rnp_tests_exportkey.c rnp_tests.c
-
-rnp_tests_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
-
-rnp_tests_LDADD		= ../lib/librnp.la $(JSONC_LIBS)
+rnp_tests_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
+rnp_tests_LDADD		= ../lib/librnp.la ../rnpkeys/librnpkeys.la $(JSON_LIBS)
+rnp_tests_SOURCES   = \
+    rnp_tests_support.c \
+    rnp_tests_cipher.c \
+    rnp_tests_generatekey.c \
+    rnp_tests_exportkey.c \
+    rnp_tests.c

--- a/src/cmocka/Makefile.am
+++ b/src/cmocka/Makefile.am
@@ -4,6 +4,6 @@ bin_PROGRAMS		= rnp_tests
 
 rnp_tests_SOURCES		= rnp_tests_support.c rnp_tests_cipher.c rnp_tests_generatekey.c rnp_tests_exportkey.c rnp_tests.c
 
-rnp_tests_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+rnp_tests_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
 
-rnp_tests_LDADD		= ../lib/librnp.la $(JSON_LIBS)
+rnp_tests_LDADD		= ../lib/librnp.la $(JSONC_LIBS)

--- a/src/cmocka/Makefile.am
+++ b/src/cmocka/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS		    = $(WARNCFLAGS)
 bin_PROGRAMS		= rnp_tests
-rnp_tests_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
+rnp_tests_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
 rnp_tests_LDADD		= ../lib/librnp.la ../rnpkeys/librnpkeys.la $(JSON_LIBS)
 rnp_tests_SOURCES   = \
     rnp_tests_support.c \

--- a/src/cmocka/rnp_tests.c
+++ b/src/cmocka/rnp_tests.c
@@ -107,7 +107,7 @@ main(void)
       cmocka_unit_test(rnpkeys_generatekey_verifykeyNonexistingHomeDir),
       cmocka_unit_test(rnpkeys_generatekey_verifykeyHomeDirNoPermission),
       cmocka_unit_test(rnpkeys_exportkey_verifyUserId),
-    };
+      cmocka_unit_test(rnpkeys_generatekey_testExpertMode)};
 
     /* Each test entry will invoke setup_test before running
      * and teardown_test after running. */

--- a/src/cmocka/rnp_tests.h
+++ b/src/cmocka/rnp_tests.h
@@ -64,6 +64,8 @@ void raw_elg_test_success(void **state);
 
 void ecdsa_signverify_success(void **state);
 
+void rnpkeys_generatekey_testExpertMode(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     {                                               \
         int _rnp_a = (a);                           \

--- a/src/cmocka/rnp_tests.h
+++ b/src/cmocka/rnp_tests.h
@@ -67,59 +67,59 @@ void ecdsa_signverify_success(void **state);
 void rnpkeys_generatekey_testExpertMode(void **state);
 
 #define rnp_assert_int_equal(state, a, b)           \
-    {                                               \
+    do {                                            \
         int _rnp_a = (a);                           \
         int _rnp_b = (b);                           \
         if (state->not_fatal && _rnp_a != _rnp_b) { \
             return;                                 \
         }                                           \
         assert_int_equal(_rnp_a, _rnp_b);           \
-    }
+    } while (0)
 
 #define rnp_assert_int_not_equal(state, a, b)       \
-    {                                               \
+    do {                                            \
         int _rnp_a = (a);                           \
         int _rnp_b = (b);                           \
         if (state->not_fatal && _rnp_a == _rnp_b) { \
             return;                                 \
         }                                           \
         assert_int_not_equal(_rnp_a, _rnp_b);       \
-    }
+    } while (0)
 
 #define rnp_assert_true(state, a)          \
-    {                                      \
+    do {                                   \
         int _rnp_a = (a);                  \
         if (state->not_fatal && !_rnp_a) { \
             return;                        \
         }                                  \
         assert_true(_rnp_a);               \
-    }
+    } while (0)
 
 #define rnp_assert_false(state, a)        \
-    {                                     \
+    do {                                  \
         int _rnp_a = (a);                 \
         if (state->not_fatal && _rnp_a) { \
             return;                       \
         }                                 \
         assert_false(_rnp_a);             \
-    }
+    } while (0)
 
 #define rnp_assert_non_null(state, a)             \
-    {                                             \
+    do {                                          \
         void *_rnp_a = (void *) (a);              \
         if (state->not_fatal && _rnp_a == NULL) { \
             return;                               \
         }                                         \
         assert_non_null(_rnp_a);                  \
-    }
+    } while (0)
 
 #define rnp_assert_null(state, a)                 \
-    {                                             \
+    do {                                          \
         void *_rnp_a = (void *) (a);              \
         if (state->not_fatal && _rnp_a != NULL) { \
             return;                               \
         }                                         \
         assert_null(_rnp_a);                      \
-    }
+    } while (0)
 
 #endif // RNP_KEY_STORE_KBX_H

--- a/src/cmocka/rnp_tests_exportkey.c
+++ b/src/cmocka/rnp_tests_exportkey.c
@@ -84,6 +84,5 @@ rnpkeys_exportkey_verifyUserId(void **state)
     rnp_assert_null(rstate, exportedkey);
     free(exportedkey);
 
-    rnp_assert_int_equal(
-      rstate, 1, rnp_end(&rnp)); // Free memory and other allocated resources.
+    rnp_end(&rnp); // Free memory and other allocated resources.
 }

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -87,7 +87,7 @@ rnpkeys_generatekey_testSignature(void **state)
         rnp_assert_int_equal(rstate, retVal, 1); // Ensure the key can be found with the userId
 
         close(pipefd[0]);
-        rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+        rnp_end(&rnp);
 
         for (unsigned int cleartext = 0; cleartext <= 1; ++cleartext) {
             for (unsigned int armored = 0; armored <= 1; ++armored) {
@@ -125,7 +125,7 @@ rnpkeys_generatekey_testSignature(void **state)
                   rstate, retVal, 0); // Ensure signature operation succeeded
                 const int sigLen = retVal;
                 close(pipefd[0]);
-                rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+                rnp_end(&rnp);
 
                 /* Setup rnp again and load keyring. Passphrase is not needed */
                 rnp_assert_int_equal(
@@ -151,7 +151,7 @@ rnpkeys_generatekey_testSignature(void **state)
                   &rnp, signatureBuf, sigLen, recoveredSig, sizeof(recoveredSig), armored);
                 /* Ensure that signature verification fails */
                 rnp_assert_int_equal(rstate, retVal, 0);
-                rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+                rnp_end(&rnp);
             }
         }
     }
@@ -206,7 +206,7 @@ rnpkeys_generatekey_testEncryption(void **state)
     retVal = rnp_find_key(&rnp, userId);
     rnp_assert_int_equal(rstate, retVal, 1); // Ensure the key can be found with the userId
 
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 
     for (int i = 0; cipherAlg[i] != NULL; i++) {
         for (unsigned int armored = 0; armored <= 1; ++armored) {
@@ -232,7 +232,7 @@ rnpkeys_generatekey_testEncryption(void **state)
             rnp_assert_int_not_equal(
               rstate, retVal, 0); // Ensure encryption operation succeeded
             const int ctextLen = retVal;
-            rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+            rnp_end(&rnp);
 
             /* setting up rnp again and decrypting memory */
             rnp_assert_int_equal(rstate, setupPassphrasefd(pipefd), 1);
@@ -252,7 +252,7 @@ rnpkeys_generatekey_testEncryption(void **state)
             rnp_assert_int_equal(rstate, retVal, strlen(memToEncrypt));
             assert_string_equal(memToEncrypt, plaintextBuf);
             close(pipefd[0]);
-            rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+            rnp_end(&rnp);
         }
     }
 }
@@ -311,8 +311,7 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
               rnp_find_key(&rnp,
                            getenv("LOGNAME"))); // Ensure the key can be found with the userId
 
-            rnp_assert_int_equal(
-              rstate, 1, rnp_end(&rnp)); // Free memory and other allocated resources.
+            rnp_end(&rnp); // Free memory and other allocated resources.
         }
     }
 }
@@ -373,8 +372,7 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
               1,
               rnp_find_key(&rnp, userId)); // Ensure the key can be found with the userId
 
-            rnp_assert_int_equal(
-              rstate, 1, rnp_end(&rnp)); // Free memory and other allocated resources.
+            rnp_end(&rnp); // Free memory and other allocated resources.
         }
     }
 }
@@ -418,7 +416,7 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
 
     rnp_assert_int_equal(rstate, 1, rnp_load_keys(&rnp));
     rnp_assert_int_equal(rstate, 1, rnp_find_key(&rnp, getenv("LOGNAME")));
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 
     // Now we start over with a new home.
     memset(&rnp, 0, sizeof(rnp));
@@ -460,8 +458,7 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
     // We should find this key, instead.
     rnp_assert_int_equal(rstate, 1, rnp_find_key(&rnp, "newhomekey"));
 
-    rnp_assert_int_equal(
-      rstate, 1, rnp_end(&rnp)); // Free memory and other allocated resources.
+    rnp_end(&rnp); // Free memory and other allocated resources.
 }
 
 void
@@ -508,7 +505,7 @@ rnpkeys_generatekey_verifykeyKBXHomeDirOption(void **state)
 
     rnp_assert_int_equal(rstate, 1, rnp_load_keys(&rnp));
     rnp_assert_int_equal(rstate, 1, rnp_find_key(&rnp, getenv("LOGNAME")));
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 
     // Now we start over with a new home.
     memset(&rnp, 0, sizeof(rnp));
@@ -554,8 +551,7 @@ rnpkeys_generatekey_verifykeyKBXHomeDirOption(void **state)
     // We should find this key, instead.
     rnp_assert_int_equal(rstate, 1, rnp_find_key(&rnp, "newhomekey"));
 
-    rnp_assert_int_equal(
-      rstate, 1, rnp_end(&rnp)); // Free memory and other allocated resources.
+    rnp_end(&rnp); // Free memory and other allocated resources.
 }
 
 void
@@ -575,14 +571,14 @@ rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
     // First, make sure init succeeds with the default (using $HOME)
     memset(&rnp, '\0', sizeof(rnp));
     rnp_assert_int_equal(rstate, 1, rnp_init(&rnp));
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 
     /****************************************************************/
     // Ensure it fails when we set an invalid "homedir"
     memset(&rnp, '\0', sizeof(rnp));
     rnp_setvar(&rnp, "homedir", fakedir);
     rnp_assert_int_equal(rstate, 0, rnp_init(&rnp));
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 
     /****************************************************************/
     // Ensure it fails when we do not explicitly set "homedir" and
@@ -592,7 +588,7 @@ rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
     rnp_assert_int_equal(rstate, 0, rnp_init(&rnp));
     // Restore our original $HOME.
     rnp_assert_int_equal(rstate, 0, setenv("HOME", ourdir, 1));
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 
     /****************************************************************/
     // Ensure key generation fails when we set an invalid "homedir"
@@ -605,7 +601,7 @@ rnpkeys_generatekey_verifykeyNonexistingHomeDir(void **state)
     rnp_setvar(&rnp, "homedir", fakedir);
     set_default_rsa_key_desc(&rnp.action.generate_key_ctx);
     rnp_assert_int_equal(rstate, 0, rnp_generate_key(&rnp, NULL));
-    rnp_assert_int_equal(rstate, 1, rnp_end(&rnp));
+    rnp_end(&rnp);
 }
 
 void
@@ -649,8 +645,7 @@ rnpkeys_generatekey_verifykeyHomeDirNoPermission(void **state)
     rnp_assert_int_equal(rstate, retVal, 0); // Ensure the key was NOT generated as the
                                              // directory has only list read permissions.
 
-    rnp_assert_int_equal(
-      rstate, 1, rnp_end(&rnp)); // Free memory and other allocated resources.
+    rnp_end(&rnp); // Free memory and other allocated resources.
 }
 
 static void

--- a/src/cmocka/rnp_tests_generatekey.c
+++ b/src/cmocka/rnp_tests_generatekey.c
@@ -672,30 +672,6 @@ ask_expert_details(rnp_t *ctx, const char *rsp, size_t rsp_len)
     close(pipefd[0]);
 }
 
-static void
-ask_expert_details(rnp_t *ctx, const char *rsp, size_t rsp_len)
-{
-    int pipefd[2] = {0};
-
-    /* Write response to fd */
-    assert_int_not_equal(pipe(pipefd), -1);
-    for (int i = 0; i < rsp_len;) {
-        i += write(pipefd[1], rsp + i, rsp_len - i);
-    }
-    close(pipefd[1]);
-
-    /* Mock user-input*/
-    ctx->user_input_fp = fdopen(pipefd[0], "r");
-
-    /* Run tests*/
-    rnp_generate_key_expert_mode(ctx);
-
-    /* Close & clean fd*/
-    fclose(ctx->user_input_fp);
-    ctx->user_input_fp = NULL;
-    close(pipefd[0]);
-}
-
 void
 rnpkeys_generatekey_testExpertMode(void **state)
 {

--- a/src/fuzzing/Makefile.am
+++ b/src/fuzzing/Makefile.am
@@ -4,6 +4,6 @@ bin_PROGRAMS		= fuzz_keys
 
 fuzz_keys_SOURCES		= fuzz_keys.c
 
-fuzz_keys_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+fuzz_keys_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
 
 fuzz_keys_LDADD		= ../lib/librnp.la

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,8 +1,8 @@
 ## $NetBSD: Makefile.am,v 1.10 2010/11/29 06:21:40 agc Exp $
 
-AM_CFLAGS		= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSON_CFLAGS)
+AM_CFLAGS		= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSONC_INCLUDES)
 
-AM_LDFLAGS              = $(BOTAN_LDFLAGS)
+AM_LDFLAGS              = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
 
 lib_LTLIBRARIES		= librnp.la
 
@@ -38,6 +38,6 @@ librnp_la_SOURCES	= \
 	validate.c \
 	writer.c
 
-librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSON_LIBS)
+librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS)
 
 dist_man_MANS		= librnp.3

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,13 +1,11 @@
 ## $NetBSD: Makefile.am,v 1.10 2010/11/29 06:21:40 agc Exp $
 
-AM_CFLAGS		= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSONC_INCLUDES)
-
-AM_LDFLAGS              = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
-
+AM_CFLAGS			= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSON_CFLAGS)
+AM_LDFLAGS          = $(BOTAN_LDFLAGS)
 lib_LTLIBRARIES		= librnp.la
-
 librnp_la_CPPFLAGS	= -I$(top_srcdir)/include
-
+librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSON_LIBS)
+dist_man_MANS		= librnp.3
 librnp_la_SOURCES	= \
 	bn.c \
 	bufgap.c \
@@ -37,7 +35,3 @@ librnp_la_SOURCES	= \
 	symmetric.c \
 	validate.c \
 	writer.c
-
-librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS)
-
-dist_man_MANS		= librnp.3

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,10 +1,10 @@
 ## $NetBSD: Makefile.am,v 1.10 2010/11/29 06:21:40 agc Exp $
 
-AM_CFLAGS			= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSON_CFLAGS)
-AM_LDFLAGS          = $(BOTAN_LDFLAGS)
+AM_CFLAGS			= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSONC_INCLUDES)
+AM_LDFLAGS          = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
 lib_LTLIBRARIES		= librnp.la
 librnp_la_CPPFLAGS	= -I$(top_srcdir)/include
-librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSON_LIBS)
+librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS)
 dist_man_MANS		= librnp.3
 librnp_la_SOURCES	= \
 	bn.c \

--- a/src/lib/bn.c
+++ b/src/lib/bn.c
@@ -578,9 +578,10 @@ BIGNUM *
 new_BN_take_mp(botan_mp_t mp)
 {
     PGPV_BIGNUM *a;
-
     a = calloc(1, sizeof(*a));
-    a->mp = mp;
+    if (a) {
+        a->mp = mp;
+    }
     return a;
 }
 
@@ -595,15 +596,19 @@ DSA_SIG *
 DSA_SIG_new()
 {
     DSA_SIG *sig = calloc(1, sizeof(DSA_SIG));
-    sig->r = BN_new();
-    sig->s = BN_new();
+    if (sig) {
+        sig->r = BN_new();
+        sig->s = BN_new();
+    }
     return sig;
 }
 
 void
 DSA_SIG_free(DSA_SIG *sig)
 {
-    BN_clear_free(sig->r);
-    BN_clear_free(sig->s);
-    free(sig);
+    if (sig) {
+        BN_clear_free(sig->r);
+        BN_clear_free(sig->s);
+        free(sig);
+    }
 }

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -80,7 +80,7 @@ void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);
 
 /* Hash everything that's read */
-void pgp_reader_push_hash(pgp_stream_t *, pgp_hash_t *);
+int  pgp_reader_push_hash(pgp_stream_t *, pgp_hash_t *);
 void pgp_reader_pop_hash(pgp_stream_t *);
 
 int pgp_decrypt_decode_mpi(

--- a/src/lib/key_store.c
+++ b/src/lib/key_store.c
@@ -71,7 +71,7 @@ conffile(rnp_t *rnp, char *homedir, char *userid, size_t length)
             (void) memcpy(userid,
                           &buf[(int) matchv[1].rm_so],
                           MIN((unsigned) (matchv[1].rm_eo - matchv[1].rm_so), length));
-            if (rnp->passfp == NULL) {
+            if (rnp->user_input_fp == NULL) {
                 (void) fprintf(stderr,
                                "rnp: default key set to \"%.*s\"\n",
                                (int) (matchv[1].rm_eo - matchv[1].rm_so),

--- a/src/lib/key_store_kbx.c
+++ b/src/lib/key_store_kbx.c
@@ -198,9 +198,9 @@ rnp_key_store_kbx_parse_pgp_blob(kbx_pgp_blob_t *pgp_blob)
 
     if (pgp_blob->sn_size > pgp_blob->blob.length - (image - pgp_blob->blob.image)) {
         fprintf(stderr,
-                "Serial number is %u and it's bigger that blob size it can use: %lu\n",
+                "Serial number is %u and it's bigger that blob size it can use: %u\n",
                 pgp_blob->sn_size,
-                pgp_blob->blob.length - (image - pgp_blob->blob.image));
+                (uint32_t)(pgp_blob->blob.length - (image - pgp_blob->blob.image)));
         return 0;
     }
 

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -961,10 +961,14 @@ pgp_reader_push_sum16(pgp_stream_t *stream)
 {
     sum16_t *arg;
 
-    if ((arg = calloc(1, sizeof(*arg))) == NULL) {
+    arg = calloc(1, sizeof(*arg));
+    if (arg == NULL) {
         (void) fprintf(stderr, "pgp_reader_push_sum16: bad alloc\n");
-    } else {
-        pgp_reader_push(stream, sum16_reader, sum16_destroyer, arg);
+        return;
+    }
+
+    if (!pgp_reader_push(stream, sum16_reader, sum16_destroyer, arg)) {
+        free(arg);
     }
 }
 

--- a/src/lib/packet-parse.h
+++ b/src/lib/packet-parse.h
@@ -118,7 +118,7 @@ void  pgp_callback_push(pgp_stream_t *, pgp_cbfunc_t *, void *);
 void *pgp_callback_arg(pgp_cbdata_t *);
 void *pgp_callback_errors(pgp_cbdata_t *);
 void  pgp_reader_set(pgp_stream_t *, pgp_reader_func_t *, pgp_reader_destroyer_t *, void *);
-void  pgp_reader_push(pgp_stream_t *, pgp_reader_func_t *, pgp_reader_destroyer_t *, void *);
+int   pgp_reader_push(pgp_stream_t *, pgp_reader_func_t *, pgp_reader_destroyer_t *, void *);
 void  pgp_reader_pop(pgp_stream_t *);
 
 void *pgp_reader_get_arg(pgp_reader_t *);

--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -306,9 +306,12 @@ list_free_strings(pgp_list_t *list)
     unsigned i;
 
     for (i = 0; i < list->used; i++) {
-        free(list->strings[i]);
-        list->strings[i] = NULL;
+        if (list->strings[i] != NULL) {
+            free(list->strings[i]);
+            list->strings[i] = NULL;
+        }
     }
+    list->used = 0;
 }
 
 static void

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -193,7 +193,7 @@ pgp_reader_set(pgp_stream_t *          stream,
  * \param destroyer Reader's destroyer
  * \param vp Reader-specific arg
  */
-void
+int
 pgp_reader_push(pgp_stream_t *          stream,
                 pgp_reader_func_t *     reader,
                 pgp_reader_destroyer_t *destroyer,
@@ -203,17 +203,19 @@ pgp_reader_push(pgp_stream_t *          stream,
 
     if ((readinfo = calloc(1, sizeof(*readinfo))) == NULL) {
         (void) fprintf(stderr, "pgp_reader_push: bad alloc\n");
-    } else {
-        *readinfo = stream->readinfo;
-        (void) memset(&stream->readinfo, 0x0, sizeof(stream->readinfo));
-        stream->readinfo.next = readinfo;
-        stream->readinfo.parent = stream;
-
-        /* should copy accumulate flags from other reader? RW */
-        stream->readinfo.accumulate = readinfo->accumulate;
-
-        pgp_reader_set(stream, reader, destroyer, vp);
+        return 0;
     }
+
+    *readinfo = stream->readinfo;
+    (void) memset(&stream->readinfo, 0x0, sizeof(stream->readinfo));
+    stream->readinfo.next = readinfo;
+    stream->readinfo.parent = stream;
+
+    /* should copy accumulate flags from other reader? RW */
+    stream->readinfo.accumulate = readinfo->accumulate;
+
+    pgp_reader_set(stream, reader, destroyer, vp);
+    return 1;
 }
 
 /**
@@ -1294,7 +1296,10 @@ pgp_reader_push_dearmour(pgp_stream_t *parse_info)
         dearmour->expect_sig = 0;
         dearmour->got_sig = 0;
 
-        pgp_reader_push(parse_info, armoured_data_reader, armoured_data_destroyer, dearmour);
+        if (!pgp_reader_push(
+              parse_info, armoured_data_reader, armoured_data_destroyer, dearmour)) {
+            free(dearmour);
+        }
     }
 }
 
@@ -1453,7 +1458,10 @@ pgp_reader_push_decrypt(pgp_stream_t *stream, pgp_crypt_t *decrypt, pgp_region_t
         encrypted->decrypt = decrypt;
         encrypted->region = region;
         pgp_decrypt_init(encrypted->decrypt);
-        pgp_reader_push(stream, encrypted_data_reader, encrypted_data_destroyer, encrypted);
+        if (!pgp_reader_push(
+              stream, encrypted_data_reader, encrypted_data_destroyer, encrypted)) {
+            free(encrypted);
+        }
     }
 }
 
@@ -1641,7 +1649,9 @@ pgp_reader_push_se_ip_data(pgp_stream_t *stream, pgp_crypt_t *decrypt, pgp_regio
     } else {
         se_ip->region = region;
         se_ip->decrypt = decrypt;
-        pgp_reader_push(stream, se_ip_data_reader, se_ip_data_destroyer, se_ip);
+        if (!pgp_reader_push(stream, se_ip_data_reader, se_ip_data_destroyer, se_ip)) {
+            free(se_ip);
+        }
     }
 }
 
@@ -2279,10 +2289,10 @@ hash_reader(pgp_stream_t *stream,
    \ingroup Internal_Readers_Hash
    \brief Push hashed data reader on stack
 */
-void
+int
 pgp_reader_push_hash(pgp_stream_t *stream, pgp_hash_t *hash)
 {
-    pgp_reader_push(stream, hash_reader, NULL, hash);
+    return pgp_reader_push(stream, hash_reader, NULL, hash);
 }
 
 /**

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -976,7 +976,7 @@ rnp_init(rnp_t *rnp)
 }
 
 /* finish off with the rnp_t struct */
-int
+void
 rnp_end(rnp_t *rnp)
 {
     unsigned i;
@@ -1007,8 +1007,6 @@ rnp_end(rnp_t *rnp)
     }
     free(rnp->io);
     rnp_ctx_free(&rnp->ctx);
-
-    return 1;
 }
 
 /* rnp_ctx_t : init, reset, free internal pointers */

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1158,6 +1158,7 @@ rnp_match_keys_json(rnp_t *rnp, char **json, char *name, const char *fmt, const 
                 if (newkey) {
                     printf("%s\n", newkey);
                     free(newkey);
+                    newkey = NULL;
                 }
             } else {
                 pgp_sprint_json(

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -750,8 +750,8 @@ set_pass_fd(rnp_t *rnp)
     pgp_io_t *io = rnp->io;
 
     if (passfd != NULL) {
-        rnp->passfp = fdopen(atoi(passfd), "r");
-        if (rnp->passfp == NULL) {
+        rnp->user_input_fp = fdopen(atoi(passfd), "r");
+        if (rnp->user_input_fp == NULL) {
             fprintf(io->errs, "cannot open fd %s for reading\n", passfd);
             return 0;
         }
@@ -1268,7 +1268,7 @@ rnp_export_key(rnp_t *rnp, char *name)
 
         rnp_strhexdump(keyid, key->sigid, PGP_KEY_ID_SIZE, "");
         memset(passphrase, 0, sizeof(passphrase));
-        find_passphrase(rnp->passfp, keyid, passphrase, sizeof(passphrase), attempts);
+        find_passphrase(rnp->user_input_fp, keyid, passphrase, sizeof(passphrase), attempts);
     }
 
     return pgp_export_key(io, key, (uint8_t *) passphrase);
@@ -1392,7 +1392,7 @@ rnp_generate_key(rnp_t *rnp, const char *id)
     rnp_strhexdump(keyid, key->sigid, PGP_KEY_ID_SIZE, "");
 
     memset(passphrase, 0, sizeof(passphrase));
-    find_passphrase(rnp->passfp, keyid, passphrase, sizeof(passphrase), attempts);
+    find_passphrase(rnp->user_input_fp, keyid, passphrase, sizeof(passphrase), attempts);
 
     /* write keypair */
     snprintf(ringfile = filename, sizeof(filename), "%s/secring.%s", dir, ext);
@@ -1472,7 +1472,7 @@ rnp_decrypt_file(rnp_t *rnp, const char *f, char *out, int armored)
                             realarmor,
                             overwrite,
                             sshkeys,
-                            rnp->passfp,
+                            rnp->user_input_fp,
                             attempts,
                             get_passphrase_cb);
 }
@@ -1509,7 +1509,7 @@ rnp_sign_file(
     }
     for (i = 0, seckey = NULL; !seckey && (i < attempts || attempts == INFINITE_ATTEMPTS);
          i++) {
-        if (rnp->passfp == NULL) {
+        if (rnp->user_input_fp == NULL) {
             /* print out the user id */
             pubkey = rnp_key_store_get_key_by_name(io, rnp->pubring, userid);
             if (pubkey == NULL) {
@@ -1523,7 +1523,7 @@ rnp_sign_file(
         }
         if (!use_ssh_keys(rnp)) {
             /* now decrypt key */
-            seckey = pgp_decrypt_seckey(keypair, rnp->passfp);
+            seckey = pgp_decrypt_seckey(keypair, rnp->user_input_fp);
             if (seckey == NULL) {
                 (void) fprintf(io->errs, "Bad passphrase\n");
             }
@@ -1639,7 +1639,7 @@ rnp_sign_memory(rnp_t *        rnp,
     }
     for (i = 0, seckey = NULL; !seckey && (i < attempts || attempts == INFINITE_ATTEMPTS);
          i++) {
-        if (rnp->passfp == NULL) {
+        if (rnp->user_input_fp == NULL) {
             /* print out the user id */
             pubkey = rnp_key_store_get_key_by_name(io, rnp->pubring, userid);
             if (pubkey == NULL) {
@@ -1653,7 +1653,7 @@ rnp_sign_memory(rnp_t *        rnp,
         }
         if (!use_ssh_keys(rnp)) {
             /* now decrypt key */
-            seckey = pgp_decrypt_seckey(keypair, rnp->passfp);
+            seckey = pgp_decrypt_seckey(keypair, rnp->user_input_fp);
             if (seckey == NULL) {
                 (void) fprintf(io->errs, "Bad passphrase\n");
             }
@@ -1825,7 +1825,7 @@ rnp_decrypt_memory(rnp_t *      rnp,
                           rnp->pubring,
                           realarmour,
                           sshkeys,
-                          rnp->passfp,
+                          rnp->user_input_fp,
                           attempts,
                           get_passphrase_cb);
     if (mem == NULL) {
@@ -1874,8 +1874,13 @@ rnp_list_packets(rnp_t *rnp, char *f, int armor, char *pubringname)
     }
     rnp->pubring = keyring;
     rnp_setvar(rnp, "pubring", pubringname);
-    ret = pgp_list_packets(
-      io, f, (unsigned) armor, rnp->secring, rnp->pubring, rnp->passfp, get_passphrase_cb);
+    ret = pgp_list_packets(io,
+                           f,
+                           (unsigned) armor,
+                           rnp->secring,
+                           rnp->pubring,
+                           rnp->user_input_fp,
+                           get_passphrase_cb);
     free(keyring);
     rnp->pubring = NULL;
     return ret;

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -1269,6 +1269,7 @@ pgp_sign_detached(rnp_ctx_t *    ctx,
         pgp_teardown_file_write(output, fd);
         pgp_memory_free(sig->mem); /* free memory allocated in pgp_start_sig*/
         pgp_create_sig_delete(sig);
+        pgp_memory_free(mem);
         return 0;
     }
     /* set armoured/not armoured here */

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -1257,11 +1257,17 @@ pgp_sign_detached(rnp_ctx_t *    ctx,
 
     /* create a new signature */
     sig = pgp_create_sig_new();
+    if (sig == NULL) {
+        (void) fprintf(stderr, "can't allocate mem\n");
+        return 0;
+    }
     pgp_start_sig(sig, seckey, hash_alg, PGP_SIG_BINARY);
 
     /* read the contents of 'f', and add that to the signature */
     mem = pgp_memory_new();
     if (mem == NULL) {
+        pgp_teardown_file_write(output, fd);
+        pgp_create_sig_delete(sig);
         (void) fprintf(stderr, "can't allocate mem\n");
         return 0;
     }

--- a/src/lib/validate.c
+++ b/src/lib/validate.c
@@ -862,6 +862,7 @@ pgp_validate_file(pgp_io_t *             io,
         } else {
             outfd = open(outfile, O_WRONLY | O_CREAT, 0666);
         }
+
         if (outfd < 0) {
             /* even if the signature was good, we can't
              * write the file, so send back a bad return
@@ -882,11 +883,13 @@ pgp_validate_file(pgp_io_t *             io,
                     break;
                 }
             }
-            if (strcmp(outfile, "-") != 0) {
-                (void) close(outfd);
-            }
         }
     }
+
+    if ((outfd > 0) && !strcmp(outfile, "-")) {
+        (void) close(outfd);
+    }
+
     pgp_memory_free(validation.mem);
     return ret;
 }

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -243,7 +243,7 @@ pgp_writer_info_delete(pgp_writer_t *writer)
  * \param destroyer
  * \param arg The argument for the writer and destroyer
  */
-void
+int
 pgp_writer_set(pgp_output_t *          output,
                pgp_writer_func_t *     writer,
                pgp_writer_finaliser_t *finaliser,
@@ -252,13 +252,14 @@ pgp_writer_set(pgp_output_t *          output,
 {
     if (output->writer.writer) {
         (void) fprintf(stderr, "pgp_writer_set: already set\n");
-    } else {
-        output->writer.writer = writer;
-        output->writer.finaliser = finaliser;
-        output->writer.destroyer = destroyer;
-        output->writer.arg = arg;
-        output->writer.ctx = output->ctx;
+        return 0;
     }
+    output->writer.writer = writer;
+    output->writer.finaliser = finaliser;
+    output->writer.destroyer = destroyer;
+    output->writer.arg = arg;
+    output->writer.ctx = output->ctx;
+    return 1;
 }
 
 /**
@@ -272,29 +273,37 @@ pgp_writer_set(pgp_output_t *          output,
  * \param destroyer
  * \param arg The argument for the writer and destroyer
  */
-void
+int
 pgp_writer_push(pgp_output_t *          output,
                 pgp_writer_func_t *     writer,
                 pgp_writer_finaliser_t *finaliser,
                 pgp_writer_destroyer_t *destroyer,
                 void *                  arg)
 {
-    pgp_writer_t *copy;
+    pgp_writer_t *copy = NULL;
 
     if ((copy = calloc(1, sizeof(*copy))) == NULL) {
         (void) fprintf(stderr, "pgp_writer_push: bad alloc\n");
-    } else if (output->writer.writer == NULL) {
-        (void) fprintf(stderr, "pgp_writer_push: no orig writer\n");
-    } else {
-        *copy = output->writer;
-        output->writer.next = copy;
-
-        output->writer.writer = writer;
-        output->writer.finaliser = finaliser;
-        output->writer.destroyer = destroyer;
-        output->writer.arg = arg;
-        output->writer.ctx = output->ctx;
+        return 0;
     }
+
+    if (output->writer.writer == NULL) {
+        if (copy != NULL) {
+            free(copy);
+        }
+        (void) fprintf(stderr, "pgp_writer_push: no orig writer\n");
+        return 0;
+    }
+
+    *copy = output->writer;
+    output->writer.next = copy;
+
+    output->writer.writer = writer;
+    output->writer.finaliser = finaliser;
+    output->writer.destroyer = destroyer;
+    output->writer.arg = arg;
+    output->writer.ctx = output->ctx;
+    return 1;
 }
 
 void
@@ -514,10 +523,14 @@ pgp_writer_push_clearsigned(pgp_output_t *output, pgp_create_sig_t *sig)
     dash->sig = sig;
     dash->trailing = pgp_memory_new();
     if (dash->trailing == NULL) {
+        free(dash);
         PGP_ERROR_1(&output->errors, PGP_E_FAIL, "%s", "can't allocate mem");
         return 0;
     }
-    pgp_writer_push(output, dash_esc_writer, NULL, dash_escaped_destroyer, dash);
+    if (!pgp_writer_push(output, dash_esc_writer, NULL, dash_escaped_destroyer, dash)) {
+        free(dash);
+        return 0;
+    }
     return ret;
 }
 
@@ -673,14 +686,20 @@ pgp_writer_use_armored_sig(pgp_output_t *output)
         PGP_ERROR_1(&output->errors, PGP_E_W, "%s", "pgp_writer_use_armored_sig: Bad alloc");
         return 0;
     }
-    pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak);
+    if (!pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak)) {
+        free(linebreak);
+        return 0;
+    }
     base64 = calloc(1, sizeof(*base64));
     if (!base64) {
         PGP_MEMORY_ERROR(&output->errors);
         return 0;
     }
     base64->checksum = CRC24_INIT;
-    pgp_writer_push(output, base64_writer, sig_finaliser, generic_destroyer, base64);
+    if (!pgp_writer_push(output, base64_writer, sig_finaliser, generic_destroyer, base64)) {
+        free(base64);
+        return 0;
+    }
     return 1;
 }
 
@@ -740,14 +759,20 @@ pgp_writer_push_armor_msg(pgp_output_t *output)
         (void) fprintf(stderr, "pgp_writer_push_armor_msg: bad lb alloc\n");
         return;
     }
-    pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak);
+    if (!pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak)) {
+        free(linebreak);
+        return;
+    }
     if ((base64 = calloc(1, sizeof(*base64))) == NULL) {
         (void) fprintf(stderr, "pgp_writer_push_armor_msg: bad alloc\n");
         return;
     }
     base64->checksum = CRC24_INIT;
-    pgp_writer_push(
-      output, base64_writer, armoured_message_finaliser, generic_destroyer, base64);
+    if (!pgp_writer_push(
+          output, base64_writer, armoured_message_finaliser, generic_destroyer, base64)) {
+        free(base64);
+        return;
+    }
 }
 
 static unsigned
@@ -855,13 +880,19 @@ pgp_writer_push_armoured(pgp_output_t *output, pgp_armor_type_t type)
         return;
     }
     pgp_write(output, header, hdrsize);
-    pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak);
+    if (!pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak)) {
+        free(linebreak);
+        return;
+    }
     if ((base64 = calloc(1, sizeof(*base64))) == NULL) {
         (void) fprintf(stderr, "pgp_writer_push_armoured: bad alloc\n");
         return;
     }
     base64->checksum = CRC24_INIT;
-    pgp_writer_push(output, base64_writer, finaliser, generic_destroyer, base64);
+    if (!pgp_writer_push(output, base64_writer, finaliser, generic_destroyer, base64)) {
+        free(base64);
+        return;
+    }
 }
 
 /**************************************************************************/
@@ -944,7 +975,9 @@ pgp_push_enc_crypt(pgp_output_t *output, pgp_crypt_t *pgp_crypt)
         pgp_encrypt->crypt = pgp_crypt;
         pgp_encrypt->free_crypt = 0;
         /* And push writer on stack */
-        pgp_writer_push(output, encrypt_writer, NULL, encrypt_destroyer, pgp_encrypt);
+        if (!pgp_writer_push(output, encrypt_writer, NULL, encrypt_destroyer, pgp_encrypt)) {
+            free(pgp_encrypt);
+        }
     }
 }
 
@@ -1011,7 +1044,14 @@ pgp_push_enc_se_ip(pgp_output_t *output, const pgp_key_t *pubkey, pgp_symm_alg_t
     se_ip->crypt = encrypted;
 
     /* And push writer on stack */
-    pgp_writer_push(output, encrypt_se_ip_writer, NULL, encrypt_se_ip_destroyer, se_ip);
+    if (!pgp_writer_push(output, encrypt_se_ip_writer, NULL, encrypt_se_ip_destroyer, se_ip)) {
+        free(se_ip);
+        pgp_pk_sesskey_free(encrypted_pk_sesskey);
+        free(encrypted_pk_sesskey);
+        free(encrypted);
+        free(iv);
+        return 0;
+    }
     /* tidy up */
     pgp_pk_sesskey_free(encrypted_pk_sesskey);
     free(encrypted_pk_sesskey);
@@ -1212,7 +1252,9 @@ pgp_writer_set_fd(pgp_output_t *output, int fd)
         (void) fprintf(stderr, "pgp_writer_set_fd: bad alloc\n");
     } else {
         writer->fd = fd;
-        pgp_writer_set(output, fd_writer, NULL, writer_fd_destroyer, writer);
+        if (!pgp_writer_set(output, fd_writer, NULL, writer_fd_destroyer, writer)) {
+            free(writer);
+        }
     }
 }
 
@@ -1407,6 +1449,9 @@ pgp_push_stream_enc_se_ip(pgp_output_t *output, const pgp_key_t *pubkey, pgp_sym
 
     se_ip->mem_data = pgp_memory_new();
     if (se_ip->mem_data == NULL) {
+        free(iv);
+        free(encrypted);
+        free(se_ip);
         (void) fprintf(stderr, "can't allocate mem\n");
         return;
     }
@@ -1416,13 +1461,21 @@ pgp_push_stream_enc_se_ip(pgp_output_t *output, const pgp_key_t *pubkey, pgp_sym
     se_ip->litoutput = NULL;
 
     if (!pgp_setup_memory_write(output->ctx, &se_ip->se_ip_out, &se_ip->se_ip_mem, bufsz)) {
+        free(iv);
+        free(encrypted);
+        free(se_ip);
         (void) fprintf(stderr, "can't setup memory write\n");
         return;
     }
 
     /* And push writer on stack */
-    pgp_writer_push(
-      output, str_enc_se_ip_writer, str_enc_se_ip_finaliser, str_enc_se_ip_destroyer, se_ip);
+    if (!pgp_writer_push(output,
+                         str_enc_se_ip_writer,
+                         str_enc_se_ip_finaliser,
+                         str_enc_se_ip_destroyer,
+                         se_ip)) {
+        free(se_ip);
+    }
     /* tidy up */
     free(encrypted_pk_sesskey);
     free(iv);

--- a/src/lib/writer.h
+++ b/src/lib/writer.h
@@ -84,16 +84,16 @@ struct pgp_writer_t {
 
 void *pgp_writer_get_arg(pgp_writer_t *);
 
-void pgp_writer_set(pgp_output_t *,
+int pgp_writer_set(pgp_output_t *,
+                   pgp_writer_func_t *,
+                   pgp_writer_finaliser_t *,
+                   pgp_writer_destroyer_t *,
+                   void *);
+int pgp_writer_push(pgp_output_t *,
                     pgp_writer_func_t *,
                     pgp_writer_finaliser_t *,
                     pgp_writer_destroyer_t *,
                     void *);
-void pgp_writer_push(pgp_output_t *,
-                     pgp_writer_func_t *,
-                     pgp_writer_finaliser_t *,
-                     pgp_writer_destroyer_t *,
-                     void *);
 void     pgp_writer_pop(pgp_output_t *);
 unsigned pgp_writer_passthrough(const uint8_t *, unsigned, pgp_error_t **, pgp_writer_t *);
 

--- a/src/rnp/Makefile.am
+++ b/src/rnp/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS		= rnp
 
 rnp_SOURCES		= rnp.c
 
-rnp_CPPFLAGS		= -I$(top_srcdir)/include
+rnp_CPPFLAGS		= -I$(top_srcdir)/include $(JSONC_INCLUDES)
 
 rnp_LDADD		= ../lib/librnp.la
 

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS   		    = $(WARNCFLAGS)
 dist_man_MANS           = rnpkeys.1
 
 lib_LTLIBRARIES         = librnpkeys.la
-librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include -I../../include
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include
 librnpkeys_la_LIBADD    = ../lib/librnp.la
 librnpkeys_la_SOURCES   = \
     rnpkeys.c \

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS   		    = $(WARNCFLAGS)
 dist_man_MANS           = rnpkeys.1
 
 lib_LTLIBRARIES         = librnpkeys.la
-librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include $(JSONC_INCLUDES)
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include -I../../include $(JSONC_INCLUDES)
 librnpkeys_la_LIBADD    = ../lib/librnp.la
 librnpkeys_la_SOURCES   = \
     rnpkeys.c \
@@ -10,5 +10,5 @@ librnpkeys_la_SOURCES   = \
 
 bin_PROGRAMS            = rnpkeys
 rnpkeys_SOURCES         = main.c
-rnpkeys_la_CPPFLAGS     = -I$(top_srcdir)/include
+rnpkeys_la_CPPFLAGS     = -I$(top_srcdir)/include -I../../include
 rnpkeys_LDADD           = librnpkeys.la

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS   		    = $(WARNCFLAGS)
 dist_man_MANS           = rnpkeys.1
 
 lib_LTLIBRARIES         = librnpkeys.la
-librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include -I../../include
 librnpkeys_la_LIBADD    = ../lib/librnp.la
 librnpkeys_la_SOURCES   = \
     rnpkeys.c \

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS   		    = $(WARNCFLAGS)
 dist_man_MANS           = rnpkeys.1
 
 lib_LTLIBRARIES         = librnpkeys.la
-librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include $(JSONC_INCLUDES)
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include
 librnpkeys_la_LIBADD    = ../lib/librnp.la
 librnpkeys_la_SOURCES   = \
     rnpkeys.c \

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -10,4 +10,5 @@ librnpkeys_la_SOURCES   = \
 
 bin_PROGRAMS            = rnpkeys
 rnpkeys_SOURCES         = main.c
+rnpkeys_la_CPPFLAGS     = -I$(top_srcdir)/include
 rnpkeys_LDADD           = librnpkeys.la

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -1,12 +1,13 @@
-AM_CFLAGS		= $(WARNCFLAGS)
+AM_CFLAGS   		    = $(WARNCFLAGS)
+dist_man_MANS           = rnpkeys.1
 
-bin_PROGRAMS		= rnpkeys
+lib_LTLIBRARIES         = librnpkeys.la
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include $(JSONC_INCLUDES)
+librnpkeys_la_LIBADD    = ../lib/librnp.la
+librnpkeys_la_SOURCES   = \
+    rnpkeys.c \
+    tui.c
 
-rnpkeys_SOURCES	=   rnpkeys.c \
-                    tui.c
-
-rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include $(JSONC_INCLUDES)
-
-rnpkeys_LDADD	= ../lib/librnp.la
-
-dist_man_MANS		= rnpkeys.1
+bin_PROGRAMS            = rnpkeys
+rnpkeys_SOURCES         = main.c
+rnpkeys_LDADD           = librnpkeys.la

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -5,7 +5,7 @@ bin_PROGRAMS		= rnpkeys
 rnpkeys_SOURCES	=   rnpkeys.c \
                     tui.c
 
-rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include
+rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include $(JSONC_INCLUDES)
 
 rnpkeys_LDADD	= ../lib/librnp.la
 

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -10,5 +10,5 @@ librnpkeys_la_SOURCES   = \
 
 bin_PROGRAMS            = rnpkeys
 rnpkeys_SOURCES         = main.c
-rnpkeys_CPPFLAGS        = -I$(top_srcdir)/include
+rnpkeys_CPPFLAGS        = -I$(top_srcdir)/include $(JSONC_INCLUDES)
 rnpkeys_LDADD           = librnpkeys.la ../lib/librnp.la

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS   		    = $(WARNCFLAGS)
 dist_man_MANS           = rnpkeys.1
 
 lib_LTLIBRARIES         = librnpkeys.la
-librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include -I../../include $(JSONC_INCLUDES)
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include $(JSONC_INCLUDES)
 librnpkeys_la_LIBADD    = ../lib/librnp.la
 librnpkeys_la_SOURCES   = \
     rnpkeys.c \
@@ -10,5 +10,5 @@ librnpkeys_la_SOURCES   = \
 
 bin_PROGRAMS            = rnpkeys
 rnpkeys_SOURCES         = main.c
-rnpkeys_la_CPPFLAGS     = -I$(top_srcdir)/include -I../../include
+rnpkeys_CPPFLAGS        = -I$(top_srcdir)/include
 rnpkeys_LDADD           = librnpkeys.la

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS   		    = $(WARNCFLAGS)
 dist_man_MANS           = rnpkeys.1
 
 lib_LTLIBRARIES         = librnpkeys.la
-librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include
+librnpkeys_la_CPPFLAGS  = -I$(top_srcdir)/include $(JSONC_INCLUDES)
 librnpkeys_la_LIBADD    = ../lib/librnp.la
 librnpkeys_la_SOURCES   = \
     rnpkeys.c \

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -11,4 +11,4 @@ librnpkeys_la_SOURCES   = \
 bin_PROGRAMS            = rnpkeys
 rnpkeys_SOURCES         = main.c
 rnpkeys_CPPFLAGS        = -I$(top_srcdir)/include
-rnpkeys_LDADD           = librnpkeys.la
+rnpkeys_LDADD           = librnpkeys.la ../lib/librnp.la

--- a/src/rnpkeys/main.c
+++ b/src/rnpkeys/main.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * Copyright (c) 2009 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is originally derived from software contributed to
+ * The NetBSD Foundation by Alistair Crooks (agc@netbsd.org), and
+ * carried further by Ribose Inc (https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/* Command line program to perform rnp operations */
+#include <getopt.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "rnp.h"
+#include "crypto.h"
+#include "../common/constants.h"
+#include "rnpkeys.h"
+
+extern struct option options[];
+extern const char *  usage;
+
+int
+main(int argc, char **argv)
+{
+    rnp_t  rnp;
+    prog_t p;
+    int    optindex;
+    int    ret;
+    int    ch;
+    int    i;
+
+    memset(&p, '\0', sizeof(p));
+    memset(&rnp, '\0', sizeof(rnp));
+
+    p.numbits = DEFAULT_RSA_NUMBITS;
+
+    if (argc < 2) {
+        print_usage(usage);
+        exit(EXIT_ERROR);
+    }
+
+    rnp_setvar(&rnp, "sshkeydir", "/etc/ssh");
+    rnp_setvar(&rnp, "res", "<stdout>");
+    rnp_setvar(&rnp, "format", "human");
+
+    optindex = 0;
+
+    while ((ch = getopt_long(argc, argv, "S:Vglo:s", options, &optindex)) != -1) {
+        if (ch >= LIST_KEYS) {
+            /* getopt_long returns 0 for long options */
+            if (!setoption(&rnp, &p, options[optindex].val, optarg))
+                fprintf(stderr, "Bad setoption result %d\n", ch);
+        } else {
+            switch (ch) {
+            case 'S':
+                rnp_setvar(&rnp, "key_store_format", "SSH");
+                rnp_setvar(&rnp, "sshkeyfile", optarg);
+                break;
+            case 'V':
+                print_praise();
+                exit(EXIT_SUCCESS);
+            case 'g':
+                p.cmd = GENERATE_KEY;
+                break;
+            case 'l':
+                p.cmd = LIST_KEYS;
+                break;
+            case 'o':
+                if (!parse_option(&rnp, &p, optarg)) {
+                    (void) fprintf(stderr, "Bad parse_option\n");
+                }
+                break;
+            case 's':
+                p.cmd = LIST_SIGS;
+                break;
+            default:
+                p.cmd = HELP_CMD;
+                break;
+            }
+        }
+    }
+    if (!rnp_init(&rnp)) {
+        fputs("fatal: failed to initialize rnpkeys\n", stderr);
+        return EXIT_ERROR;
+    }
+
+    if (!rnp_load_keys(&rnp)) {
+        /* Keys mightn't loaded if this is a key generation step. */
+        if (p.cmd != GENERATE_KEY) {
+            fputs("fatal: failed to load keys\n", stderr);
+            return EXIT_ERROR;
+        }
+    }
+
+    /* now do the required action for each of the command line args */
+    ret = EXIT_SUCCESS;
+    if (optind == argc) {
+        if (!rnp_cmd(&rnp, &p, NULL))
+            ret = EXIT_FAILURE;
+    } else {
+        for (i = optind; i < argc; i++) {
+            if (!rnp_cmd(&rnp, &p, argv[i]))
+                ret = EXIT_FAILURE;
+        }
+    }
+    rnp_end(&rnp);
+
+    return ret;
+}

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -202,12 +202,15 @@ rnp_cmd(rnp_t *rnp, prog_t *p, char *f)
     case GENERATE_KEY:
         key = f ? f : rnp_getvar(rnp, "userid");
         rnp_keygen_desc_t *key_desc = &rnp->action.generate_key_ctx;
-        if (findvar(rnp, "expert") > 0) {
-            (void) rnp_generate_key_expert_mode(rnp);
+
+        if ((findvar(rnp, "expert") > 0) && (rnp_generate_key_expert_mode(rnp) != PGP_E_OK)) {
+            (void) fprintf(stderr, "Critical error: Key generation failed\n");
+            exit(EXIT_ERROR);
         } else {
             key_desc->key_alg = PGP_PKA_RSA;
             key_desc->rsa.modulus_bit_len = p->numbits;
         }
+
         adjust_key_params(key_desc, rnp_getvar(rnp, "hash"), rnp_getvar(rnp, "cipher"));
         return rnp_generate_key(rnp, key);
     case GET_KEY:

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -1,0 +1,58 @@
+#ifndef _rnpkeys_H_
+#define _rnpkeys_H_
+
+#include <sys/param.h>
+
+#define EXIT_ERROR 2
+#define DEFAULT_RSA_NUMBITS 2048
+
+enum optdefs {
+    /* commands */
+    LIST_KEYS = 260,
+    LIST_SIGS,
+    FIND_KEY,
+    EXPORT_KEY,
+    IMPORT_KEY,
+    GENERATE_KEY,
+    VERSION_CMD,
+    HELP_CMD,
+    GET_KEY,
+    TRUSTED_KEYS,
+
+    /* options */
+    SSHKEYS,
+    KEYRING,
+    KEY_STORE_FORMAT,
+    USERID,
+    HOMEDIR,
+    NUMBITS,
+    HASH_ALG,
+    VERBOSE,
+    COREDUMPS,
+    PASSWDFD,
+    RESULTS,
+    SSHKEYFILE,
+    CIPHER,
+    FORMAT,
+    EXPERT,
+
+    /* debug */
+    OPS_DEBUG
+
+};
+
+/* gather up program variables into one struct */
+typedef struct prog_t {
+    char keyring[MAXPATHLEN + 1]; /* name of keyring */
+    int  numbits;                 /* # of bits */
+    int  cmd;                     /* rnpkeys command */
+} prog_t;
+
+void print_praise(void);
+void print_usage(const char *usagemsg);
+int setoption(rnp_t *rnp, prog_t *p, int val, char *arg);
+int parse_option(rnp_t *rnp, prog_t *p, const char *s);
+int rnp_cmd(rnp_t *rnp, prog_t *p, char *f);
+pgp_errcode_t rnp_generate_key_expert_mode(rnp_t *rnp);
+
+#endif /* _rnpkeys_ */

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -15,7 +15,7 @@ extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
  *
 -------------------------------------------------------------------------------- */
 static bool
-rnp_secure_get_long_from_fd(const FILE *fp, long *result)
+rnp_secure_get_long_from_fd(FILE *fp, long *result)
 {
     char  buff[BUFSIZ];
     char *end_ptr;
@@ -26,7 +26,7 @@ rnp_secure_get_long_from_fd(const FILE *fp, long *result)
         goto end;
     }
 
-    if (fgets(buff, sizeof(buff), stdin) == NULL) {
+    if (fgets(buff, sizeof(buff), fp) == NULL) {
         RNP_LOG("EOF or read error");
         goto end;
     } else {
@@ -78,7 +78,7 @@ is_keygen_supported_for_alg(pgp_pubkey_alg_t id)
 }
 
 static pgp_curve_t
-ask_curve()
+ask_curve(FILE *input_fp)
 {
     pgp_curve_t result = PGP_CURVE_MAX;
     long        val = 0;
@@ -89,7 +89,7 @@ ask_curve()
             printf("\t(%u) %s\n", i + 1, ec_curves[i].pgp_name);
         }
         printf("> ");
-        ok = rnp_secure_get_long_from_fd(stdin, &val);
+        ok = rnp_secure_get_long_from_fd(input_fp, &val);
         ok &= (val > 0) && (val < PGP_CURVE_MAX);
     } while (!ok);
 
@@ -101,7 +101,7 @@ ask_curve()
 }
 
 static long
-ask_algorithm()
+ask_algorithm(FILE *input_fp)
 {
     long result = 0;
     do {
@@ -112,18 +112,18 @@ ask_algorithm()
                "\t(22) EDDSA\n"
                "> ");
 
-    } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
+    } while (!rnp_secure_get_long_from_fd(input_fp, &result) ||
              !is_keygen_supported_for_alg(result));
     return result;
 }
 
 static long
-ask_bitlen()
+ask_bitlen(FILE *input_fp)
 {
     long result = 0;
     do {
         printf("Please provide bit length of the key (between 1024 and 4096):\n> ");
-    } while (!rnp_secure_get_long_from_fd(stdin, &result) ||
+    } while (!rnp_secure_get_long_from_fd(input_fp, &result) ||
              !is_rsa_keysize_supported(result));
     return result;
 }
@@ -144,7 +144,8 @@ ask_bitlen()
 pgp_errcode_t
 rnp_generate_key_expert_mode(rnp_t *rnp)
 {
-    rnp->action.generate_key_ctx.key_alg = (pgp_pubkey_alg_t) ask_algorithm();
+    FILE *input_fd = rnp->user_input_fp ? rnp->user_input_fp : stdin;
+    rnp->action.generate_key_ctx.key_alg = (pgp_pubkey_alg_t) ask_algorithm(input_fd);
 
     // get more details about the key
     switch (rnp->action.generate_key_ctx.key_alg) {
@@ -152,11 +153,11 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
         // Those algorithms must _NOT_ be supported
         //  case PGP_PKA_RSA_ENCRYPT_ONLY:
         //  case PGP_PKA_RSA_SIGN_ONLY:
-        rnp->action.generate_key_ctx.rsa.modulus_bit_len = ask_bitlen();
+        rnp->action.generate_key_ctx.rsa.modulus_bit_len = ask_bitlen(input_fd);
         break;
     case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
-        rnp->action.generate_key_ctx.ecc.curve = ask_curve();
+        rnp->action.generate_key_ctx.ecc.curve = ask_curve(input_fd);
         break;
     case PGP_PKA_EDDSA:
         rnp->action.generate_key_ctx.ecc.curve = PGP_CURVE_ED25519;

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -122,6 +122,7 @@ ask_bitlen(FILE *input_fp)
 {
     long result = 0;
     do {
+        result = 0;
         printf("Please provide bit length of the key (between 1024 and 4096):\n> ");
     } while (!rnp_secure_get_long_from_fd(input_fp, &result) ||
              !is_rsa_keysize_supported(result));

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS		= $(WARNCFLAGS) $(JSON_CFLAGS)
+AM_CFLAGS		= $(WARNCFLAGS) $(JSONC_INCLUDES)
 
 bin_PROGRAMS		= rnpv
 
@@ -10,8 +10,8 @@ rnpv_SOURCES	= \
 	misc.c \
 	pgpsum.c
 
-rnpv_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+rnpv_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
 
-rnpv_LDADD	= ../lib/librnp.la $(JSON_LIBS)
+rnpv_LDADD	= ../lib/librnp.la $(JSONC_LIBS)
 
 dist_man_MANS		= rnpv.1

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS		= $(WARNCFLAGS) $(JSON_CFLAGS)
 bin_PROGRAMS	= rnpv
-rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
 rnpv_LDADD	    = ../lib/librnp.la $(JSON_LIBS)
 dist_man_MANS	= rnpv.1
 rnpv_SOURCES    = \

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS		= $(WARNCFLAGS) $(JSON_CFLAGS)
 bin_PROGRAMS	= rnpv
-rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
+rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
 rnpv_LDADD	    = ../lib/librnp.la $(JSON_LIBS)
 dist_man_MANS	= rnpv.1
 rnpv_SOURCES    = \

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS		= $(WARNCFLAGS) $(JSONC_INCLUDES)
 bin_PROGRAMS	= rnpv
 rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
-rnpv_LDADD	    = ../lib/librnp.la $(JSON_LIBS)
+rnpv_LDADD	    = ../lib/librnp.la $(JSONC_LIBS)
 dist_man_MANS	= rnpv.1
 rnpv_SOURCES    = \
     b64.c \

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,17 +1,12 @@
-AM_CFLAGS		= $(WARNCFLAGS) $(JSONC_INCLUDES)
-
-bin_PROGRAMS		= rnpv
-
-rnpv_SOURCES	= \
-	b64.c \
-	bufgap.c \
-	libverify.c \
-	main.c \
-	misc.c \
-	pgpsum.c
-
-rnpv_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
-
-rnpv_LDADD	= ../lib/librnp.la $(JSONC_LIBS)
-
-dist_man_MANS		= rnpv.1
+AM_CFLAGS		= $(WARNCFLAGS) $(JSON_CFLAGS)
+bin_PROGRAMS	= rnpv
+rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
+rnpv_LDADD	    = ../lib/librnp.la $(JSON_LIBS)
+dist_man_MANS	= rnpv.1
+rnpv_SOURCES    = \
+    b64.c \
+    bufgap.c \
+    libverify.c \
+    main.c \
+    misc.c \
+    pgpsum.c

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,6 +1,6 @@
-AM_CFLAGS		= $(WARNCFLAGS) $(JSON_CFLAGS)
+AM_CFLAGS		= $(WARNCFLAGS) $(JSONC_INCLUDES)
 bin_PROGRAMS	= rnpv
-rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
+rnpv_CPPFLAGS   = -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
 rnpv_LDADD	    = ../lib/librnp.la $(JSON_LIBS)
 dist_man_MANS	= rnpv.1
 rnpv_SOURCES    = \


### PR DESCRIPTION
Number of changes here:
1. Code to be tested is in ``rnpkyes`` module. In order to test ``rnpkeys`` it needs to be build to static library that doesn't contain main() function. This patch splits rnpkeys.c in two files.
2. ``rnp_t`` structure contains ``passfp`` field which points to user input stream. Password is not the only input that user provides. Field name is now changed to  ``user_input_fp``. But, I think in the future we should add it to ``pgp_io_t`` and change code accordingly. Also function ``find_passphrase`` requires some changes (see 
#263). I believe both - changes to ``pgp_io_t`` and #263 should be addressed at the same time
3. tui.c: Must read from custom stream, not hardcoded ``stdin``.
4. Finally tests for expert mode were added.

Additionally, I've noticed that calling ``rnp_init`` ``rnp_end`` and again ``rnp_init`` causes segmentation fault as array ``rnp_t::names`` is incorrectly freed/initialized. I didn't investigated this further.