### PR TITLE
Abstract key generation a bit

### DIFF
--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -72,7 +72,8 @@
 
 void pgp_crypto_finish(void);
 
-/* Key generation */
+/* raw key generation */
+bool pgp_generate_seckey(const rnp_keygen_crypto_params_t *params, pgp_seckey_t *seckey);
 
 pgp_key_t *pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid);
 

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1039,7 +1039,7 @@ typedef struct pgp_key_t {
 } pgp_key_t;
 
 /* structure used to hold context of key generation */
-typedef struct rnp_keygen_desc_t {
+typedef struct rnp_keygen_crypto_params_t {
     // Asymmteric algorithm that user requesed key for
     pgp_pubkey_alg_t key_alg;
     // Hash to be used for key signature
@@ -1054,6 +1054,10 @@ typedef struct rnp_keygen_desc_t {
             uint32_t modulus_bit_len;
         } rsa;
     };
+} rnp_keygen_crypto_params_t;
+
+typedef struct rnp_keygen_desc_t {
+    rnp_keygen_crypto_params_t crypto;
 } rnp_keygen_desc_t;
 
 #endif /* PACKET_H_ */

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -95,17 +95,8 @@ pgp_key_new(void)
     return calloc(1, sizeof(pgp_key_t));
 }
 
-/**
- \ingroup HighLevel_Keyring
-
- \brief Frees key and its memory
-
- \param key Key to be freed.
-
- \note This frees the key itself, as well as any other memory alloc-ed by it.
-*/
 void
-pgp_key_free(pgp_key_t *key)
+pgp_key_free_data(pgp_key_t *key)
 {
     unsigned n;
 
@@ -155,7 +146,12 @@ pgp_key_free(pgp_key_t *key)
     } else {
         pgp_seckey_free(&key->key.seckey);
     }
+}
 
+void
+pgp_key_free(pgp_key_t *key)
+{
+    pgp_key_free_data(key);
     free(key);
 }
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -58,7 +58,19 @@
 
 struct pgp_key_t *pgp_key_new(void);
 
+/** free the internal data of a key *and* the key structure itself
+ *
+ *  @param key the key
+ **/
 void pgp_key_free(pgp_key_t *);
+
+/** free the internal data of a key
+ *
+ *  This does *not* free the key structure itself.
+ *
+ *  @param key the key
+ **/
+void pgp_key_free_data(pgp_key_t *);
 
 const pgp_pubkey_t *pgp_get_pubkey(const pgp_key_t *);
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1012,18 +1012,18 @@ rnp_import_key(rnp_t *rnp, char *f)
 }
 
 static uint32_t
-get_numbits(const rnp_keygen_desc_t *key)
+get_numbits(const rnp_keygen_crypto_params_t *crypto)
 {
-    switch (key->key_alg) {
+    switch (crypto->key_alg) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
-        return key->rsa.modulus_bit_len;
+        return crypto->rsa.modulus_bit_len;
     case PGP_PKA_ECDSA:
     case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
-        return ec_curves[key->ecc.curve].bitlen;
+        return ec_curves[crypto->ecc.curve].bitlen;
     default:
         return 0;
     }
@@ -1065,8 +1065,8 @@ rnp_generate_key(rnp_t *rnp, const char *id)
         snprintf(newid,
                  sizeof(newid),
                  "%s %d-bit key <%s@localhost>",
-                 pgp_show_pka(rnp->action.generate_key_ctx.key_alg),
-                 get_numbits(&rnp->action.generate_key_ctx),
+                 pgp_show_pka(rnp->action.generate_key_ctx.crypto.key_alg),
+                 get_numbits(&rnp->action.generate_key_ctx.crypto),
                  getenv("LOGNAME"));
     }
     uid = (uint8_t *) newid;

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -181,12 +181,12 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
     case CMD_GENERATE_KEY:
         key = f ? f : rnp_cfg_get(cfg, CFG_USERID);
         rnp_keygen_desc_t *key_desc = &rnp->action.generate_key_ctx;
-        key_desc->hash_alg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
-        key_desc->sym_alg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
+        key_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
+        key_desc->crypto.sym_alg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
 
         if (!rnp_cfg_getbool(cfg, CFG_EXPERT)) {
-            key_desc->key_alg = PGP_PKA_RSA;
-            key_desc->rsa.modulus_bit_len = rnp_cfg_getint(cfg, CFG_NUMBITS);
+            key_desc->crypto.key_alg = PGP_PKA_RSA;
+            key_desc->crypto.rsa.modulus_bit_len = rnp_cfg_getint(cfg, CFG_NUMBITS);
         } else if (rnp_generate_key_expert_mode(rnp) != PGP_E_OK) {
             RNP_LOG("Critical error: Key generation failed");
             return false;

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -161,10 +161,10 @@ pkcs1_rsa_test_success(void **state)
     const pgp_rsa_pubkey_t *pub_rsa;
     const pgp_rsa_seckey_t *sec_rsa;
 
-    const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_RSA,
-                                        .hash_alg = PGP_HASH_SHA256,
-                                        .sym_alg = PGP_SA_AES_128,
-                                        .rsa = {.modulus_bit_len = 1024}};
+    const rnp_keygen_desc_t key_desc = {.crypto = {.key_alg = PGP_PKA_RSA,
+                                                   .hash_alg = PGP_HASH_SHA256,
+                                                   .sym_alg = PGP_SA_AES_128,
+                                                   .rsa = {.modulus_bit_len = 1024}}};
     pgp_key = pgp_generate_keypair(&key_desc, NULL);
     rnp_assert_non_null(rstate, pgp_key);
 
@@ -225,8 +225,9 @@ void
 rnp_test_eddsa(void **state)
 {
     rnp_test_state_t *      rstate = *state;
-    const rnp_keygen_desc_t key_desc = {
-      .key_alg = PGP_PKA_EDDSA, .hash_alg = PGP_HASH_SHA256, .sym_alg = PGP_SA_AES_128};
+    const rnp_keygen_desc_t key_desc = {.crypto = {.key_alg = PGP_PKA_EDDSA,
+                                                   .hash_alg = PGP_HASH_SHA256,
+                                                   .sym_alg = PGP_SA_AES_128}};
     pgp_key_t *pgp_key = pgp_generate_keypair(&key_desc, NULL);
     rnp_assert_non_null(rstate, pgp_key);
 
@@ -370,10 +371,10 @@ ecdsa_signverify_success(void **state)
 
     for (int i = 0; i < sizeof(curves) / sizeof(curves[0]); i++) {
         pgp_ecc_sig_t           sig = {NULL, NULL};
-        const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_ECDSA,
-                                            .hash_alg = PGP_HASH_SHA512,
-                                            .sym_alg = PGP_SA_AES_128,
-                                            .ecc = {.curve = curves[i].id}};
+        const rnp_keygen_desc_t key_desc = {.crypto = {.key_alg = PGP_PKA_ECDSA,
+                                                       .hash_alg = PGP_HASH_SHA512,
+                                                       .sym_alg = PGP_SA_AES_128,
+                                                       .ecc = {.curve = curves[i].id}}};
 
         pgp_key_t *pgp_key1 = pgp_generate_keypair(&key_desc, NULL);
         rnp_assert_non_null(rstate, pgp_key1);

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -255,7 +255,7 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
             set_default_rsa_key_desc(&rnp.action.generate_key_ctx,
                                      pgp_str_to_hash_alg(hashAlg[i]));
             rnp_assert_int_not_equal(
-              rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_UNKNOWN);
+              rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_UNKNOWN);
 
             /* Generate key with specified parameters */
             rnp_assert_ok(rstate, rnp_generate_key(&rnp, NULL));
@@ -560,48 +560,53 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_assert_true(rstate, rnp_cfg_setbool(&ops, CFG_EXPERT, true));
 
     rnp_assert_true(rstate, ask_expert_details(&rnp, &ops, test_sm2, sizeof(test_sm2)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_SM2);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.ecc.curve, PGP_CURVE_SM2_P_256);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_SM3);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_SM2);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_SM2_P_256);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SM3);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_256, sizeof(test_ecdsa_256)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_ECDSA);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.ecc.curve, PGP_CURVE_NIST_P_256);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_SHA256);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_NIST_P_256);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA256);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, sizeof(test_ecdsa_384)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_ECDSA);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.ecc.curve, PGP_CURVE_NIST_P_384);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_SHA384);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_NIST_P_384);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA384);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_521, sizeof(test_ecdsa_521)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_ECDSA);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.ecc.curve, PGP_CURVE_NIST_P_521);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_SHA512);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_NIST_P_521);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA512);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate, ask_expert_details(&rnp, &ops, test_eddsa, sizeof(test_eddsa)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_EDDSA);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.ecc.curve, PGP_CURVE_ED25519);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_EDDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_ED25519);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_rsa_1024, sizeof(test_rsa_1024)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_RSA);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.rsa.modulus_bit_len, 1024);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_RSA);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.rsa.modulus_bit_len, 1024);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(
                       &rnp, &ops, test_rsa_ask_twice_4096, sizeof(test_rsa_ask_twice_4096)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.key_alg, PGP_PKA_RSA);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.rsa.modulus_bit_len, 4096);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_RSA);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.rsa.modulus_bit_len, 4096);
     rnp_end(&rnp);
 
     rnp_cfg_free(&ops);
@@ -621,7 +626,7 @@ generatekey_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state)
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, sizeof(test_ecdsa_384)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_SHA384);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA384);
 
     rnp_cfg_free(&ops);
 }
@@ -640,7 +645,7 @@ generatekey_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, sizeof(test_ecdsa_384)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.hash_alg, PGP_HASH_SHA512);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA512);
 
     rnp_cfg_free(&ops);
 }

--- a/src/tests/support.c
+++ b/src/tests/support.c
@@ -395,8 +395,8 @@ setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pi
 void
 set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc, pgp_hash_alg_t hashalg)
 {
-    key_desc->key_alg = PGP_PKA_RSA;
-    key_desc->sym_alg = PGP_SA_DEFAULT_CIPHER;
-    key_desc->rsa.modulus_bit_len = 1024;
-    key_desc->hash_alg = hashalg;
+    key_desc->crypto.key_alg = PGP_PKA_RSA;
+    key_desc->crypto.sym_alg = PGP_SA_DEFAULT_CIPHER;
+    key_desc->crypto.rsa.modulus_bit_len = 1024;
+    key_desc->crypto.hash_alg = hashalg;
 }


### PR DESCRIPTION
Depends on: #341 

This is an intermediate step I took when working on subkey generation (with some updates).

The last two commits are the ones relevant for this PR.
(Actually the middle commit is sort of unrelated, but is used in some future fixes)

The diff is kind of hard to read, so you're probably better off just checking out `pgp_generate_seckey` and `pgp_generate_keypair` in https://github.com/riboseinc/rnp/blob/efe2cad0aabacde3b88bf366efef60e5ccbe7fc5/src/lib/crypto.c