### PR TITLE
use pkgconfig for getting json-c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - BOTAN_INSTALL="$HOME/builds/botan-install"
     - CMOCKA_INSTALL="$HOME/builds/cmocka-install"
-    - JSON_C_INSTALL="$HOME/builds/json-c-install"
+    - JSONC_INSTALL="$HOME/builds/jsonc-install"
     - LOGNAME="Travis"
     - CLANG_FORMAT_DIFF="clang-format-diff-4.0"
 
@@ -44,7 +44,7 @@ cache:
   directories:
     - "$BOTAN_INSTALL"
     - "$CMOCKA_INSTALL"
-    - "$JSON_C_INSTALL"
+    - "$JSONC_INSTALL"
 
 install:
   - ./ci/install.sh

--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -93,7 +93,7 @@ git clone https://github.com/riboseinc/rnp
 cd rnp
 export BOTAN_INSTALL="$HOME/builds/botan-install"
 export CMOCKA_INSTALL="$HOME/builds/cmocka-install"
-export JSON_C_INSTALL="$HOME/builds/json-c-install"
+export JSONC_INSTALL="$HOME/builds/json-c-install"
 export BUILD_MODE=normal
 ci/install.sh
 env CC=clang ci/main.sh

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -27,13 +27,13 @@ if [ ! -e "${CMOCKA_INSTALL}/lib/libcmocka.so" ]; then
 fi
 
 # json-c
-if [ ! -e "${JSON_C_INSTALL}/lib/libjson-c.so" ]; then
+if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ]; then
   mkdir ~/builds/json-c
   cd ~/builds/json-c
   wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz -O json-c.tar.gz
   tar xzf json-c.tar.gz --strip 1
 
-  ./configure --prefix="${JSON_C_INSTALL}"
+  ./configure --prefix="${JSONC_INSTALL}"
   make -j${CORES} install
 fi
 

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -5,7 +5,7 @@ set -eux
 
 CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
 
-LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib"
+LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib"
 LDFLAGS="-L${CMOCKA_INSTALL}/lib"
 CFLAGS="-I${CMOCKA_INSTALL}/include"
 
@@ -23,7 +23,7 @@ CFLAGS="-I${CMOCKA_INSTALL}/include"
 export LD_LIBRARY_PATH CFLAGS LDFLAGS
 
 autoreconf -vfi
-./configure --with-botan=${BOTAN_INSTALL} PKG_CONFIG_PATH=${JSON_C_INSTALL}/lib/pkgconfig/
+./configure --with-botan=${BOTAN_INSTALL} --with-jsonc=${JSONC_INSTALL}
 make clean
 make -j${CORES}
 

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -5,9 +5,9 @@ set -eux
 
 CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
 
-LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSON_C_INSTALL}/lib"
-LDFLAGS="-L${CMOCKA_INSTALL}/lib -L${JSON_C_INSTALL}/lib -ljson-c"
-CFLAGS="-I${CMOCKA_INSTALL}/include -I${JSON_C_INSTALL}/include/json-c"
+LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib"
+LDFLAGS="-L${CMOCKA_INSTALL}/lib"
+CFLAGS="-I${CMOCKA_INSTALL}/include"
 
 [ "$BUILD_MODE" = "coverage" ] && CFLAGS+=" -O0 --coverage"
 
@@ -23,7 +23,7 @@ CFLAGS="-I${CMOCKA_INSTALL}/include -I${JSON_C_INSTALL}/include/json-c"
 export LD_LIBRARY_PATH CFLAGS LDFLAGS
 
 autoreconf -vfi
-./configure --with-botan=${BOTAN_INSTALL}
+./configure --with-botan=${BOTAN_INSTALL} PKG_CONFIG_PATH=${JSON_C_INSTALL}/lib/pkgconfig/
 make clean
 make -j${CORES}
 

--- a/configure.ac
+++ b/configure.ac
@@ -79,9 +79,8 @@ AC_CHECK_HEADERS([sys/cdefs.h sys/file.h sys/mman.h sys/param.h \
 AC_CHECK_HEADERS([bzlib.h],
                  [],
                  [AC_MSG_FAILURE([missing <bzlib.h>; is bzip2 installed?])])
-AC_CHECK_HEADERS([json.h],,
-  [AC_MSG_FAILURE([missing <json.h>; is json-c installed?])]
-)
+# Check JSON
+PKG_CHECK_MODULES(JSON, json-c,,,,[AC_MSG_ERR("json-c missing")])
 
 # Checks for typedefs, structures, and compiler characteristics.
 #
@@ -111,8 +110,6 @@ AX_CHECK_BOTAN_DEFINES([CFLAGS="$CFLAGS $BOTAN_INCLUDES"
 AC_SEARCH_LIBS([_cmocka_run_group_tests], [cmocka],,AC_MSG_ERROR(CMocka not found!))
 AC_SEARCH_LIBS([gzopen], [z],,AC_MSG_ERROR(libz not found!))
 AC_SEARCH_LIBS([BZ2_bzDecompress], [bz2],,AC_MSG_ERROR(Libbz2 not found!))
-AC_SEARCH_LIBS([json_object_new_object], [json-c],,AC_MSG_ERROR(json-c not found!))
-
 
 # Initialize the testsuite
 #

--- a/configure.ac
+++ b/configure.ac
@@ -79,17 +79,8 @@ AC_CHECK_HEADERS([sys/cdefs.h sys/file.h sys/mman.h sys/param.h \
 AC_CHECK_HEADERS([bzlib.h],
                  [],
                  [AC_MSG_FAILURE([missing <bzlib.h>; is bzip2 installed?])])
-# Check JSON
-PKG_CHECK_MODULES(JSON, json-c,,,,[AC_MSG_ERR("json-c missing")])
-# also checking the actual header in the given include path
-# for this we have to set CFLAGS to contain the include path got
-# from pkg-config, and restore afterwards
-SAVED_CFLAGS=$CFLAGS
-CFLAGS=$JSON_CFLAGS
-AC_CHECK_HEADER([json.h],,
-  [AC_MSG_FAILURE([missing <json.h>; is json-c properly installed?])]
-)
-CFLAGS=$SAVED_CFLAGS
+
+AX_CHECK_JSONC([], AC_MSG_ERROR([missing json-c library]))
 
 # Checks for typedefs, structures, and compiler characteristics.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,15 @@ AC_CHECK_HEADERS([bzlib.h],
                  [AC_MSG_FAILURE([missing <bzlib.h>; is bzip2 installed?])])
 # Check JSON
 PKG_CHECK_MODULES(JSON, json-c,,,,[AC_MSG_ERR("json-c missing")])
+# also checking the actual header in the given include path
+# for this we have to set CFLAGS to contain the include path got
+# from pkg-config, and restore afterwards
+SAVED_CFLAGS=$CFLAGS
+CFLAGS=$JSON_CFLAGS
+AC_CHECK_HEADER([json.h],,
+  [AC_MSG_FAILURE([missing <json.h>; is json-c properly installed?])]
+)
+CFLAGS=$SAVED_CFLAGS
 
 # Checks for typedefs, structures, and compiler characteristics.
 #

--- a/m4/ax_check_jsonc.m4
+++ b/m4/ax_check_jsonc.m4
@@ -1,0 +1,117 @@
+# SYNOPSIS
+#
+#   AX_CHECK_JSONC([action-if-found[, action-if-not-found]])
+#
+# DESCRIPTION
+#
+#   Look for json-c in a number of default spots, or in a user-selected
+#   spot (via --with-jsonc).  Sets
+#
+#     JSONC_INCLUDES to the include directives required
+#     JSONC_LIBS to the -l directives required
+#     JSONC_LDFLAGS to the -L or -R flags required
+#
+#   and calls ACTION-IF-FOUND or ACTION-IF-NOT-FOUND appropriately
+#
+#   This macro sets JSONC_INCLUDES such that source files should include
+#   json.h like so:
+#
+#     #include <json.h>
+#
+# LICENSE
+# Based on
+#     https://www.gnu.org/software/autoconf-archive/ax_check_jsonc.html
+#
+#   Copyright (c) 2009,2010 Zmanda Inc. <http://www.zmanda.com/>
+#   Copyright (c) 2009,2010 Dustin J. Mitchell <dustin@zmanda.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+AU_ALIAS([CHECK_JSONC], [AX_CHECK_JSONC])
+AC_DEFUN([AX_CHECK_JSONC], [
+    found=false
+    AC_ARG_WITH([jsonc],
+        [AS_HELP_STRING([--with-jsonc=DIR],
+            [root of the json-c directory])],
+        [
+            case "$withval" in
+            "" | y | ye | yes | n | no)
+            AC_MSG_ERROR([Invalid --with-jsonc value])
+              ;;
+            *) jsoncdirs="$withval"
+              ;;
+            esac
+        ], [
+            # if pkg-config is installed and jsonc has installed a .pc file,
+            # then use that information and don't search jsoncdirs
+            AC_CHECK_TOOL([PKG_CONFIG], [pkg-config])
+            if test x"$PKG_CONFIG" != x""; then
+                JSONC_LDFLAGS=`$PKG_CONFIG json-c --libs-only-L 2>/dev/null`
+                if test $? = 0; then
+                    JSONC_LIBS=`$PKG_CONFIG json-c --libs-only-l 2>/dev/null`
+                    JSONC_INCLUDES=`$PKG_CONFIG json-c --cflags-only-I 2>/dev/null`
+                    found=true
+                fi
+            fi
+
+            # no such luck; use some default jsoncdirs
+            if ! $found; then
+                jsoncdirs="/usr/local/json-c /usr/lib/json-c /usr/json-c /usr/pkg /usr/local /usr"
+            fi
+        ]
+        )
+
+
+    if ! $found; then
+        JSONC_INCLUDES=
+        for jsoncdir in $jsoncdirs; do
+            AC_MSG_CHECKING([for json.h in $jsoncdir])
+            if test -f "$jsoncdir/include/json-c/json.h"; then
+                JSONC_INCLUDES="-I$jsoncdir/include/json-c"
+                JSONC_LDFLAGS="-L$jsoncdir/lib"
+                JSONC_LIBS="-ljson-c"
+                found=true
+                AC_MSG_RESULT([yes])
+                break
+            else
+                AC_MSG_RESULT([no])
+            fi
+        done
+
+        # if the file wasn't found, well, go ahead and try the link anyway -- maybe
+        # it will just work!
+    fi
+
+    # try the preprocessor and linker with our new flags,
+    # being careful not to pollute the global LIBS, LDFLAGS, and CPPFLAGS
+
+    AC_MSG_CHECKING([whether compiling and linking against json-c works])
+    echo "Trying link with JSONC_LDFLAGS=$JSONC_LDFLAGS;" \
+        "JSONC_LIBS=$JSONC_LIBS; JSONC_INCLUDES=$JSONC_INCLUDES" >&AS_MESSAGE_LOG_FD
+
+    save_LIBS="$LIBS"
+    save_LDFLAGS="$LDFLAGS"
+    save_CPPFLAGS="$CPPFLAGS"
+    LDFLAGS="$LDFLAGS $JSONC_LDFLAGS"
+    LIBS="$JSONC_LIBS $LIBS"
+    CPPFLAGS="$JSONC_INCLUDES $CPPFLAGS"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([#include <json.h>], [json_object_new_object()])],
+        [
+            AC_MSG_RESULT([yes])
+            $1
+        ], [
+            AC_MSG_RESULT([no])
+            $2
+        ])
+    CPPFLAGS="$save_CPPFLAGS"
+    LDFLAGS="$save_LDFLAGS"
+    LIBS="$save_LIBS"
+
+    AC_SUBST([JSONC_INCLUDES])
+    AC_SUBST([JSONC_LIBS])
+    AC_SUBST([JSONC_LDFLAGS])
+])

--- a/src/cmocka/Makefile.am
+++ b/src/cmocka/Makefile.am
@@ -4,6 +4,6 @@ bin_PROGRAMS		= rnp_tests
 
 rnp_tests_SOURCES		= rnp_tests_support.c rnp_tests_cipher.c rnp_tests_generatekey.c rnp_tests_exportkey.c rnp_tests.c
 
-rnp_tests_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+rnp_tests_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
 
-rnp_tests_LDADD		= ../lib/librnp.la $(JSON_LIBS)
+rnp_tests_LDADD		= ../lib/librnp.la $(JSONC_LIBS)

--- a/src/fuzzing/Makefile.am
+++ b/src/fuzzing/Makefile.am
@@ -4,6 +4,6 @@ bin_PROGRAMS		= fuzz_keys
 
 fuzz_keys_SOURCES		= fuzz_keys.c
 
-fuzz_keys_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+fuzz_keys_CPPFLAGS		= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES)
 
 fuzz_keys_LDADD		= ../lib/librnp.la

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -1,8 +1,8 @@
 ## $NetBSD: Makefile.am,v 1.10 2010/11/29 06:21:40 agc Exp $
 
-AM_CFLAGS		= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSON_CFLAGS)
+AM_CFLAGS		= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSONC_INCLUDES)
 
-AM_LDFLAGS              = $(BOTAN_LDFLAGS)
+AM_LDFLAGS              = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
 
 lib_LTLIBRARIES		= librnp.la
 
@@ -38,6 +38,6 @@ librnp_la_SOURCES	= \
 	validate.c \
 	writer.c
 
-librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSON_LIBS)
+librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS)
 
 dist_man_MANS		= librnp.3

--- a/src/rnp/Makefile.am
+++ b/src/rnp/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS		= rnp
 
 rnp_SOURCES		= rnp.c
 
-rnp_CPPFLAGS		= -I$(top_srcdir)/include $(JSON_CFLAGS)
+rnp_CPPFLAGS		= -I$(top_srcdir)/include $(JSONC_INCLUDES)
 
 rnp_LDADD		= ../lib/librnp.la
 

--- a/src/rnp/Makefile.am
+++ b/src/rnp/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS		= rnp
 
 rnp_SOURCES		= rnp.c
 
-rnp_CPPFLAGS		= -I$(top_srcdir)/include
+rnp_CPPFLAGS		= -I$(top_srcdir)/include $(JSON_CFLAGS)
 
 rnp_LDADD		= ../lib/librnp.la
 

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -5,7 +5,7 @@ bin_PROGRAMS		= rnpkeys
 rnpkeys_SOURCES	=   rnpkeys.c \
                     tui.c
 
-rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include
+rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include $(JSON_CFLAGS)
 
 rnpkeys_LDADD	= ../lib/librnp.la
 

--- a/src/rnpkeys/Makefile.am
+++ b/src/rnpkeys/Makefile.am
@@ -5,7 +5,7 @@ bin_PROGRAMS		= rnpkeys
 rnpkeys_SOURCES	=   rnpkeys.c \
                     tui.c
 
-rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include $(JSON_CFLAGS)
+rnpkeys_CPPFLAGS	= -I$(top_srcdir)/include $(JSONC_INCLUDES)
 
 rnpkeys_LDADD	= ../lib/librnp.la
 

--- a/src/rnpv/Makefile.am
+++ b/src/rnpv/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS		= $(WARNCFLAGS) $(JSON_CFLAGS)
+AM_CFLAGS		= $(WARNCFLAGS) $(JSONC_INCLUDES)
 
 bin_PROGRAMS		= rnpv
 
@@ -10,8 +10,8 @@ rnpv_SOURCES	= \
 	misc.c \
 	pgpsum.c
 
-rnpv_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSON_CFLAGS)
+rnpv_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib
 
-rnpv_LDADD	= ../lib/librnp.la $(JSON_LIBS)
+rnpv_LDADD	= ../lib/librnp.la $(JSONC_LIBS)
 
 dist_man_MANS		= rnpv.1


### PR DESCRIPTION
 With the introduction of AC_CHECK_HEADERS in 4cdd9b5 the configure script couldn't find out of the box
the headers of a standard json-c implementation. To save the user from the need of manually
tinkering with the CFLAGS and co. we (re-)introduce using pkg-config to get the proper
compiler- and linker flags, while keeping the CI build (with non-standard json-c install path)
functioning by passing a custom PKG_CONFIG_PATH envvar to ./configure.