### PR TITLE
Fix uninitialized variable read in rnp_cmd.

### DIFF
--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -250,7 +250,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
     char *      out = NULL;
     char *      in = NULL;
     const char *outf;
-    const char *userid;
+    const char *userid = NULL;
     int         ret;
     int         cc;
     int         clearsign = (cmd == CMD_CLEARSIGN) ? 1 : 0;


### PR DESCRIPTION
Note: I have not looked in-depth at whether a larger problem exists here.
I have only noticed that my compiler does not like this and that it does appear there's a chance to read uninitialized data.

Fixes #280.