### PR TITLE
Add key flag loading/printing in listed keys.

### DIFF
--- a/src/lib/key_store_pgp.c
+++ b/src/lib/key_store_pgp.c
@@ -205,6 +205,10 @@ cb_keyring_read(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         revocation->code = pkt->u.ss_revocation.code;
         revocation->reason = rnp_strdup(pgp_show_ss_rr_code(pkt->u.ss_revocation.code));
         break;
+    case PGP_PTAG_SS_KEY_FLAGS:
+        key = &keyring->keys[keyring->keyc - 1];
+        key->flags = pkt->u.ss_key_flags.contents[0];
+        break;
     case PGP_PTAG_CT_SIGNATURE_FOOTER:
     case PGP_PARSER_ERRCODE:
         break;

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -606,6 +606,22 @@ typedef enum {
     PGP_SIG_3RD_PARTY = 0x50 /* Third-Party Confirmation signature */
 } pgp_sig_type_t;
 
+/** Key Flags
+ *
+ * \see RFC4880 5.2.3.21
+ */
+typedef enum {
+    PGP_KF_CERTIFY = 0x01,         /* This key may be used to certify other keys. */
+    PGP_KF_SIGN = 0x02,            /* This key may be used to sign data. */
+    PGP_KF_ENCRYPT_COMMS = 0x04,   /* This key may be used to encrypt communications. */
+    PGP_KF_ENCRYPT_STORAGE = 0x08, /* This key may be used to encrypt storage. */
+    PGP_KF_SPLIT = 0x10,           /* The private component of this key may have been split
+                                            by a secret-sharing mechanism. */
+    PGP_KF_AUTH = 0x20,            /* This key may be used for authentication. */
+    PGP_KF_SHARED = 0x80           /* The private component of this key may be in the
+                                            possession of more than one person. */
+} pgp_key_flags_t;
+
 /** Struct to hold params of an RSA signature */
 typedef struct pgp_rsa_sig_t {
     BIGNUM *sig; /* the signature value (m^d % n) */
@@ -1004,6 +1020,7 @@ typedef struct pgp_key_t {
     DYNARRAY(pgp_revoke_t, revoke);    /* array of signature revocations */
     pgp_content_enum  type;            /* type of key */
     pgp_keydata_key_t key;             /* pubkey/seckey data */
+    uint8_t           flags;           /* key flags */
     pgp_pubkey_t      sigkey;          /* signature key */
     uint8_t           sigid[PGP_KEY_ID_SIZE];
     pgp_fingerprint_t sigfingerprint; /* pgp signature fingerprint */

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -325,6 +325,10 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
         birthtime = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
         p(fp, " ", ptimestr(tbuf, sizeof(tbuf), birthtime), NULL);
 
+        if (json_object_object_get_ex(obj, "usage", &tmp)) {
+            p(fp, " [", json_object_get_string(tmp), "]", NULL);
+        }
+
         if (json_object_object_get_ex(obj, "duration", &tmp)) {
             duration = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
             if (duration > 0) {
@@ -356,6 +360,7 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
 
     if (json_object_object_get_ex(obj, "encryption", &tmp)) {
         if (!json_object_is_type(tmp, json_type_null)) {
+            json_object *usage;
             p(fp, "encryption", NULL);
             pobj(fp, json_object_array_get_idx(tmp, 0), 1); /* size */
             p(fp, "/", NULL);
@@ -368,8 +373,11 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
                        sizeof(tbuf),
                        (time_t) strtoll(
                          json_object_get_string(json_object_array_get_idx(tmp, 3)), NULL, 10)),
-              "\n",
               NULL);
+            if (json_object_object_get_ex(obj, "usage", &usage)) {
+                p(fp, " [", json_object_get_string(usage), "]", NULL);
+            }
+            p(fp, "\n", NULL);
         }
     }
 


### PR DESCRIPTION
`rnpkeys --list-keys` (and some other commands) will now show something like "[SC]" (sign+certify), similar to gpg.

This also adds key flags to the pgp_key_t structure. These are not currently used beyond loading them from
signature packets and printing them out.

list-packets already handles key flags, so no update there.

The JSON produced is like `{"flags": 3, "usage": "SC"}`. So the raw flags value is available as well as our interpretation of them.

**Known Issues**:
* With subkeys, this will typically show the flags for the wrong key. This will be fixed after https://github.com/riboseinc/rnp/issues/277. Since this has no effect, other than printing some output, I think it's OK for the moment.
* Key flags are not set during key generation, are not persisted to disk, etc. (ongoing effort)

Part of #35