### PR TITLE
Fix memory leak and sig subpkt parsing issue with pgp keyrings.

### DIFF
--- a/src/lib/key_store_pgp.c
+++ b/src/lib/key_store_pgp.c
@@ -252,12 +252,11 @@ rnp_key_store_pgp_read_from_mem(pgp_io_t *       io,
 
     (void) memset(&cb, 0x0, sizeof(cb));
     cb.keyring = keyring;
-    stream = pgp_new(sizeof(*stream));
-    pgp_parse_options(stream, PGP_PTAG_SS_ALL, PGP_PARSE_PARSED);
     if (!pgp_setup_memory_read(io, &stream, mem, &cb, cb_keyring_read, noaccum)) {
         (void) fprintf(io->errs, "can't setup memory read\n");
         return RNP_FAIL;
     }
+    pgp_parse_options(stream, PGP_PTAG_SS_ALL, PGP_PARSE_PARSED);
     if (armour) {
         pgp_reader_push_dearmour(stream);
     }


### PR DESCRIPTION
Two issues here:
- We are allocating a stream twice, and leaking one. Once with pgp_new
and once with pgp_setup_memory_read.
- We were calling pgp_parse_options on the unused stream, so effectively
signature subpkts would never be parsed.

Fixes #278.