### PR TITLE
Fixes #210: --output option doesn't work when input is stdin

### DIFF
--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1072,24 +1072,23 @@ rnp_encrypt_file(rnp_ctx_t *ctx, const char *userid, const char *f, const char *
 {
     const pgp_key_t *key;
     const char *     suffix;
-    pgp_io_t *       io;
     char             outname[MAXPATHLEN];
 
-    io = ctx->rnp->io;
     if (f == NULL) {
-        (void) fprintf(io->errs, "rnp_encrypt_file: no filename specified\n");
+        (void) fprintf(ctx->rnp->io->errs, "rnp_encrypt_file: no filename specified\n");
         return RNP_FAIL;
     }
-    suffix = (ctx->armour) ? ".asc" : ".gpg";
     /* get key with which to sign */
     if ((key = resolve_userid(ctx->rnp, ctx->rnp->pubring, userid)) == NULL) {
         return RNP_FAIL;
     }
+    /* generate output file name if needed */
     if (out == NULL) {
+        suffix = (ctx->armour) ? ".asc" : ".gpg";
         (void) snprintf(outname, sizeof(outname), "%s%s", f, suffix);
         out = outname;
     }
-    return (int) pgp_encrypt_file(ctx, io, f, out, key);
+    return (int) pgp_encrypt_file(ctx, ctx->rnp->io, f, out, key);
 }
 
 #define ARMOR_HEAD "-----BEGIN PGP MESSAGE-----"

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -262,8 +262,6 @@ show_output(rnp_cfg_t *cfg, char *out, int size, const char *header)
         }
     }
 
-    
-
     if (fd != STDOUT_FILENO) {
         close(fd);
     }

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -247,21 +247,22 @@ show_output(rnp_cfg_t *cfg, char *out, int size, const char *header)
 
         fd = open(outfile, flags, 0600);
         if (fd < 0) {
-            if (overwrite && (errno == EEXIST)) {
-                fprintf(stderr, "Failed to write to the %s : file already exists.\n", outfile);
-            } else {
-                fprintf(
-                  stderr, "Failed to open file %s for writing : error %d.\n", outfile, errno);
-            }
+            fprintf(stderr, "Failed to write to the %s : %s.\n", outfile, strerror(errno));
             return RNP_FAIL;
         }
     }
 
     for (cc = 0; cc < size; cc += n) {
         if ((n = write(fd, &out[cc], size - cc)) <= 0) {
+            if (n < 0) {
+                fprintf(stderr, "Write failed: %s.\n", strerror(errno));
+            }
+
             break;
         }
     }
+
+    
 
     if (fd != STDOUT_FILENO) {
         close(fd);


### PR DESCRIPTION
For the rnp utility, during the signing/encryption/whatever else, --output option worked only for file input, i.e. when input filename is specified, and was ignored when input is stdin. Now it should work for stdin as well.