### PR TITLE
Rename misleading keydata items to key.

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -240,15 +240,15 @@ pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
     pgp_seckey_t *seckey = NULL;
     pgp_output_t *output = NULL;
     pgp_memory_t *mem = NULL;
-    pgp_key_t *   keydata = NULL;
+    pgp_key_t *   key = NULL;
     bool          ok = false;
 
-    keydata = pgp_keydata_new();
-    if (!keydata)
+    key = pgp_key_new();
+    if (!key)
         goto end;
 
-    pgp_keydata_init(keydata, PGP_PTAG_CT_SECRET_KEY);
-    seckey = pgp_get_writable_seckey(keydata);
+    pgp_key_init(key, PGP_PTAG_CT_SECRET_KEY);
+    seckey = pgp_get_writable_seckey(key);
     if (!seckey)
         goto end;
 
@@ -289,10 +289,10 @@ pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
     }
     seckey->checksum = 0;
 
-    if (!pgp_keyid(keydata->sigid, PGP_KEY_ID_SIZE, &keydata->key.seckey.pubkey))
+    if (!pgp_keyid(key->sigid, PGP_KEY_ID_SIZE, &key->key.seckey.pubkey))
         goto end;
 
-    if (!pgp_fingerprint(&keydata->sigfingerprint, &keydata->key.seckey.pubkey))
+    if (!pgp_fingerprint(&key->sigfingerprint, &key->key.seckey.pubkey))
         goto end;
 
     /* Generate checksum */
@@ -318,7 +318,7 @@ pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
         goto end;
     }
 
-    if (userid != NULL && !pgp_add_selfsigned_userid(keydata, userid)) {
+    if (userid != NULL && !pgp_add_selfsigned_userid(key, userid)) {
         goto end;
     }
 
@@ -330,12 +330,12 @@ end:
     }
 
     if (ok == false) {
-        if (keydata != NULL) {
-            pgp_keydata_free(keydata);
+        if (key != NULL) {
+            pgp_key_free(key);
         }
         return NULL;
     }
-    return keydata;
+    return key;
 }
 
 static pgp_cb_ret_t

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -138,7 +138,7 @@ struct pgp_reader_t {
 struct pgp_cryptinfo_t {
     char *           passphrase;
     rnp_key_store_t *secring;
-    const pgp_key_t *keydata;
+    const pgp_key_t *key;
     pgp_cbfunc_t *   getpassphrase;
     rnp_key_store_t *pubring;
 };

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -500,7 +500,7 @@ write_struct_pubkey(pgp_output_t *output, pgp_content_enum tag, const pgp_pubkey
 
    \brief Writes a transferable PGP public key to the given output stream.
 
-   \param keydata Key to be written
+   \param key Key to be written
    \param armoured Flag is set for armoured output
    \param output Output stream
 
@@ -577,7 +577,7 @@ pgp_write_xfer_pubkey(pgp_output_t *         output,
 
    \brief Writes a transferable PGP secret key to the given output stream.
 
-   \param keydata Key to be written
+   \param key Key to be written
    \param passphrase
    \param pplen
    \param armoured Flag is set for armoured output
@@ -905,8 +905,8 @@ create_unencoded_m_buf(pgp_pk_sesskey_t *sesskey, pgp_crypt_t *cipherinfo, uint8
 
 /**
  \ingroup Core_Create
-\brief Creates an pgp_pk_sesskey_t struct from keydata
-\param key Keydata to use
+\brief Creates an pgp_pk_sesskey_t struct from key
+\param key Key to use
 \param cipher Encryption algorithm used
 \return pgp_pk_sesskey_t struct
 \note It is the caller's responsiblity to free the returned pointer

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -598,13 +598,13 @@ format_key_usage(char *buffer, size_t size, uint8_t flags)
 
 /* print into a string (malloc'ed) the pubkeydata */
 int
-pgp_sprint_keydata(pgp_io_t *             io,
-                   const rnp_key_store_t *keyring,
-                   const pgp_key_t *      key,
-                   char **                buf,
-                   const char *           header,
-                   const pgp_pubkey_t *   pubkey,
-                   const int              psigs)
+pgp_sprint_key(pgp_io_t *             io,
+               const rnp_key_store_t *keyring,
+               const pgp_key_t *      key,
+               char **                buf,
+               const char *           header,
+               const pgp_pubkey_t *   pubkey,
+               const int              psigs)
 {
     unsigned i;
     time_t   now;
@@ -811,12 +811,12 @@ pgp_sprint_json(pgp_io_t *             io,
 }
 
 int
-pgp_hkp_sprint_keydata(pgp_io_t *             io,
-                       const rnp_key_store_t *keyring,
-                       const pgp_key_t *      key,
-                       char **                buf,
-                       const pgp_pubkey_t *   pubkey,
-                       const int              psigs)
+pgp_hkp_sprint_key(pgp_io_t *             io,
+                   const rnp_key_store_t *keyring,
+                   const pgp_key_t *      key,
+                   char **                buf,
+                   const pgp_pubkey_t *   pubkey,
+                   const int              psigs)
 {
     const pgp_key_t *trustkey;
     unsigned         from;
@@ -901,16 +901,16 @@ pgp_hkp_sprint_keydata(pgp_io_t *             io,
 
 /* print the key data for a pub or sec key */
 void
-pgp_print_keydata(pgp_io_t *             io,
-                  const rnp_key_store_t *keyring,
-                  const pgp_key_t *      key,
-                  const char *           header,
-                  const pgp_pubkey_t *   pubkey,
-                  const int              psigs)
+pgp_print_key(pgp_io_t *             io,
+              const rnp_key_store_t *keyring,
+              const pgp_key_t *      key,
+              const char *           header,
+              const pgp_pubkey_t *   pubkey,
+              const int              psigs)
 {
     char *cp;
 
-    if (pgp_sprint_keydata(io, keyring, key, &cp, header, pubkey, psigs) >= 0) {
+    if (pgp_sprint_key(io, keyring, key, &cp, header, pubkey, psigs) >= 0) {
         (void) fprintf(io->res, "%s", cp);
         free(cp);
     }
@@ -1764,7 +1764,7 @@ pgp_list_packets(pgp_io_t *       io,
 
 /* this interface isn't right - hook into callback for getting passphrase */
 char *
-pgp_export_key(pgp_io_t *io, const pgp_key_t *keydata, uint8_t *passphrase)
+pgp_export_key(pgp_io_t *io, const pgp_key_t *key, uint8_t *passphrase)
 {
     pgp_output_t *output;
     pgp_memory_t *mem;
@@ -1776,10 +1776,10 @@ pgp_export_key(pgp_io_t *io, const pgp_key_t *keydata, uint8_t *passphrase)
         return NULL;
     }
 
-    if (keydata->type == PGP_PTAG_CT_PUBLIC_KEY) {
-        pgp_write_xfer_pubkey(output, keydata, NULL, 1);
+    if (key->type == PGP_PTAG_CT_PUBLIC_KEY) {
+        pgp_write_xfer_pubkey(output, key, NULL, 1);
     } else {
-        pgp_write_xfer_seckey(output, keydata, passphrase, NULL, 1);
+        pgp_write_xfer_seckey(output, key, passphrase, NULL, 1);
     }
 
     const size_t mem_len = pgp_mem_len(mem) + 1;

--- a/src/lib/packet-print.h
+++ b/src/lib/packet-print.h
@@ -58,13 +58,13 @@
 #include "packet.h"
 #include <rekey/rnp_key_store.h>
 
-int pgp_sprint_keydata(pgp_io_t *,
-                       const rnp_key_store_t *,
-                       const pgp_key_t *,
-                       char **,
-                       const char *,
-                       const pgp_pubkey_t *,
-                       const int);
+int pgp_sprint_key(pgp_io_t *,
+                   const rnp_key_store_t *,
+                   const pgp_key_t *,
+                   char **,
+                   const char *,
+                   const pgp_pubkey_t *,
+                   const int);
 int pgp_sprint_json(pgp_io_t *,
                     const rnp_key_store_t *,
                     const pgp_key_t *,
@@ -72,18 +72,18 @@ int pgp_sprint_json(pgp_io_t *,
                     const char *,
                     const pgp_pubkey_t *,
                     const int);
-int pgp_hkp_sprint_keydata(pgp_io_t *,
-                           const rnp_key_store_t *,
-                           const pgp_key_t *,
-                           char **,
-                           const pgp_pubkey_t *,
-                           const int);
-void pgp_print_keydata(pgp_io_t *,
+int pgp_hkp_sprint_key(pgp_io_t *,
                        const rnp_key_store_t *,
                        const pgp_key_t *,
-                       const char *,
+                       char **,
                        const pgp_pubkey_t *,
                        const int);
+void pgp_print_key(pgp_io_t *,
+                   const rnp_key_store_t *,
+                   const pgp_key_t *,
+                   const char *,
+                   const pgp_pubkey_t *,
+                   const int);
 void pgp_print_pubkey(const pgp_pubkey_t *);
 int  pgp_sprint_pubkey(const pgp_key_t *, char *, size_t);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -56,9 +56,9 @@
 #include <stdio.h>
 #include "packet.h"
 
-struct pgp_key_t *pgp_keydata_new(void);
+struct pgp_key_t *pgp_key_new(void);
 
-void pgp_keydata_free(pgp_key_t *);
+void pgp_key_free(pgp_key_t *);
 
 const pgp_pubkey_t *pgp_get_pubkey(const pgp_key_t *);
 
@@ -86,6 +86,6 @@ struct pgp_rawpacket_t *pgp_add_rawpacket(pgp_key_t *, const pgp_rawpacket_t *);
 
 bool pgp_add_selfsigned_userid(pgp_key_t *, const unsigned char *);
 
-void pgp_keydata_init(pgp_key_t *, const pgp_content_enum);
+void pgp_key_init(pgp_key_t *, const pgp_content_enum);
 
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -2133,9 +2133,9 @@ pgp_pk_sesskey_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
             return (pgp_cb_ret_t) 0;
         }
         from = 0;
-        cbinfo->cryptinfo.keydata = rnp_key_store_get_key_by_id(
+        cbinfo->cryptinfo.key = rnp_key_store_get_key_by_id(
           io, cbinfo->cryptinfo.secring, content->pk_sesskey.key_id, &from, NULL);
-        if (!cbinfo->cryptinfo.keydata) {
+        if (!cbinfo->cryptinfo.key) {
             break;
         }
         break;
@@ -2184,12 +2184,12 @@ pgp_get_seckey_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
           io, cbinfo->cryptinfo.pubring, content->get_seckey.pk_sesskey->key_id, &from, NULL);
         /* validate key from secring */
         from = 0;
-        cbinfo->cryptinfo.keydata = rnp_key_store_get_key_by_id(
+        cbinfo->cryptinfo.key = rnp_key_store_get_key_by_id(
           io, cbinfo->cryptinfo.secring, content->get_seckey.pk_sesskey->key_id, &from, NULL);
-        if (!cbinfo->cryptinfo.keydata || !pgp_is_key_secret(cbinfo->cryptinfo.keydata)) {
+        if (!cbinfo->cryptinfo.key || !pgp_is_key_secret(cbinfo->cryptinfo.key)) {
             return (pgp_cb_ret_t) 0;
         }
-        keypair = cbinfo->cryptinfo.keydata;
+        keypair = cbinfo->cryptinfo.key;
         if (pubkey == NULL) {
             pubkey = keypair;
         }
@@ -2197,7 +2197,7 @@ pgp_get_seckey_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         cbinfo->gotpass = 0;
         for (i = 0; cbinfo->numtries == -1 || i < cbinfo->numtries; i++) {
             /* print out the user id */
-            pgp_print_keydata(
+            pgp_print_key(
               io, cbinfo->cryptinfo.pubring, pubkey, "signature ", &pubkey->key.pubkey, 0);
             /* now decrypt key */
             secret = pgp_decrypt_seckey(keypair, cbinfo->passfp);
@@ -2237,15 +2237,15 @@ get_passphrase_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
     if (rnp_get_debug(__FILE__)) {
         pgp_print_packet(&cbinfo->printstate, pkt);
     }
-    if (cbinfo->cryptinfo.keydata == NULL) {
-        (void) fprintf(io->errs, "get_passphrase_cb: NULL keydata\n");
+    if (cbinfo->cryptinfo.key == NULL) {
+        (void) fprintf(io->errs, "get_passphrase_cb: NULL key\n");
     } else {
-        pgp_print_keydata(io,
-                          cbinfo->cryptinfo.pubring,
-                          cbinfo->cryptinfo.keydata,
-                          "signature ",
-                          &cbinfo->cryptinfo.keydata->key.pubkey,
-                          0);
+        pgp_print_key(io,
+                      cbinfo->cryptinfo.pubring,
+                      cbinfo->cryptinfo.key,
+                      "signature ",
+                      &cbinfo->cryptinfo.key->key.pubkey,
+                      0);
     }
     switch (pkt->tag) {
     case PGP_GET_PASSPHRASE:

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -146,7 +146,7 @@ resultp(pgp_io_t *io, const char *f, pgp_validation_t *res, rnp_key_store_t *rin
                            "WARNING: signature for %s made with encryption key\n",
                            (f) ? f : "<stdin>");
         }
-        pgp_print_keydata(io, ring, key, "signature ", &key->key.pubkey, 0);
+        pgp_print_key(io, ring, key, "signature ", &key->key.pubkey, 0);
     }
 }
 
@@ -814,16 +814,16 @@ rnp_match_keys(rnp_t *rnp, char *name, const char *fmt, void *vp, const int psig
         if (key != NULL) {
             ALLOC(char *, pubs.v, pubs.size, pubs.c, 10, 10, "rnp_match_keys", return 0);
             if (strcmp(fmt, "mr") == 0) {
-                pgp_hkp_sprint_keydata(
+                pgp_hkp_sprint_key(
                   rnp->io, rnp->pubring, key, &pubs.v[pubs.c], &key->key.pubkey, psigs);
             } else {
-                pgp_sprint_keydata(rnp->io,
-                                   rnp->pubring,
-                                   key,
-                                   &pubs.v[pubs.c],
-                                   "signature ",
-                                   &key->key.pubkey,
-                                   psigs);
+                pgp_sprint_key(rnp->io,
+                               rnp->pubring,
+                               key,
+                               &pubs.v[pubs.c],
+                               "signature ",
+                               &key->key.pubkey,
+                               psigs);
             }
             if (pubs.v[pubs.c] != NULL) {
                 pubs.c += 1;
@@ -867,8 +867,7 @@ rnp_match_keys_json(rnp_t *rnp, char **json, char *name, const char *fmt, const 
         }
         if (key != NULL) {
             if (strcmp(fmt, "mr") == 0) {
-                pgp_hkp_sprint_keydata(
-                  rnp->io, rnp->pubring, key, &newkey, &key->key.pubkey, 0);
+                pgp_hkp_sprint_key(rnp->io, rnp->pubring, key, &newkey, &key->key.pubkey, 0);
                 if (newkey) {
                     printf("%s\n", newkey);
                     free(newkey);
@@ -942,12 +941,12 @@ rnp_get_key(rnp_t *rnp, const char *name, const char *fmt)
         return NULL;
     }
     if (strcmp(fmt, "mr") == 0) {
-        return (pgp_hkp_sprint_keydata(
-                  rnp->io, rnp->pubring, key, &newkey, &key->key.pubkey, 0) > 0) ?
+        return (pgp_hkp_sprint_key(rnp->io, rnp->pubring, key, &newkey, &key->key.pubkey, 0) >
+                0) ?
                  newkey :
                  NULL;
     }
-    return (pgp_sprint_keydata(
+    return (pgp_sprint_key(
               rnp->io, rnp->pubring, key, &newkey, "signature", &key->key.pubkey, 0) > 0) ?
              newkey :
              NULL;
@@ -1080,11 +1079,11 @@ rnp_generate_key(rnp_t *rnp, const char *id)
 
     if (!rnp_key_store_add_key(io, rnp->pubring, key, PGP_PTAG_CT_PUBLIC_KEY) ||
         !rnp_key_store_add_key(io, rnp->secring, key, PGP_PTAG_CT_SECRET_KEY)) {
-        pgp_keydata_free(key);
+        pgp_key_free(key);
         return RNP_FAIL;
     }
 
-    pgp_sprint_keydata(rnp->io, NULL, key, &cp, "signature ", &key->key.seckey.pubkey, 0);
+    pgp_sprint_key(rnp->io, NULL, key, &cp, "signature ", &key->key.seckey.pubkey, 0);
     (void) fprintf(stdout, "%s", cp);
     free(cp);
 
@@ -1095,16 +1094,16 @@ rnp_generate_key(rnp_t *rnp, const char *id)
 
     /* write keypair */
     if (!rnp_key_store_write_to_file(rnp, rnp->secring, (uint8_t *) passphrase, 0)) {
-        pgp_keydata_free(key);
+        pgp_key_free(key);
         return RNP_FAIL;
     }
 
     if (!rnp_key_store_write_to_file(rnp, rnp->pubring, (uint8_t *) passphrase, 0)) {
-        pgp_keydata_free(key);
+        pgp_key_free(key);
         return RNP_FAIL;
     }
 
-    pgp_keydata_free(key);
+    pgp_key_free(key);
     return RNP_OK;
 }
 
@@ -1205,14 +1204,14 @@ rnp_sign_file(rnp_ctx_t * ctx,
             }
             if (pubkey == NULL) {
                 (void) fprintf(io->errs, "rnp: warning - using pubkey from secring\n");
-                pgp_print_keydata(io,
-                                  ctx->rnp->pubring,
-                                  keypair,
-                                  "signature ",
-                                  &keypair->key.seckey.pubkey,
-                                  0);
+                pgp_print_key(io,
+                              ctx->rnp->pubring,
+                              keypair,
+                              "signature ",
+                              &keypair->key.seckey.pubkey,
+                              0);
             } else {
-                pgp_print_keydata(
+                pgp_print_key(
                   io, ctx->rnp->pubring, pubkey, "signature ", &pubkey->key.pubkey, 0);
             }
         }
@@ -1321,14 +1320,14 @@ rnp_sign_memory(rnp_ctx_t * ctx,
             }
             if (pubkey == NULL) {
                 (void) fprintf(io->errs, "rnp: warning - using pubkey from secring\n");
-                pgp_print_keydata(io,
-                                  ctx->rnp->pubring,
-                                  keypair,
-                                  "signature ",
-                                  &keypair->key.seckey.pubkey,
-                                  0);
+                pgp_print_key(io,
+                              ctx->rnp->pubring,
+                              keypair,
+                              "signature ",
+                              &keypair->key.seckey.pubkey,
+                              0);
             } else {
-                pgp_print_keydata(
+                pgp_print_key(
                   io, ctx->rnp->pubring, pubkey, "signature ", &pubkey->key.pubkey, 0);
             }
         }

--- a/src/lib/validate.c
+++ b/src/lib/validate.c
@@ -92,12 +92,12 @@ __RCSID("$NetBSD: validate.c,v 1.44 2012/03/05 02:20:18 christos Exp $");
 #endif
 
 static int
-keydata_reader(pgp_stream_t *stream,
-               void *        dest,
-               size_t        length,
-               pgp_error_t **errors,
-               pgp_reader_t *readinfo,
-               pgp_cbdata_t *cbinfo)
+key_reader(pgp_stream_t *stream,
+           void *        dest,
+           size_t        length,
+           pgp_error_t **errors,
+           pgp_reader_t *readinfo,
+           pgp_cbdata_t *cbinfo)
 {
     validate_reader_t *reader = pgp_reader_get_arg(readinfo);
 
@@ -117,7 +117,7 @@ keydata_reader(pgp_stream_t *stream,
      * read
      */
     if (reader->key->packets[reader->packet].length < reader->offset + length) {
-        (void) fprintf(stderr, "keydata_reader: weird length\n");
+        (void) fprintf(stderr, "key_reader: weird length\n");
         return 0;
     }
 
@@ -561,23 +561,23 @@ validate_data_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
 }
 
 static void
-keydata_destroyer(pgp_reader_t *readinfo)
+key_destroyer(pgp_reader_t *readinfo)
 {
     free(pgp_reader_get_arg(readinfo));
 }
 
 void
-pgp_keydata_reader_set(pgp_stream_t *stream, const pgp_key_t *key)
+pgp_key_reader_set(pgp_stream_t *stream, const pgp_key_t *key)
 {
     validate_reader_t *data;
 
     if ((data = calloc(1, sizeof(*data))) == NULL) {
-        (void) fprintf(stderr, "pgp_keydata_reader_set: bad alloc\n");
+        (void) fprintf(stderr, "pgp_key_reader_set: bad alloc\n");
     } else {
         data->key = key;
         data->packet = 0;
         data->offset = 0;
-        pgp_reader_set(stream, keydata_reader, keydata_destroyer, data);
+        pgp_reader_set(stream, key_reader, key_destroyer, data);
     }
 }
 
@@ -690,7 +690,7 @@ pgp_validate_key_sigs(pgp_validation_t *     result,
 
     pgp_set_callback(stream, pgp_validate_key_cb, &keysigs);
     stream->readinfo.accumulate = 1;
-    pgp_keydata_reader_set(stream, key);
+    pgp_key_reader_set(stream, key);
 
     /* Note: Coverity incorrectly reports an error that keysigs.reader */
     /* is never used. */

--- a/src/lib/validate.h
+++ b/src/lib/validate.h
@@ -109,7 +109,7 @@ bool pgp_validate_all_sigs(pgp_validation_t *,
                            const rnp_key_store_t *,
                            pgp_cb_ret_t cb(const pgp_packet_t *, pgp_cbdata_t *));
 
-void pgp_keydata_reader_set(pgp_stream_t *, const pgp_key_t *);
+void pgp_key_reader_set(pgp_stream_t *, const pgp_key_t *);
 
 pgp_cb_ret_t pgp_validate_key_cb(const pgp_packet_t *, pgp_cbdata_t *);
 

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -464,9 +464,9 @@ rnp_key_store_list(pgp_io_t *io, const rnp_key_store_t *keyring, const int psigs
 
     for (n = 0, key = keyring->keys; n < keyring->keyc; ++n, ++key) {
         if (pgp_is_key_secret(key)) {
-            pgp_print_keydata(io, keyring, key, "sec", &key->key.seckey.pubkey, 0);
+            pgp_print_key(io, keyring, key, "sec", &key->key.seckey.pubkey, 0);
         } else {
-            pgp_print_keydata(io, keyring, key, "signature ", &key->key.pubkey, psigs);
+            pgp_print_key(io, keyring, key, "signature ", &key->key.pubkey, psigs);
         }
         (void) fputc('\n', io->res);
     }

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -218,7 +218,7 @@ pkcs1_rsa_test_success(void **state)
     test_value_equal("RSA 1024 decrypt", "616263", decrypted, 3);
 
     rnp_assert_int_equal(rstate, decrypted_size, 3);
-    pgp_keydata_free(pgp_key);
+    pgp_key_free(pgp_key);
 }
 
 void
@@ -262,7 +262,7 @@ rnp_test_eddsa(void **state)
 
     BN_free(r);
     BN_free(s);
-    pgp_keydata_free(pgp_key);
+    pgp_key_free(pgp_key);
 }
 
 void
@@ -406,7 +406,7 @@ ecdsa_signverify_success(void **state)
 
         BN_clear_free(sig.r);
         BN_clear_free(sig.s);
-        pgp_keydata_free(pgp_key1);
-        pgp_keydata_free(pgp_key2);
+        pgp_key_free(pgp_key1);
+        pgp_key_free(pgp_key2);
     }
 }


### PR DESCRIPTION
This is just a simple rename for variables/functions that refer to a `pgp_key_t` as `keydata`.
This is misleading since we have an actual union typedef `pgp_keydata_key_t`. Items that actually deal with `pgp_keydata_key_t` are untouched.

This is basically a relic from OpenPGP-SDK, where our `pgp_key_t` was actually `ops_keydata`.

I had this in my original large branch because 1) it makes sense and 2) it makes the names of some functions I added later less ambiguous.