### PR TITLE
Fixes #256: duplication of keys in keyring after the new key generation

### DIFF
--- a/src/lib/key_store.c
+++ b/src/lib/key_store.c
@@ -504,6 +504,7 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
         pgp_fingerprint(&key->sigfingerprint, &keydata->pubkey);
         key->type = tag;
         key->key = *keydata;
+        key->loaded = 1;
     } else {
         // it's is a subkey, adding as enckey to master that was before the key
         // TODO: move to the right way — support multiple subkeys

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1030,6 +1030,7 @@ typedef struct pgp_key_t {
     uint32_t          uid0;           /* primary uid index in uids array */
     uint8_t           revoked;        /* key has been revoked */
     pgp_revoke_t      revocation;     /* revocation reason */
+    uint8_t           loaded;         /* key was loaded so has key packet in subpackets */
 } pgp_key_t;
 
 /* structure used to hold context of key generation */


### PR DESCRIPTION
When key is loaded then all packets are saved into the sub packets array. Then, when keyring is re-saved all those packets were written together with public key packet + user id, causing duplication of key + user id packets on output. I changed this behavior that now for loaded key pub key and userid are saved from records only for non-loaded keys. This also have another meaning : already existing packets should written as they were to not break to the signature.

This solution is quick and dirty since within current implementation of key data structures it is hard to imagine correct working of multiple user ids, subkeys, signatures, direct key signatures and so on. 

@dewyatt I will write separate post about it somewhere, since it is closely related to what you are doing now.