### PR TITLE
Set hash algorithm while calculating fingerprint

### DIFF
--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -397,7 +397,6 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "v2/v3 fingerprint", fp->fingerprint, fp->length);
         }
-        fp->hashtype = PGP_HASH_MD5;
     } else if (key->version == 4) {
         mem = pgp_memory_new();
         if (mem == NULL) {
@@ -419,7 +418,6 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "sha1 fingerprint", fp->fingerprint, fp->length);
         }
-        fp->hashtype = PGP_HASH_SHA1;
     } else {
         (void) fprintf(stderr, "pgp_fingerprint: unsupported key version\n");
         return RNP_FAIL;

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -397,6 +397,7 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "v2/v3 fingerprint", fp->fingerprint, fp->length);
         }
+        fp->hashtype = PGP_HASH_MD5;
     } else if (key->version == 4) {
         mem = pgp_memory_new();
         if (mem == NULL) {
@@ -418,6 +419,7 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "sha1 fingerprint", fp->fingerprint, fp->length);
         }
+        fp->hashtype = PGP_HASH_SHA1;
     } else {
         (void) fprintf(stderr, "pgp_fingerprint: unsupported key version\n");
         return RNP_FAIL;

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1022,10 +1022,10 @@ typedef struct pgp_key_t {
     uint8_t           flags;           /* key flags */
     pgp_pubkey_t      sigkey;          /* signature key */
     uint8_t           sigid[PGP_KEY_ID_SIZE];
-    pgp_fingerprint_t sigfingerprint; /* pgp signature fingerprint */
+    pgp_fingerprint_t sigfingerprint; /* pgp key fingerprint */
     pgp_pubkey_t      enckey;         /* encryption key */
     uint8_t           encid[PGP_KEY_ID_SIZE];
-    pgp_fingerprint_t encfingerprint; /* pgp encryption id fingerprint */
+    pgp_fingerprint_t encfingerprint; /* deprecated (see GH #277) */
     uint32_t          uid0;           /* primary uid index in uids array */
     uint8_t           revoked;        /* key has been revoked */
     pgp_revoke_t      revocation;     /* revocation reason */

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -908,9 +908,8 @@ struct pgp_packet_t {
 
 /** pgp_fingerprint_t */
 typedef struct pgp_fingerprint_t {
-    uint8_t        fingerprint[PGP_FINGERPRINT_SIZE];
-    unsigned       length;
-    pgp_hash_alg_t hashtype;
+    uint8_t  fingerprint[PGP_FINGERPRINT_SIZE];
+    unsigned length;
 } pgp_fingerprint_t;
 
 int pgp_keyid(uint8_t *, const size_t, const pgp_pubkey_t *);


### PR DESCRIPTION
Found during ECDH development - hash algorithm was not set when fingerprint is calculated.