### PR TITLE
Rename pgp_subpacket_t and add tag field

### DIFF
--- a/src/lib/key_store.c
+++ b/src/lib/key_store.c
@@ -453,7 +453,7 @@ rnp_key_store_add_key(pgp_io_t *       io,
         if (newkey->packets == NULL) {
             return false;
         }
-        memcpy(&newkey->packets[newkey->packetc], &key->packets[i], sizeof(pgp_subpacket_t));
+        memcpy(&newkey->packets[newkey->packetc], &key->packets[i], sizeof(pgp_rawpacket_t));
         newkey->packetc++;
     }
 

--- a/src/lib/key_store_pgp.c
+++ b/src/lib/key_store_pgp.c
@@ -79,7 +79,7 @@ __RCSID("$NetBSD: keyring.c,v 1.50 2011/06/25 00:37:44 agc Exp $");
 #include "utils.h"
 #include "packet.h"
 
-void print_packet_hex(const pgp_subpacket_t *pkt);
+void print_packet_hex(const pgp_rawpacket_t *pkt);
 
 /* used to point to data during keyring read */
 typedef struct keyringcb_t {

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -3147,11 +3147,12 @@ parse_mdc(pgp_region_t *region, pgp_stream_t *stream)
 static rnp_result
 parse_packet(pgp_stream_t *stream, uint32_t *pktlen)
 {
-    pgp_packet_t pkt = {0};
-    pgp_region_t region = {0};
-    uint8_t      ptag;
-    unsigned     indeterminate = 0;
-    int          ret;
+    pgp_packet_t     pkt = {0};
+    pgp_region_t     region = {0};
+    uint8_t          ptag;
+    unsigned         indeterminate = 0;
+    int              ret;
+    pgp_content_enum tag;
 
     pkt.u.ptag.position = stream->readinfo.position;
 
@@ -3210,6 +3211,7 @@ parse_packet(pgp_stream_t *stream, uint32_t *pktlen)
             return RNP_ERROR_GENERIC;
         }
     }
+    tag = pkt.u.ptag.type;
 
     CALLBACK(PGP_PARSER_PTAG, &stream->cbinfo, &pkt);
 
@@ -3305,6 +3307,7 @@ parse_packet(pgp_stream_t *stream, uint32_t *pktlen)
     if (ret > 0 && stream->readinfo.accumulate) {
         pkt.u.packet.length = stream->readinfo.alength;
         pkt.u.packet.raw = stream->readinfo.accumulated;
+        pkt.u.packet.tag = tag;
         stream->readinfo.accumulated = NULL;
         stream->readinfo.asize = 0;
         CALLBACK(PGP_PARSER_PACKET_END, &stream->cbinfo, &pkt);

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -881,7 +881,7 @@ string_free(char **str)
 */
 /* ! Free packet memory, set pointer to NULL */
 void
-pgp_subpacket_free(pgp_subpacket_t *packet)
+pgp_rawpacket_free(pgp_rawpacket_t *packet)
 {
     if (packet->raw == NULL) {
         return;
@@ -1136,7 +1136,7 @@ pgp_parser_content_free(pgp_packet_t *c)
         break;
 
     case PGP_PARSER_PACKET_END:
-        pgp_subpacket_free(&c->u.packet);
+        pgp_rawpacket_free(&c->u.packet);
         break;
 
     case PGP_PTAG_RAW_SS:
@@ -3577,7 +3577,7 @@ accumulate_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         return PGP_KEEP_MEMORY;
     case PGP_PARSER_PACKET_END:
         if (keyring->keyc > 0) {
-            pgp_add_subpacket(&keyring->keys[keyring->keyc - 1], &content->packet);
+            pgp_add_rawpacket(&keyring->keys[keyring->keyc - 1], &content->packet);
             return PGP_KEEP_MEMORY;
         }
         return PGP_RELEASE_MEMORY;

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -192,7 +192,7 @@ print_bn(int indent, const char *name, const BIGNUM *bn)
 }
 
 static void
-print_packet_hex(const pgp_subpacket_t *pkt)
+print_packet_hex(const pgp_rawpacket_t *pkt)
 {
     hexdump(stdout, "packet contents:", pkt->raw, pkt->length);
 }

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -709,11 +709,11 @@ typedef struct pgp_ss_sig_target_t {
     pgp_data_t       hash;
 } pgp_ss_sig_target_t;
 
-/** pgp_subpacket_t */
-typedef struct pgp_subpacket_t {
+/** pgp_rawpacket_t */
+typedef struct pgp_rawpacket_t {
     size_t   length;
     uint8_t *raw;
-} pgp_subpacket_t;
+} pgp_rawpacket_t;
 
 /** Types of Compression */
 typedef enum {
@@ -860,7 +860,7 @@ typedef union {
     time_t                  ss_time;
     uint8_t                 ss_issuer[PGP_KEY_ID_SIZE];
     pgp_ss_notation_t       ss_notation;
-    pgp_subpacket_t         packet;
+    pgp_rawpacket_t         packet;
     pgp_compression_type_t  compressed;
     pgp_one_pass_sig_t      one_pass_sig;
     pgp_data_t              ss_skapref;
@@ -926,7 +926,7 @@ void pgp_ss_notation_free(pgp_ss_notation_t *);
 void pgp_ss_revocation_free(pgp_ss_revocation_t *);
 void pgp_ss_sig_target_free(pgp_ss_sig_target_t *);
 
-void pgp_subpacket_free(pgp_subpacket_t *);
+void pgp_rawpacket_free(pgp_rawpacket_t *);
 void pgp_parser_content_free(pgp_packet_t *);
 void pgp_seckey_free(pgp_seckey_t *);
 void pgp_pk_sesskey_free(pgp_pk_sesskey_t *);
@@ -993,7 +993,7 @@ typedef union {
 /* sigpacket_t */
 typedef struct sigpacket_t {
     uint8_t **       userid;
-    pgp_subpacket_t *packet;
+    pgp_rawpacket_t *packet;
 } sigpacket_t;
 
 /* user revocation info */
@@ -1014,7 +1014,7 @@ typedef struct pgp_subsig_t {
 /* describes a user's key */
 typedef struct pgp_key_t {
     DYNARRAY(uint8_t *, uid);          /* array of user ids */
-    DYNARRAY(pgp_subpacket_t, packet); /* array of raw subpackets */
+    DYNARRAY(pgp_rawpacket_t, packet); /* array of raw packets */
     DYNARRAY(pgp_subsig_t, subsig);    /* array of signature subkeys */
     DYNARRAY(pgp_revoke_t, revoke);    /* array of signature revocations */
     pgp_content_enum  type;            /* type of key */

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -711,8 +711,9 @@ typedef struct pgp_ss_sig_target_t {
 
 /** pgp_rawpacket_t */
 typedef struct pgp_rawpacket_t {
-    size_t   length;
-    uint8_t *raw;
+    pgp_content_enum tag;
+    size_t           length;
+    uint8_t *        raw;
 } pgp_rawpacket_t;
 
 /** Types of Compression */

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -106,7 +106,7 @@ pgp_keydata_free(pgp_key_t *keydata)
 
     if (keydata->packets != NULL) {
         for (n = 0; n < keydata->packetc; ++n) {
-            pgp_subpacket_free(&keydata->packets[n]);
+            pgp_rawpacket_free(&keydata->packets[n]);
         }
         free(keydata->packets);
         keydata->packets = NULL;
@@ -392,8 +392,8 @@ copy_userid(uint8_t **dst, const uint8_t *src)
 \param src Source packet
 \note If dst already has a packet, it will be freed.
 */
-static pgp_subpacket_t *
-copy_packet(pgp_subpacket_t *dst, const pgp_subpacket_t *src)
+static pgp_rawpacket_t *
+copy_packet(pgp_rawpacket_t *dst, const pgp_rawpacket_t *src)
 {
     if (dst->raw) {
         free(dst->raw);
@@ -437,10 +437,10 @@ pgp_add_userid(pgp_key_t *key, const uint8_t *userid)
 \param packet Packet to add
 \return Pointer to new packet
 */
-pgp_subpacket_t *
-pgp_add_subpacket(pgp_key_t *keydata, const pgp_subpacket_t *packet)
+pgp_rawpacket_t *
+pgp_add_rawpacket(pgp_key_t *keydata, const pgp_rawpacket_t *packet)
 {
-    pgp_subpacket_t *subpktp;
+    pgp_rawpacket_t *subpktp;
 
     EXPAND_ARRAY(keydata, packet);
     if (keydata->packets == NULL) {
@@ -465,7 +465,7 @@ bool
 pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
 {
     struct pgp_create_sig_t *sig;
-    pgp_subpacket_t          sigpacket;
+    pgp_rawpacket_t          sigpacket;
     struct pgp_memory_t *    mem_userid = NULL;
     pgp_output_t *           useridoutput = NULL;
     struct pgp_memory_t *    mem_sig = NULL;
@@ -503,7 +503,7 @@ pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
 
     /* add userid to key */
     (void) pgp_add_userid(key, userid);
-    (void) pgp_add_subpacket(key, &sigpacket);
+    (void) pgp_add_rawpacket(key, &sigpacket);
 
     /* cleanup */
     pgp_create_sig_delete(sig);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -82,7 +82,7 @@ const unsigned char *pgp_get_userid(const pgp_key_t *, unsigned);
 
 unsigned char *pgp_add_userid(pgp_key_t *, const unsigned char *);
 
-struct pgp_subpacket_t *pgp_add_subpacket(pgp_key_t *, const pgp_subpacket_t *);
+struct pgp_rawpacket_t *pgp_add_rawpacket(pgp_key_t *, const pgp_rawpacket_t *);
 
 bool pgp_add_selfsigned_userid(pgp_key_t *, const unsigned char *);
 


### PR DESCRIPTION
* Rename pgp_subpacket_t to pgp_rawpacket_t. The naming on this is very misleading and it confuses me every time I see it.
This structure never had anything to do with signature subpackets, it's just a raw chunk of data. 
In OpenPGP-SDK this was called ops_packet_t, which probably made more sense. Unfortunately, we use pgp_packet_t to refer to what OpenPGP-SDK called ops_parser_content_t (parsed pkts).

* Add tag field to pgp_rawpacket_t
I have plans to use this and I think it makes sense to toss it into the structure since it's already been parsed out.