### PR TITLE
#328 autohell

### DIFF
--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -11,3 +11,7 @@ rnp_tests_SOURCES   = \
     rnp_tests.c \
     utils-list.c \
     pgp-parse.c
+
+# don't install any test stuff
+install-binPROGRAMS:
+uninstall-binPROGRAMS:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ TESTSUITE_DEPS	= \
 	crypt.at \
 	detached.at \
 	verify.at \
+	rnp_tests.at \
 	package.m4 \
 	testsuite.at
 

--- a/tests/rnp_tests.at
+++ b/tests/rnp_tests.at
@@ -1,0 +1,5 @@
+AT_SETUP([run rnp_tests])
+
+AT_CHECK([${TOPSRCDIR}/src/tests/rnp_tests], [0], [ignore], [ignore])
+
+AT_CLEANUP

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -12,3 +12,5 @@ m4_include([cat.at])
 m4_include([crypt.at])
 m4_include([detached.at])
 m4_include([verify.at])
+
+m4_include([rnp_tests.at])


### PR DESCRIPTION
Hey,

I just:
 - removed from `make install` test program;
 - added runs this test program to `make check`.

for https://github.com/riboseinc/rnp/pull/327 and https://github.com/riboseinc/rnp/pull/328

But `make check` is broken right now:
```
## --------------------------- ##
## rnp 0.8.0~ test suite: rnp. ##
## --------------------------- ##
  1: tests with no default userid in gpg.conf        ok
  2: init                                            ok
  3: attached signature and verification             ok
  4: encryption and decryption                       FAILED (crypt.at:13)
  5: detached signature and verification             ok
  6: simple signature and verification               ok
  7: run rnp_tests                                   ok
``` 

But it was broken at https://github.com/riboseinc/rnp/commit/551a1c8e5220da8e82da2e38c0755413070a1727
```
## ----------------------------------- ##
## netpgp 20140220 test suite: netpgp. ##
## ----------------------------------- ##
  1: tests with no default userid in gpg.conf        ok
  2: init                                            ok
  3: attached signature and verification             ok
  4: encryption and decryption                       FAILED (crypt.at:9)
  5: detached signature and verification             ok
  6: simple signature and verification               ok
```

So, I created an issue https://github.com/riboseinc/rnp/issues/330 to fix it one day ;)