### PR TITLE
Don't mix Edwards and Bernstein curves

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -109,7 +109,7 @@ const ec_curve_desc_t ec_curves[] = {
    {0x2b, 0x06, 0x01, 0x04, 0x01, 0xda, 0x47, 0x0f, 0x01},
    9,
    "Ed25519",
-   "Curve 25519"}};
+   "Ed25519"}};
 
 /**
 \ingroup Core_MPI


### PR DESCRIPTION
Found during ECDH development.

We display wrong name of the curve