### PR TITLE
Correct usage of rnp_keyid and rnp_fingerprint functions

### DIFF
--- a/src/lib/create.c
+++ b/src/lib/create.c
@@ -1265,7 +1265,7 @@ pgp_write_one_pass_sig(pgp_output_t *       output,
 {
     uint8_t keyid[PGP_KEY_ID_SIZE];
 
-    pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey, PGP_HASH_SHA1); /* XXX - hardcoded */
+    pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey);
     return pgp_write_ptag(output, PGP_PTAG_CT_1_PASS_SIG) &&
            pgp_write_length(output, 1 + 1 + 1 + 1 + 8 + 1) &&
            pgp_write_scalar(output, 3, 1) /* version */ &&

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -277,12 +277,10 @@ pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
     }
     seckey->checksum = 0;
 
-    if (pgp_keyid(
-          keydata->sigid, PGP_KEY_ID_SIZE, &keydata->key.seckey.pubkey, seckey->hash_alg) != 1)
+    if (pgp_keyid(keydata->sigid, PGP_KEY_ID_SIZE, &keydata->key.seckey.pubkey) != RNP_OK)
         goto end;
 
-    if (pgp_fingerprint(
-          &keydata->sigfingerprint, &keydata->key.seckey.pubkey, seckey->hash_alg) != 1)
+    if (pgp_fingerprint(&keydata->sigfingerprint, &keydata->key.seckey.pubkey) != RNP_OK)
         goto end;
 
     /* Generate checksum */

--- a/src/lib/key_store.c
+++ b/src/lib/key_store.c
@@ -521,16 +521,16 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
         }
         key = &keyring->keys[keyring->keyc++];
         (void) memset(key, 0x0, sizeof(*key));
-        pgp_keyid(key->sigid, PGP_KEY_ID_SIZE, &keydata->pubkey, keyring->hashtype);
-        pgp_fingerprint(&key->sigfingerprint, &keydata->pubkey, keyring->hashtype);
+        pgp_keyid(key->sigid, PGP_KEY_ID_SIZE, &keydata->pubkey);
+        pgp_fingerprint(&key->sigfingerprint, &keydata->pubkey);
         key->type = tag;
         key->key = *keydata;
     } else {
         // it's is a subkey, adding as enckey to master that was before the key
         // TODO: move to the right way — support multiple subkeys
         key = &keyring->keys[keyring->keyc - 1];
-        pgp_keyid(key->encid, PGP_KEY_ID_SIZE, &keydata->pubkey, keyring->hashtype);
-        pgp_fingerprint(&key->encfingerprint, &keydata->pubkey, keyring->hashtype);
+        pgp_keyid(key->encid, PGP_KEY_ID_SIZE, &keydata->pubkey);
+        pgp_fingerprint(&key->encfingerprint, &keydata->pubkey);
         (void) memcpy(&key->enckey, &keydata->pubkey, sizeof(key->enckey));
         key->enckey.duration = key->key.pubkey.duration;
     }

--- a/src/lib/key_store.h
+++ b/src/lib/key_store.h
@@ -111,7 +111,6 @@ typedef struct {
 typedef struct rnp_key_store_t {
     DYNARRAY(pgp_key_t, key);
     DYNARRAY(kbx_blob_t *, blob);
-    pgp_hash_alg_t hashtype;
 } rnp_key_store_t;
 
 int rnp_key_store_load_keys(rnp_t *rnp, int loadsecret);

--- a/src/lib/key_store_ssh.c
+++ b/src/lib/key_store_ssh.c
@@ -157,24 +157,6 @@ getbignum(bufgap_t *bg, char *buf, const char *header)
     return bignum;
 }
 
-#if 0
-static int
-putbignum(bufgap_t *bg, BIGNUM *bignum)
-{
-    uint32_t     len;
-
-    len = BN_num_bytes(bignum);
-    (void) bufgap_insert(bg, &len, sizeof(len));
-    (void) bufgap_insert(bg, buf, len);
-    bignum = BN_bin2bn((const uint8_t *)buf, (int)len, NULL);
-    if (rnp_get_debug(__FILE__)) {
-        hexdump(stderr, header, buf, (int)len);
-    }
-    (void) bufgap_seek(bg, len, BGFromHere, BGByte);
-    return bignum;
-}
-#endif
-
 static str_t pkatypes[] = {{"ssh-rsa", 7, PGP_PKA_RSA},
                            {"ssh-dss", 7, PGP_PKA_DSA},
                            {"ssh-dsa", 7, PGP_PKA_DSA},
@@ -194,9 +176,59 @@ findstr(str_t *array, const char *name)
     return -1;
 }
 
+/* ssh-style fingerprint calculation, moved here from the pgp_fingerprint */
+static int
+ssh_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
+{
+    pgp_memory_t *mem;
+    pgp_hash_t    hash = {0};
+    const char *  type;
+    uint32_t      len;
+
+    if (!pgp_hash_create(&hash, PGP_HASH_MD5)) {
+        (void) fprintf(stderr, "ssh_fingerprint: bad md5 alloc\n");
+        return RNP_FAIL;
+    }
+
+    type = (key->alg == PGP_PKA_RSA) ? "ssh-rsa" : "ssh-dss";
+    hash_string(&hash, (const uint8_t *) (const void *) type, (unsigned) strlen(type));
+    switch (key->alg) {
+    case PGP_PKA_RSA:
+        hash_bignum(&hash, key->key.rsa.e);
+        hash_bignum(&hash, key->key.rsa.n);
+        break;
+    case PGP_PKA_DSA:
+        hash_bignum(&hash, key->key.dsa.p);
+        hash_bignum(&hash, key->key.dsa.q);
+        hash_bignum(&hash, key->key.dsa.g);
+        hash_bignum(&hash, key->key.dsa.y);
+        break;
+    default:
+        break;
+    }
+
+    fp->length = pgp_hash_finish(&hash, fp->fingerprint);
+    if (rnp_get_debug(__FILE__)) {
+        hexdump(stderr, "md5 ssh fingerprint", fp->fingerprint, fp->length);
+    }
+
+    return RNP_OK;
+}
+
+static int
+ssh_keyid(uint8_t *keyid, const size_t idlen, const pgp_pubkey_t *key)
+{
+    pgp_fingerprint_t finger;
+
+    ssh_fingerprint(&finger, key);
+    (void) memcpy(keyid, finger.fingerprint + finger.length - idlen, idlen);
+
+    return RNP_OK;
+}
+
 /* convert an ssh (host) pubkey to a pgp pubkey */
 static int
-ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hashtype)
+ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key)
 {
     pgp_pubkey_t *pubkey;
     struct stat   st;
@@ -339,9 +371,9 @@ ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hashtype)
             snprintf(buffer, buffer_size, "%s (%s) <%s>", hostname, f, owner);
             userid = (uint8_t *) buffer;
         }
-        pgp_keyid(key->sigid, sizeof(key->sigid), pubkey, hashtype);
+        ssh_keyid(key->sigid, sizeof(key->sigid), pubkey);
         pgp_add_userid(key, userid);
-        pgp_fingerprint(&key->sigfingerprint, pubkey, hashtype);
+        ssh_fingerprint(&key->sigfingerprint, pubkey);
 
         free((void *) userid);
 
@@ -358,8 +390,7 @@ ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_hash_alg_t hashtype)
 
 /* convert an ssh (host) seckey to a pgp seckey */
 static int
-ssh2seckey(
-  pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey, pgp_hash_alg_t hashtype)
+ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey)
 {
     pgp_crypt_t crypted;
     uint8_t     sesskey[PGP_MAX_KEY_SIZE];
@@ -406,8 +437,8 @@ ssh2seckey(
     pgp_cipher_set_iv(&crypted, key->key.seckey.iv);
     pgp_cipher_set_key(&crypted, sesskey);
     pgp_encrypt_init(&crypted);
-    pgp_fingerprint(&key->sigfingerprint, pubkey, hashtype);
-    pgp_keyid(key->sigid, sizeof(key->sigid), pubkey, hashtype);
+    ssh_fingerprint(&key->sigfingerprint, pubkey);
+    ssh_keyid(key->sigid, sizeof(key->sigid), pubkey);
     return RNP_OK;
 }
 
@@ -429,7 +460,7 @@ ssh2_readkeys(pgp_io_t *       io,
         if (rnp_get_debug(__FILE__)) {
             (void) fprintf(io->errs, "ssh2_readkeys: pubfile '%s'\n", pubfile);
         }
-        if (!ssh2pubkey(io, pubfile, &key, pubring->hashtype)) {
+        if (!ssh2pubkey(io, pubfile, &key)) {
             (void) fprintf(io->errs, "ssh2_readkeys: can't read pubkeys '%s'\n", pubfile);
             return RNP_FAIL;
         }
@@ -448,7 +479,7 @@ ssh2_readkeys(pgp_io_t *       io,
         if (pubkey == NULL) {
             pubkey = &pubring->keys[0];
         }
-        if (!ssh2seckey(io, secfile, &key, &pubkey->key.pubkey, secring->hashtype)) {
+        if (!ssh2seckey(io, secfile, &key, &pubkey->key.pubkey)) {
             (void) fprintf(io->errs, "ssh2_readkeys: can't read seckeys '%s'\n", secfile);
             return RNP_FAIL;
         }
@@ -588,7 +619,7 @@ rnp_key_store_ssh_from_file(pgp_io_t *io, rnp_key_store_t *keyring, const char *
           io->errs, "rnp_key_store_ssh_from_file: read as pubkey '%s'\n", filename);
     }
 
-    if (ssh2pubkey(io, filename, &key, keyring->hashtype)) {
+    if (ssh2pubkey(io, filename, &key)) {
         (void) fprintf(io->errs, "rnp_key_store_ssh_from_file: it's pubkeys '%s'\n", filename);
         rnp_key_store_add_key(io, keyring, &key, PGP_PTAG_CT_PUBLIC_KEY);
         return RNP_OK;
@@ -600,13 +631,13 @@ rnp_key_store_ssh_from_file(pgp_io_t *io, rnp_key_store_t *keyring, const char *
     }
 
     (void) snprintf(f, sizeof(f), "%s.pub", filename);
-    if (!ssh2pubkey(io, filename, &pubkey, keyring->hashtype)) {
+    if (!ssh2pubkey(io, filename, &pubkey)) {
         (void) fprintf(
           io->errs, "rnp_key_store_ssh_from_file: can't read pubkey from '%s'\n", f);
         return RNP_FAIL;
     }
 
-    if (ssh2seckey(io, filename, &key, &pubkey.key.pubkey, keyring->hashtype)) {
+    if (ssh2seckey(io, filename, &key, &pubkey.key.pubkey)) {
         (void) fprintf(io->errs, "rnp_key_store_ssh_from_file: it's seckey '%s'\n", filename);
         rnp_key_store_add_key(io, keyring, &key, PGP_PTAG_CT_SECRET_KEY);
         return RNP_OK;

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -913,8 +913,8 @@ typedef struct pgp_fingerprint_t {
     pgp_hash_alg_t hashtype;
 } pgp_fingerprint_t;
 
-int pgp_keyid(uint8_t *, const size_t, const pgp_pubkey_t *, pgp_hash_alg_t);
-int pgp_fingerprint(pgp_fingerprint_t *, const pgp_pubkey_t *, pgp_hash_alg_t);
+int pgp_keyid(uint8_t *, const size_t, const pgp_pubkey_t *);
+int pgp_fingerprint(pgp_fingerprint_t *, const pgp_pubkey_t *);
 
 void pgp_finish(void);
 void pgp_pubkey_free(pgp_pubkey_t *);

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -1053,7 +1053,7 @@ pgp_sign_file(rnp_ctx_t *         ctx,
             return RNP_FAIL;
         }
 
-        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey, hash_alg);
+        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey);
         ret = pgp_add_issuer_keyid(sig, keyid) && pgp_end_hashed_subpkts(sig) &&
               pgp_write_sig(output, sig, &seckey->pubkey, seckey);
 
@@ -1083,7 +1083,7 @@ pgp_sign_file(rnp_ctx_t *         ctx,
         pgp_add_time(sig, (int64_t) ctx->sigcreate, PGP_PTAG_SS_CREATION_TIME);
         pgp_add_time(sig, (int64_t) ctx->sigexpire, PGP_PTAG_SS_EXPIRATION_TIME);
         /* add key id to signature */
-        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey, hash_alg);
+        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey);
         pgp_add_issuer_keyid(sig, keyid);
         pgp_end_hashed_subpkts(sig);
         pgp_write_sig(output, sig, &seckey->pubkey, seckey);
@@ -1179,7 +1179,7 @@ pgp_sign_buf(rnp_ctx_t *         ctx,
         if (ret == 0) {
             return NULL;
         }
-        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey, hash_alg);
+        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey);
         ret = pgp_add_issuer_keyid(sig, keyid) && pgp_end_hashed_subpkts(sig) &&
               pgp_write_sig(output, sig, &seckey->pubkey, seckey);
 
@@ -1214,7 +1214,7 @@ pgp_sign_buf(rnp_ctx_t *         ctx,
         pgp_add_time(sig, ctx->sigcreate, PGP_PTAG_SS_CREATION_TIME);
         pgp_add_time(sig, (int64_t) ctx->sigexpire, PGP_PTAG_SS_EXPIRATION_TIME);
         /* add key id to signature */
-        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey, hash_alg);
+        pgp_keyid(keyid, PGP_KEY_ID_SIZE, &seckey->pubkey);
         pgp_add_issuer_keyid(sig, keyid);
         pgp_end_hashed_subpkts(sig);
 
@@ -1287,7 +1287,7 @@ pgp_sign_detached(
     /* calculate the signature */
     pgp_add_time(sig, ctx->sigcreate, PGP_PTAG_SS_CREATION_TIME);
     pgp_add_time(sig, (int64_t) ctx->sigexpire, PGP_PTAG_SS_EXPIRATION_TIME);
-    pgp_keyid(keyid, sizeof(keyid), &seckey->pubkey, hash_alg);
+    pgp_keyid(keyid, sizeof(keyid), &seckey->pubkey);
     pgp_add_issuer_keyid(sig, keyid);
     pgp_end_hashed_subpkts(sig);
     pgp_write_sig(output, sig, &seckey->pubkey, seckey);


### PR DESCRIPTION
This PR fixes usage of rnp_keyid and rnp_fingerprint functions by removing hashtype parameter.
Also it was removed from the keyring.
The only purpose of these parameters was support for custom ssh fingerprint calculation.
So I added ssh_keyid and ssh_fingerprint static functions as this code is used only in ssh_keystore.c, and cleaned up main pgp code.

Waiting for approval of the PR #299 since it includes some more changes to ssh_keystore making it compilable.