### PR TITLE
ECDH support

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -9,7 +9,7 @@ CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
 if [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.so" ]; then
   git clone https://github.com/randombit/botan ~/builds/botan
   cd ~/builds/botan
-  ./configure.py --prefix="${BOTAN_INSTALL}"
+  ./configure.py --cc=clang --prefix="${BOTAN_INSTALL}"
   make -j${CORES} install
 fi
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -3,7 +3,7 @@
 AM_CFLAGS			= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSONC_INCLUDES)
 AM_LDFLAGS          = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
 lib_LTLIBRARIES		= librnp.la
-librnp_la_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/
+librnp_la_CPPFLAGS	= -I$(top_srcdir)/include
 librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS) ../librekey/librekey.la
 dist_man_MANS		= librnp.3
 librnp_la_SOURCES	= \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -3,7 +3,7 @@
 AM_CFLAGS			= $(WARNCFLAGS) $(BOTAN_INCLUDES) $(JSONC_INCLUDES)
 AM_LDFLAGS          = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
 lib_LTLIBRARIES		= librnp.la
-librnp_la_CPPFLAGS	= -I$(top_srcdir)/include
+librnp_la_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/
 librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS) ../librekey/librekey.la
 dist_man_MANS		= librnp.3
 librnp_la_SOURCES	= \
@@ -12,6 +12,7 @@ librnp_la_SOURCES	= \
 	compress.c \
 	crypto.c \
 	dsa.c \
+	ecdh.c \
 	ecdsa.c \
 	eddsa.c \
 	elgamal.c \

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -66,8 +66,10 @@
 #include <rekey/rnp_key_store.h>
 
 #define PGP_MIN_HASH_SIZE 16
-#define MAX_CURVE_BYTELEN BITS_TO_BYTES(521) /* Length of NIST P-521 */
-
+/* Maximal byte size of elliptic curve order (NIST P-521) */
+#define MAX_CURVE_BYTELEN BITS_TO_BYTES(521)
+/* Maximal size of symmetric key */
+#define MAX_SYMM_KEY_SIZE 32
 #define NTAGS 0x100 /* == 256 */
 
 void pgp_crypto_finish(void);
@@ -246,10 +248,20 @@ pgp_curve_t find_curve_by_OID(const uint8_t *oid, size_t oid_len);
  * @pre     output      must be not null
  * @pre     pubkey      must be not null
  *
- * @returns success PGP_E_OK, error code otherwise
+ * @returns true on success
  *
  * @remarks see RFC 4880 bis 01 - 5.5.2 Public-Key Packet Formats
 -------------------------------------------------------------------------------- */
-pgp_errcode_t ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
+bool ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey);
+
+/* -----------------------------------------------------------------------------
+ * @brief   Returns pointer to the curve descriptor
+ *
+ * @param   Valid curve ID
+ *
+ * @returns NULL if wrong ID provided, otherwise descriptor
+ *
+-------------------------------------------------------------------------------- */
+const ec_curve_desc_t *get_curve_desc(const pgp_curve_t curve_id);
 
 #endif /* CRYPTO_H_ */

--- a/src/lib/ecdh.c
+++ b/src/lib/ecdh.c
@@ -214,10 +214,10 @@ pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
     // See 13.5 of RFC 4880 for definition of other_info_size
     const size_t other_info_size = (pubkey->ec.curve == PGP_CURVE_NIST_P_256) ? 54 : 51;
     const size_t key_len = BITS_TO_BYTES(curve_desc->bitlen) * 2 + 1;
-    const size_t kek_len = pgp_key_size(pubkey->kdf.wrap_alg);
+    const size_t kek_len = pgp_key_size(pubkey->key_wrap_alg);
 
     size_t tmp_len = kdf_other_info_serialize(
-      other_info, curve_desc, fingerprint, pubkey->kdf.hash, pubkey->kdf.wrap_alg);
+      other_info, curve_desc, fingerprint, pubkey->kdf_hash_alg, pubkey->key_wrap_alg);
 
     if (tmp_len != other_info_size) {
         RNP_LOG("Serialization of other info failed");
@@ -240,7 +240,7 @@ pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
                      curve_desc,
                      pubkey->ec.point->mp,
                      eph_prv_key,
-                     pubkey->kdf.hash)) {
+                     pubkey->kdf_hash_alg)) {
         RNP_LOG("KEK computation failed");
         goto end;
     }
@@ -317,8 +317,8 @@ pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
         return RNP_ERROR_NOT_SUPPORTED;
     }
 
-    const pgp_symm_alg_t wrap_alg = pubkey->kdf.wrap_alg;
-    const pgp_hash_alg_t kdf_hash = pubkey->kdf.hash;
+    const pgp_symm_alg_t wrap_alg = pubkey->key_wrap_alg;
+    const pgp_hash_alg_t kdf_hash = pubkey->kdf_hash_alg;
     /* Ensure that AES is used for wrapping */
     if ((wrap_alg != PGP_SA_AES_128) && (wrap_alg != PGP_SA_AES_192) &&
         (wrap_alg != PGP_SA_AES_256)) {

--- a/src/lib/ecdh.c
+++ b/src/lib/ecdh.c
@@ -67,19 +67,19 @@ kdf_other_info_serialize(uint8_t                  other_info[MAX_SP800_56A_OTHER
     // Value reserved for future use
     *(buf_ptr++) = 0x01;
     // Hash used with KDF
-    *(buf_ptr++) = kdf_hash,
+    *(buf_ptr++) = kdf_hash;
     // Algorithm ID used for key wrapping
-      *(buf_ptr++) = wrap_alg;
+    *(buf_ptr++) = wrap_alg;
 
     /* KDF-OtherInfo: PartyUInfo
      *   20 bytes representing "Anonymous Sender "
      */
     memcpy(buf_ptr, ANONYMOUS_SENDER, sizeof(ANONYMOUS_SENDER));
+
     buf_ptr += sizeof(ANONYMOUS_SENDER);
 
     // keep 20, as per spec
     memcpy(buf_ptr, fingerprint->fingerprint, 20);
-
     return (buf_ptr - other_info) + 20 /*anonymous_sender*/;
 }
 
@@ -131,7 +131,7 @@ compute_kek(uint8_t *              kek,
             const pgp_hash_alg_t   hash_alg)
 {
     botan_pk_op_ka_t op_key_agreement = NULL;
-    uint8_t          point_bytes[BITS_TO_BYTES(521) * 2 + 1] = {0};
+    uint8_t          point_bytes[MAX_CURVE_BYTELEN * 2 + 1] = {0};
     bool             ret = true;
 
     // Name of Botan's KDF and backing hash algorithm

--- a/src/lib/ecdh.c
+++ b/src/lib/ecdh.c
@@ -145,6 +145,7 @@ compute_kek(uint8_t *              kek,
         return false;
     }
 
+    // OZAPTF: use KDF from botan
     do {
         ret = botan_pk_op_key_agreement_create(&op_key_agreement, ec_prvkey, "Raw", 0);
         if (ret) {

--- a/src/lib/ecdh.c
+++ b/src/lib/ecdh.c
@@ -1,0 +1,373 @@
+/*-
+ * Copyright (c) 2017 Ribose Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <assert.h>
+#include <botan/ffi.h>
+#include "packet.h"
+#include "ecdh.h"
+#include "ecdsa.h"
+#include "crypto.h"
+
+#define MAX_SP800_56A_OTHER_INFO 54
+#define OBFUSCATED_KEY_SIZE 40
+
+// "Anonymous Sender " in hex
+static const unsigned char ANONYMOUS_SENDER[] = {0x41, 0x6E, 0x6F, 0x6E, 0x79, 0x6D, 0x6F,
+                                                 0x75, 0x73, 0x20, 0x53, 0x65, 0x6E, 0x64,
+                                                 0x65, 0x72, 0x20, 0x20, 0x20, 0x20};
+
+// returns size of data written to other_info
+static size_t
+kdf_other_info_serialize(uint8_t                  other_info[MAX_SP800_56A_OTHER_INFO],
+                         const ec_curve_desc_t *  ec_curve,
+                         const pgp_fingerprint_t *fingerprint,
+                         const pgp_hash_alg_t     kdf_hash,
+                         const pgp_symm_alg_t     wrap_alg)
+{
+    if (fingerprint->length < 20) {
+        RNP_LOG("Implementation error: unexpected fingerprint length");
+        return false;
+    }
+
+    uint8_t *buf_ptr = &other_info[0];
+
+    /* KDF-OtherInfo: AlgorithmID
+     *   Current implementation will alwyas use SHA-512 and AES-256 for KEK wrapping
+     */
+    *(buf_ptr++) = ec_curve->OIDhex_len;
+    memcpy(buf_ptr, ec_curve->OIDhex, ec_curve->OIDhex_len);
+    buf_ptr += ec_curve->OIDhex_len;
+    *(buf_ptr++) = PGP_PKA_ECDH;
+    // size of following 3 params (each 1 byte)
+    *(buf_ptr++) = 0x03;
+    // Value reserved for future use
+    *(buf_ptr++) = 0x01;
+    // Hash used with KDF
+    *(buf_ptr++) = kdf_hash,
+    // Algorithm ID used for key wrapping
+      *(buf_ptr++) = wrap_alg;
+
+    /* KDF-OtherInfo: PartyUInfo
+     *   20 bytes representing "Anonymous Sender "
+     */
+    memcpy(buf_ptr, ANONYMOUS_SENDER, sizeof(ANONYMOUS_SENDER));
+    buf_ptr += sizeof(ANONYMOUS_SENDER);
+
+    // keep 20, as per spec
+    memcpy(buf_ptr, fingerprint->fingerprint, 20);
+
+    return (buf_ptr - other_info) + 20 /*anonymous_sender*/;
+}
+
+static bool
+pad_pkcs7(uint8_t *buf, size_t buf_len, size_t offset)
+{
+    if (buf_len < offset) {
+        return false;
+    }
+
+    const uint8_t pad_byte = buf_len - offset;
+    memset(buf + offset, pad_byte, pad_byte);
+    return true;
+}
+
+static bool
+unpad_pkcs7(uint8_t *buf, size_t buf_len, size_t *offset)
+{
+    uint8_t        err = 0;
+    const uint8_t  pad_byte = buf[buf_len - 1];
+    const uint32_t pad_begin = buf_len - pad_byte;
+
+    if (!buf || !offset || !buf_len) {
+        return false;
+    }
+
+    // TODO: Still >, <, and <=,==  are not constant time (maybe?)
+    err |= (pad_byte > buf_len);
+    err |= (pad_byte == 0);
+
+    /* Check if padding is OK */
+    for (size_t c = 0; c < buf_len; c++) {
+        err |= (buf[c] ^ pad_byte) * (pad_begin <= c);
+    }
+
+    *offset = pad_begin;
+    return (err == 0);
+}
+
+// Produces kek of size kek_len which corresponds to length of wrapping key
+static bool
+compute_kek(uint8_t *              kek,
+            size_t                 kek_len,
+            const uint8_t *        other_info,
+            size_t                 other_info_size,
+            const ec_curve_desc_t *curve_desc,
+            const botan_mp_t       ec_pubkey,
+            const botan_privkey_t  ec_prvkey,
+            const pgp_hash_alg_t   hash_alg)
+{
+    botan_pk_op_ka_t op_key_agreement = NULL;
+    uint8_t          S[BITS_TO_BYTES(521) * 2 + 1] = {0};
+    size_t           S_len = BITS_TO_BYTES(curve_desc->bitlen) * 2 + 1;
+    uint8_t          point_bytes[BITS_TO_BYTES(521) * 2 + 1] = {0};
+    int              ret = 0;
+
+    if (botan_mp_to_bin(ec_pubkey, point_bytes) < 0) {
+        return false;
+    }
+
+    size_t num_bytes = 0;
+    if (botan_mp_num_bytes(ec_pubkey, &num_bytes) < 0) {
+        return false;
+    }
+
+    do {
+        ret = botan_pk_op_key_agreement_create(&op_key_agreement, ec_prvkey, "Raw", 0);
+        if (ret) {
+            break;
+        }
+        ret = botan_pk_op_key_agreement(
+          op_key_agreement, S, &S_len, point_bytes, num_bytes, NULL, 0);
+    } while (false);
+    ret |= botan_pk_op_key_agreement_destroy(op_key_agreement);
+
+    if (ret) {
+        RNP_LOG("ECDH key agreement failed");
+        return false;
+    }
+
+    // Name of Botan's KDF and backing hash algorithm
+    const char *hash_botan_name = pgp_hash_name_botan(hash_alg);
+    if (!hash_botan_name) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    char botan_kdf_name[64] = {0};
+    snprintf(botan_kdf_name, 64, "SP800-56A(%s)", hash_botan_name);
+
+    if (botan_kdf(
+          botan_kdf_name, kek, kek_len, S, S_len, NULL, 0, other_info, other_info_size)) {
+        RNP_LOG("Key derivation failed");
+        return false;
+    }
+
+    return true;
+}
+
+rnp_result
+pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
+                       size_t                   session_key_len,
+                       uint8_t *                wrapped_key,
+                       size_t *                 wrapped_key_len,
+                       botan_mp_t               ephemeral_key,
+                       const pgp_ecdh_pubkey_t *pubkey,
+                       const pgp_fingerprint_t *fingerprint)
+{
+    botan_privkey_t eph_prv_key = NULL;
+    botan_rng_t     rng = NULL;
+    rnp_result      ret = RNP_ERROR_GENERIC;
+    uint8_t         m[OBFUSCATED_KEY_SIZE];
+    size_t          m_len = sizeof(m);
+    uint8_t         other_info[MAX_SP800_56A_OTHER_INFO];
+    uint8_t *       tmp_buf = NULL;
+    uint8_t         kek[32] = {0}; // Size of SHA-256 or smaller
+
+    if ((session_key_len > OBFUSCATED_KEY_SIZE) || !ephemeral_key || !pubkey || !wrapped_key ||
+        !wrapped_key_len || !fingerprint || !pubkey->ec.point) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    const ec_curve_desc_t *curve_desc = get_curve_desc(pubkey->ec.curve);
+    if (!curve_desc) {
+        return RNP_ERROR_NOT_SUPPORTED;
+    }
+
+    if (*wrapped_key_len < ECDH_WRAPPED_KEY_SIZE) {
+        return RNP_ERROR_SHORT_BUFFER;
+    }
+
+    // See 13.5 of RFC 4880 for definition of other_info_size
+    const size_t other_info_size = (pubkey->ec.curve == PGP_CURVE_NIST_P_256) ? 54 : 51;
+    const size_t key_len = BITS_TO_BYTES(curve_desc->bitlen) * 2 + 1;
+    const size_t kek_len = pgp_key_size(pubkey->kdf.wrap_alg);
+
+    size_t tmp_len = kdf_other_info_serialize(
+      other_info, curve_desc, fingerprint, pubkey->kdf.hash, pubkey->kdf.wrap_alg);
+
+    if (tmp_len != other_info_size) {
+        RNP_LOG("Serialization of other info failed");
+        return RNP_ERROR_GENERIC;
+    }
+
+    // Generate ephemeral key pair from public key of other party
+    if (botan_rng_init(&rng, NULL)) {
+        return RNP_ERROR_GENERIC;
+    }
+
+    if (botan_privkey_create_ecdh(&eph_prv_key, rng, curve_desc->botan_name)) {
+        goto end;
+    }
+
+    if (!compute_kek(kek,
+                     kek_len,
+                     other_info,
+                     other_info_size,
+                     curve_desc,
+                     pubkey->ec.point->mp,
+                     eph_prv_key,
+                     pubkey->kdf.hash)) {
+        RNP_LOG("KEK computation failed");
+        goto end;
+    }
+
+    /*
+     * Pad m with PKCS-5 to 40 bytes
+     */
+    memcpy(m, session_key, session_key_len);
+    if (!pad_pkcs7(m, OBFUSCATED_KEY_SIZE, session_key_len)) {
+        // Should never happen
+        goto end;
+    }
+
+    /* 3394 wrapping adds 8 bytes */
+    if (botan_key_wrap3394(m, m_len, kek, kek_len, wrapped_key, wrapped_key_len) ||
+        (*wrapped_key_len != ECDH_WRAPPED_KEY_SIZE)) {
+        goto end;
+    }
+
+    tmp_buf = malloc(key_len);
+    if (!tmp_buf) {
+        ret = RNP_ERROR_OUT_OF_MEMORY;
+        goto end;
+    }
+
+    tmp_len = key_len;
+    if (botan_pk_op_key_agreement_export_public(eph_prv_key, tmp_buf, &tmp_len)) {
+        goto end;
+    }
+
+    if (tmp_len > key_len) {
+        goto end;
+    }
+
+    if (botan_mp_from_bin(ephemeral_key, tmp_buf, tmp_len)) {
+        goto end;
+    }
+
+    // All OK
+    ret = RNP_SUCCESS;
+
+end:
+    ret |= botan_rng_destroy(rng);
+    ret |= botan_privkey_destroy(eph_prv_key);
+    free(tmp_buf);
+    return ret;
+}
+
+rnp_result
+pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
+                       size_t *                 session_key_len,
+                       uint8_t *                wrapped_key,
+                       size_t                   wrapped_key_len,
+                       const botan_mp_t         ephemeral_key,
+                       const pgp_ecc_seckey_t * seckey,
+                       const pgp_ecdh_pubkey_t *pubkey,
+                       const pgp_fingerprint_t *fingerprint)
+{
+    rnp_result ret = RNP_ERROR_GENERIC;
+    // Size of SHA-256 or smaller
+    uint8_t         kek[MAX_SYMM_KEY_SIZE];
+    uint8_t         other_info[MAX_SP800_56A_OTHER_INFO];
+    botan_privkey_t prv_key = NULL;
+    uint8_t         key[OBFUSCATED_KEY_SIZE] = {0};
+    size_t          key_len = sizeof(key);
+
+    if (!pubkey || !seckey->x || !seckey->x->mp) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    const ec_curve_desc_t *curve_desc = get_curve_desc(pubkey->ec.curve);
+    if (!curve_desc) {
+        return RNP_ERROR_NOT_SUPPORTED;
+    }
+
+    /* Ensure that AES is used for wrapping */
+    if ((pubkey->kdf.wrap_alg != PGP_SA_AES_128) && (pubkey->kdf.wrap_alg != PGP_SA_AES_192) &&
+        (pubkey->kdf.wrap_alg != PGP_SA_AES_256)) {
+        return RNP_ERROR_NOT_SUPPORTED;
+    }
+
+    // See 13.5 of RFC 4880 for definition of other_info_size
+    const size_t other_info_size =
+      (curve_desc->rnp_curve_id == PGP_CURVE_NIST_P_256) ? 54 : 51;
+    const size_t tmp_len = kdf_other_info_serialize(
+      other_info, curve_desc, fingerprint, pubkey->kdf.hash, pubkey->kdf.wrap_alg);
+
+    if (other_info_size != tmp_len) {
+        RNP_LOG("Serialization of other info failed");
+        goto end;
+    }
+
+    if (botan_privkey_load_ecdh(&prv_key, seckey->x->mp, curve_desc->botan_name)) {
+        goto end;
+    }
+
+    size_t kek_len = pgp_key_size(pubkey->kdf.wrap_alg);
+    if (!compute_kek(kek,
+                     kek_len,
+                     other_info,
+                     other_info_size,
+                     curve_desc,
+                     ephemeral_key,
+                     prv_key,
+                     pubkey->kdf.hash)) {
+        goto end;
+    }
+
+    if (botan_key_unwrap3394(wrapped_key, wrapped_key_len, kek, kek_len, key, &key_len)) {
+        goto end;
+    }
+
+    size_t offset = 0;
+    if (!unpad_pkcs7(key, key_len, &offset)) {
+        goto end;
+    }
+
+    if (*session_key_len < offset) {
+        ret = RNP_ERROR_SHORT_BUFFER;
+        goto end;
+    }
+
+    *session_key_len = offset;
+    memcpy(session_key, key, *session_key_len);
+
+    ret = RNP_SUCCESS;
+
+end:
+    botan_privkey_destroy(prv_key);
+    return ret;
+}

--- a/src/lib/ecdh.c
+++ b/src/lib/ecdh.c
@@ -306,7 +306,8 @@ pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
     uint8_t         key[OBFUSCATED_KEY_SIZE] = {0};
     size_t          key_len = sizeof(key);
 
-    if (!pubkey || !seckey->x || !seckey->x->mp) {
+    if (!session_key_len || !session_key_len || !wrapped_key || !pubkey || !seckey ||
+        !seckey->x || !seckey->x->mp) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 

--- a/src/lib/ecdh.h
+++ b/src/lib/ecdh.h
@@ -1,0 +1,70 @@
+/*-
+ * Copyright (c) 2017 Ribose Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ECDH_H_
+#define ECDH_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "errors.h"
+#include "rnp.h"
+#include "packet.h"
+
+/* Size of wrapped and obfuscated key size
+ *
+ * RNP pads a key with PKCS-5 always to 40 bytes,
+ * then 8 bytes is added by 3394.
+ */
+#define ECDH_WRAPPED_KEY_SIZE 48
+
+/*
+ * Performs ECDH encryption
+ *
+ * @param in plaintext to be encrypted
+ * @param length length of an input
+ * @param pubkey public key to be used for encryption
+ * @param ephemeral_key [out]
+ * @param wrapped_key [out]
+ *
+ * @return PGP_E_OK on success, otherwise error code
+ */
+rnp_result pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
+                                  size_t                   session_key_len,
+                                  uint8_t *                wrapped_key,
+                                  size_t *                 wrapped_key_len,
+                                  botan_mp_t               ephemeral_key,
+                                  const pgp_ecdh_pubkey_t *pubkey,
+                                  const pgp_fingerprint_t *fingerprint);
+
+rnp_result pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
+                                  size_t *                 session_key_len,
+                                  uint8_t *                wrapped_key,
+                                  size_t                   wrapped_key_len,
+                                  const botan_mp_t         ephemeral_key,
+                                  const pgp_ecc_seckey_t * seckey,
+                                  const pgp_ecdh_pubkey_t *pubkey,
+                                  const pgp_fingerprint_t *fingerprint);
+#endif // ECDH_H_

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -38,6 +38,21 @@
 
 extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
 
+/* Used by ECDH keys. Specifies which hash and wrapping algorithm
+ * to be used (see point 15. of RFC 4880).
+ */
+struct {
+    pgp_hash_alg_t hash;     /* Hash used by kdf */
+    pgp_symm_alg_t wrap_alg; /* Symmetric algorithm used to wrap KEK*/
+} ecdh_params[] = {
+  // PGP_CURVE_NIST_P_256
+  {.hash = PGP_HASH_SHA256, .wrap_alg = PGP_SA_AES_128},
+  // PGP_CURVE_NIST_P_384
+  {.hash = PGP_HASH_SHA384, .wrap_alg = PGP_SA_AES_192},
+  // PGP_CURVE_NIST_P_521
+  {.hash = PGP_HASH_SHA512, .wrap_alg = PGP_SA_AES_256},
+};
+
 pgp_curve_t
 find_curve_by_OID(const uint8_t *oid, size_t oid_len)
 {
@@ -51,8 +66,14 @@ find_curve_by_OID(const uint8_t *oid, size_t oid_len)
     return PGP_CURVE_MAX;
 }
 
+const ec_curve_desc_t *
+get_curve_desc(const pgp_curve_t curve_id)
+{
+    return (curve_id < PGP_CURVE_MAX) ? &ec_curves[curve_id] : NULL;
+}
+
 pgp_errcode_t
-pgp_ecdsa_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve)
+pgp_ecdh_ecdsa_genkeypair(pgp_seckey_t *seckey, const pgp_curve_t curve)
 {
     /**
      * Keeps "0x04 || x || y"
@@ -73,7 +94,11 @@ pgp_ecdsa_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve)
         goto end;
     }
 
-    if (botan_privkey_create_ecdsa(&pr_key, rng, ec_curves[curve].botan_name)) {
+    int bret = (seckey->pubkey.alg == PGP_PKA_ECDSA) ?
+                 botan_privkey_create_ecdsa(&pr_key, rng, ec_curves[curve].botan_name) :
+                 botan_privkey_create_ecdh(&pr_key, rng, ec_curves[curve].botan_name);
+
+    if (bret) {
         goto end;
     }
 
@@ -128,6 +153,11 @@ pgp_ecdsa_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve)
     seckey->pubkey.key.ecc.point = BN_bin2bn(point_bytes, (2 * filed_byte_size) + 1, NULL);
     if (!seckey->pubkey.key.ecc.point) {
         goto end;
+    }
+
+    if (seckey->pubkey.alg == PGP_PKA_ECDH) {
+        seckey->pubkey.key.ecdh.kdf.hash = ecdh_params[curve].hash;
+        seckey->pubkey.key.ecdh.kdf.wrap_alg = ecdh_params[curve].wrap_alg;
     }
 
     // All good now
@@ -282,16 +312,15 @@ end:
     return ret;
 }
 
-pgp_errcode_t
+bool
 ec_serialize_pubkey(pgp_output_t *output, const pgp_ecc_pubkey_t *pubkey)
 {
-    const ec_curve_desc_t *curve = &ec_curves[pubkey->curve];
-
-    if (pgp_write_scalar(output, curve->OIDhex_len, 1) &&
-        pgp_write(output, curve->OIDhex, curve->OIDhex_len) &&
-        pgp_write_mpi(output, pubkey->point)) {
-        return PGP_E_OK;
+    const ec_curve_desc_t *curve = get_curve_desc(pubkey->curve);
+    if (!curve) {
+        return false;
     }
 
-    return PGP_E_W_WRITE_FAILED;
+    return pgp_write_scalar(output, curve->OIDhex_len, 1) &&
+           pgp_write(output, curve->OIDhex, curve->OIDhex_len) &&
+           pgp_write_mpi(output, pubkey->point);
 }

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -72,6 +72,11 @@ get_curve_desc(const pgp_curve_t curve_id)
     return (curve_id < PGP_CURVE_MAX) ? &ec_curves[curve_id] : NULL;
 }
 
+/*
+ * TODO: This code is common to ECDSA, ECDH, SM2.
+ *       Put it to ec_utils.c together with the code above and
+ *       some ohter stuff common to EC.
+ */
 pgp_errcode_t
 pgp_ecdh_ecdsa_genkeypair(pgp_seckey_t *seckey, const pgp_curve_t curve)
 {

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -161,8 +161,8 @@ pgp_ecdh_ecdsa_genkeypair(pgp_seckey_t *seckey, const pgp_curve_t curve)
     }
 
     if (seckey->pubkey.alg == PGP_PKA_ECDH) {
-        seckey->pubkey.key.ecdh.kdf.hash = ecdh_params[curve].hash;
-        seckey->pubkey.key.ecdh.kdf.wrap_alg = ecdh_params[curve].wrap_alg;
+        seckey->pubkey.key.ecdh.kdf_hash_alg = ecdh_params[curve].hash;
+        seckey->pubkey.key.ecdh.key_wrap_alg = ecdh_params[curve].wrap_alg;
     }
 
     // All good now

--- a/src/lib/ecdsa.h
+++ b/src/lib/ecdsa.h
@@ -42,7 +42,7 @@
  * @returns success PGP_E_OK, error code otherwise
  *
 -------------------------------------------------------------------------------- */
-pgp_errcode_t pgp_ecdsa_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve);
+pgp_errcode_t pgp_ecdh_ecdsa_genkeypair(pgp_seckey_t *seckey, const pgp_curve_t curve);
 
 pgp_errcode_t pgp_ecdsa_sign_hash(pgp_ecc_sig_t *         sign,
                                   const uint8_t *         hashbuf,

--- a/src/lib/errors.h
+++ b/src/lib/errors.h
@@ -64,11 +64,15 @@
 /** error codes */
 /* Remember to add names to map in errors.c */
 typedef enum {
-    PGP_E_OK = 0x0000,            /* no error */
-    PGP_E_FAIL = 0x0001,          /* general error */
-    PGP_E_SYSTEM_ERROR = 0x0002,  /* system error, look at errno for
-                                   * details */
-    PGP_E_UNIMPLEMENTED = 0x0003, /* feature not yet implemented */
+    PGP_E_OK = 0x0000,               /* no error */
+    PGP_E_FAIL = 0x0001,             /* general error */
+    PGP_E_SYSTEM_ERROR = 0x0002,     /* system error, look at errno for
+                                      * details */
+    PGP_E_UNIMPLEMENTED = 0x0003,    /* feature not yet implemented */
+    PGP_E_BUFFER_TOO_SHORT = 0x0004, /* if the output buffer is not large enough
+                                        to contain the output */
+    PGP_E_BAD_PARAMETERS = 0x0005,   /* unexpected parameters supplied to the function */
+    PGP_E_OUT_OF_MEMORY = 0x0006,    /* Memory allocation failed */
 
     /* reader errors */
     PGP_E_R = 0x1000, /* general reader error */

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -747,7 +747,7 @@ pgp_mem_readfile(pgp_memory_t *mem, const char *f)
     int         cc;
 
     if ((fp = fopen(f, "rb")) == NULL) {
-        (void) fprintf(stderr, "pgp_mem_readfile: can't open \"%s\"\n", f);
+        RNP_LOG("can't open \"%s\"", f);
         return false;
     }
     (void) fstat(fileno(fp), &st);
@@ -756,7 +756,7 @@ pgp_mem_readfile(pgp_memory_t *mem, const char *f)
     if (mem->buf == MAP_FAILED) {
         /* mmap failed for some reason - try to allocate memory */
         if ((mem->buf = calloc(1, mem->allocated)) == NULL) {
-            (void) fprintf(stderr, "pgp_mem_readfile: calloc\n");
+            RNP_LOG("calloc failed");
             (void) fclose(fp);
             return false;
         }

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -246,8 +246,8 @@ write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
         return ec_serialize_pubkey(output, &key->key.ecdh.ec) &&
                pgp_write_scalar(output, 3 /*size of following attributes*/, 1) &&
                pgp_write_scalar(output, 1 /*reserved*/, 1) &&
-               pgp_write_scalar(output, (uint8_t) key->key.ecdh.kdf.hash, 1) &&
-               pgp_write_scalar(output, (uint8_t) key->key.ecdh.kdf.wrap_alg, 1);
+               pgp_write_scalar(output, (uint8_t) key->key.ecdh.kdf_hash_alg, 1) &&
+               pgp_write_scalar(output, (uint8_t) key->key.ecdh.key_wrap_alg, 1);
     case PGP_PKA_ELGAMAL:
         return pgp_write_mpi(output, key->key.elgamal.p) &&
                pgp_write_mpi(output, key->key.elgamal.g) &&

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -1059,7 +1059,7 @@ pgp_create_pk_sesskey(const pgp_key_t *key, pgp_symm_alg_t cipher)
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "encrypted mpi", encmpibuf, out_len);
         }
-    } else {
+    } else if (key->key.pubkey.alg == PGP_PKA_ELGAMAL) {
         /* ElGamal case */
         uint8_t encmpibuf[RNP_BUFSIZ];
         uint8_t g_to_k[RNP_BUFSIZ];
@@ -1079,6 +1079,9 @@ pgp_create_pk_sesskey(const pgp_key_t *key, pgp_symm_alg_t cipher)
             hexdump(stderr, "elgamal g^k", g_to_k, n / 2);
             hexdump(stderr, "encrypted mpi", encmpibuf, n / 2);
         }
+    } else {
+        RNP_LOG("Unknown algorithm %d", key->key.pubkey.alg);
+        goto error;
     }
 
 done:

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -95,6 +95,7 @@ __RCSID("$NetBSD: create.c,v 1.38 2010/11/15 08:03:39 agc Exp $");
 #include <rnp/rnp_sdk.h>
 #include "ecdsa.h"
 #include <rnp/rnp_def.h>
+#include "ecdh.h"
 
 extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
 
@@ -160,7 +161,13 @@ pubkey_length(const pgp_pubkey_t *key)
     case PGP_PKA_DSA:
         return mpi_length(key->key.dsa.p) + mpi_length(key->key.dsa.q) +
                mpi_length(key->key.dsa.g) + mpi_length(key->key.dsa.y);
-
+    case PGP_PKA_ECDH:
+        return 1 // length of curve OID
+               + ec_curves[key->key.ecc.curve].OIDhex_len + mpi_length(key->key.ecc.point) +
+               1    // Size of following fields
+               + 1  // Value 1 reserved for future use
+               + 1  // Hash function ID used with KDF
+               + 1; // Symmetric algorithm used to wrap symmetric key
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
@@ -183,6 +190,7 @@ seckey_length(const pgp_seckey_t *key)
 
     len = 0;
     switch (key->pubkey.alg) {
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
@@ -204,6 +212,7 @@ seckey_length(const pgp_seckey_t *key)
  * Note that we support v3 keys here because they're needed for for
  * verification - the writer doesn't allow them, though
  */
+
 static bool
 write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
 {
@@ -228,12 +237,17 @@ write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
-        return (ec_serialize_pubkey(output, &key->key.ecc) == PGP_E_OK);
+        return ec_serialize_pubkey(output, &key->key.ecc);
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
         return pgp_write_mpi(output, key->key.rsa.n) && pgp_write_mpi(output, key->key.rsa.e);
-
+    case PGP_PKA_ECDH:
+        return ec_serialize_pubkey(output, &key->key.ecdh.ec) &&
+               pgp_write_scalar(output, 3 /*size of following attributes*/, 1) &&
+               pgp_write_scalar(output, 1 /*reserved*/, 1) &&
+               pgp_write_scalar(output, (uint8_t) key->key.ecdh.kdf.hash, 1) &&
+               pgp_write_scalar(output, (uint8_t) key->key.ecdh.kdf.wrap_alg, 1);
     case PGP_PKA_ELGAMAL:
         return pgp_write_mpi(output, key->key.elgamal.p) &&
                pgp_write_mpi(output, key->key.elgamal.g) &&
@@ -298,6 +312,7 @@ hash_key_material(const pgp_seckey_t *key, uint8_t *result)
     case PGP_PKA_DSA:
         hash_bn(&hash, key->key.dsa.x);
         break;
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
@@ -454,6 +469,7 @@ write_seckey_body(const pgp_seckey_t *key, const uint8_t *passphrase, pgp_output
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_ECDH:
         if (!pgp_write_mpi(output, key->key.ecc.x))
             return false;
         break;
@@ -585,7 +601,7 @@ pgp_write_xfer_pubkey(pgp_output_t *         output,
 
 */
 
-unsigned
+bool
 pgp_write_xfer_seckey(pgp_output_t *         output,
                       const pgp_key_t *      key,
                       const uint8_t *        passphrase,
@@ -670,7 +686,7 @@ pgp_write_xfer_anykey(pgp_output_t *         output,
     case PGP_PTAG_CT_SECRET_KEY:
     case PGP_PTAG_CT_SECRET_SUBKEY:
         if (!pgp_write_xfer_seckey(output, key, passphrase, NULL, armoured)) {
-            fprintf(stderr, "Can't write private key\n");
+            RNP_LOG("Can't write private key");
             return false;
         }
         break;
@@ -891,7 +907,11 @@ create_unencoded_m_buf(pgp_pk_sesskey_t *sesskey, pgp_crypt_t *cipherinfo, uint8
     /* m_buf is the buffer which will be encoded in PKCS#1 block
      * encoding to form the "m" value used in the Public Key
      * Encrypted Session Key Packet as defined in RFC Section 5.1
-     * "Public-Key Encrypted Session Key Packet"
+     * "Public-Key Encrypted Session Key Packet". Notice that
+     * in case of ECDH different than PKCS#1 encoding is used.
+     *
+     * Format:
+     *   m = symm_alg_ID || session key || checksum
      */
     m_buf[0] = sesskey->symm_alg;
     for (i = 0; i < cipherinfo->keysize; i++) {
@@ -941,9 +961,14 @@ pgp_create_pk_sesskey(const pgp_key_t *key, pgp_symm_alg_t cipher)
         return NULL;
     }
 
-    if (pubkey->alg != PGP_PKA_RSA && pubkey->alg != PGP_PKA_DSA &&
-        pubkey->alg != PGP_PKA_ELGAMAL) {
-        (void) fprintf(stderr, "pgp_create_pk_sesskey: bad pubkey algorithm\n");
+    switch (pubkey->alg) {
+    case PGP_PKA_RSA:
+    case PGP_PKA_DSA:
+    case PGP_PKA_ELGAMAL:
+    case PGP_PKA_ECDH:
+        break;
+    default:
+        RNP_LOG("Bad public key encryption algorithm");
         return NULL;
     }
 
@@ -1009,6 +1034,31 @@ pgp_create_pk_sesskey(const pgp_key_t *key, pgp_symm_alg_t cipher)
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "encrypted mpi", encmpibuf, n);
         }
+    } else if (key->key.pubkey.alg == PGP_PKA_ECDH) {
+        uint8_t encmpibuf[ECDH_WRAPPED_KEY_SIZE] = {0};
+        size_t  out_len = sizeof(encmpibuf);
+
+        sesskey->params.ecdh.ephemeral_point = BN_new();
+        if (!sesskey->params.ecdh.ephemeral_point) {
+            goto done;
+        }
+
+        const rnp_result err = pgp_ecdh_encrypt_pkcs5(encoded_key,
+                                                      sz_encoded_key,
+                                                      encmpibuf,
+                                                      &out_len,
+                                                      sesskey->params.ecdh.ephemeral_point->mp,
+                                                      &key->key.pubkey.key.ecdh,
+                                                      &key->sigfingerprint);
+        if (RNP_SUCCESS != err) {
+            RNP_LOG("Encryption failed %d\n", err);
+            goto error;
+        }
+        memcpy(sesskey->params.ecdh.encrypted_m, encmpibuf, out_len);
+        sesskey->params.ecdh.encrypted_m_size = out_len;
+        if (rnp_get_debug(__FILE__)) {
+            hexdump(stderr, "encrypted mpi", encmpibuf, out_len);
+        }
     } else {
         /* ElGamal case */
         uint8_t encmpibuf[RNP_BUFSIZ];
@@ -1048,7 +1098,7 @@ error:
 \param pksk Public Key Session Key to write out
 \return 1 if OK; else 0
 */
-unsigned
+bool
 pgp_write_pk_sesskey(pgp_output_t *output, pgp_pk_sesskey_t *pksk)
 {
     /* XXX - Flexelint - Pointer parameter 'pksk' (line 1076) could be declared as pointing to
@@ -1080,9 +1130,21 @@ pgp_write_pk_sesskey(pgp_output_t *output, pgp_pk_sesskey_t *pksk)
                pgp_write(output, pksk->key_id, 8) &&
                pgp_write_scalar(output, (unsigned) pksk->alg, 1) &&
                pgp_write_mpi(output, pksk->params.elgamal.g_to_k) &&
-               pgp_write_mpi(output, pksk->params.elgamal.encrypted_m)
-          /* ??    && pgp_write_scalar(output, 0, 2); */
-          ;
+               pgp_write_mpi(output, pksk->params.elgamal.encrypted_m);
+    /* ??    && pgp_write_scalar(output, 0, 2); */
+    case PGP_PKA_ECDH:
+        return pgp_write_ptag(output, PGP_PTAG_CT_PK_SESSION_KEY) &&
+               pgp_write_length(output,
+                                (unsigned) (1 + 8 + 1 +
+                                            BN_num_bytes(pksk->params.ecdh.ephemeral_point) +
+                                            2 + 1 + pksk->params.ecdh.encrypted_m_size)) &&
+               pgp_write_scalar(output, (unsigned) pksk->version, 1) &&
+               pgp_write(output, pksk->key_id, 8) &&
+               pgp_write_scalar(output, (unsigned) pksk->alg, 1) &&
+               pgp_write_mpi(output, pksk->params.ecdh.ephemeral_point) &&
+               pgp_write_scalar(output, pksk->params.ecdh.encrypted_m_size, 1) &&
+               pgp_write(
+                 output, pksk->params.ecdh.encrypted_m, pksk->params.ecdh.encrypted_m_size);
     default:
         (void) fprintf(stderr, "pgp_write_pk_sesskey: bad algorithm\n");
         return false;

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -54,6 +54,7 @@
 #ifndef CREATE_H_
 #define CREATE_H_
 
+#include <stdbool.h>
 #include "types.h"
 #include "packet.h"
 #include "crypto.h"
@@ -92,12 +93,12 @@ unsigned pgp_write_one_pass_sig(pgp_output_t *,
                                 const pgp_sig_type_t);
 unsigned pgp_write_litdata(pgp_output_t *, const uint8_t *, const int, const pgp_litdata_enum);
 pgp_pk_sesskey_t *pgp_create_pk_sesskey(const pgp_key_t *, pgp_symm_alg_t);
-unsigned          pgp_write_pk_sesskey(pgp_output_t *, pgp_pk_sesskey_t *);
+bool              pgp_write_pk_sesskey(pgp_output_t *, pgp_pk_sesskey_t *);
 unsigned          pgp_write_xfer_pubkey(pgp_output_t *,
                                const pgp_key_t *,
                                const rnp_key_store_t *,
                                const unsigned);
-unsigned pgp_write_xfer_seckey(
+bool pgp_write_xfer_seckey(
   pgp_output_t *, const pgp_key_t *, const uint8_t *, const rnp_key_store_t *, const unsigned);
 bool pgp_write_xfer_anykey(
   pgp_output_t *, const pgp_key_t *, const uint8_t *, const rnp_key_store_t *, const unsigned);

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -1363,8 +1363,8 @@ parse_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
         if (!limread_scalar(&tmp, 1, region, stream) || (tmp != 1)) {
             return false;
         }
-        if (!limread_scalar(&key->key.ecdh.kdf.hash, 1, region, stream) ||
-            !limread_scalar(&key->key.ecdh.kdf.wrap_alg, 1, region, stream)) {
+        if (!limread_scalar(&key->key.ecdh.kdf_hash_alg, 1, region, stream) ||
+            !limread_scalar(&key->key.ecdh.key_wrap_alg, 1, region, stream)) {
             return false;
         }
         break;

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -1241,7 +1241,7 @@ pgp_pubkey_free(pgp_pubkey_t *p)
 }
 
 static bool
-parse_ecdsa_ecdh_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
+parse_ec_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
 {
     pgp_data_t OID = {0};
     unsigned   OID_len = 0;
@@ -1346,13 +1346,13 @@ parse_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
-        if (!parse_ecdsa_ecdh_pubkey_data(key, region, stream)) {
+        if (!parse_ec_pubkey_data(key, region, stream)) {
             return false;
         }
         break;
 
     case PGP_PKA_ECDH: {
-        if (!parse_ecdsa_ecdh_pubkey_data(key, region, stream)) {
+        if (!parse_ec_pubkey_data(key, region, stream)) {
             return false;
         }
 

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -53,6 +53,7 @@
  * \brief Parser for OpenPGP packets
  */
 #include "config.h"
+#include <assert.h>
 
 #ifdef HAVE_SYS_CDEFS_H
 #include <sys/cdefs.h>
@@ -92,6 +93,7 @@ __RCSID("$NetBSD: packet-parse.c,v 1.51 2012/03/05 02:20:18 christos Exp $");
 #include "rnpdigest.h"
 #include "s2k.h"
 #include "utils.h"
+#include "ecdh.h"
 
 #define ERRP(cbinfo, cont, err)                    \
     do {                                           \
@@ -965,6 +967,7 @@ pgp_sig_free(pgp_sig_t *sig)
     case PGP_PKA_EDDSA:
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_ECDH:
         free_BN(&sig->info.sig.ecc.r);
         free_BN(&sig->info.sig.ecc.s);
         break;
@@ -984,7 +987,7 @@ pgp_sig_free(pgp_sig_t *sig)
         break;
 
     default:
-        (void) fprintf(stderr, "pgp_sig_free: bad sig type\n");
+        RNP_LOG("bad sig type %u", sig->info.key_alg);
     }
 }
 
@@ -1182,9 +1185,11 @@ pgp_pk_sesskey_free(pgp_pk_sesskey_t *sk)
         free_BN(&sk->params.elgamal.g_to_k);
         free_BN(&sk->params.elgamal.encrypted_m);
         break;
-
+    case PGP_PKA_ECDH:
+        free_BN(&sk->params.ecdh.ephemeral_point);
+        break;
     default:
-        (void) fprintf(stderr, "pgp_pk_sesskey_free: bad alg\n");
+        RNP_LOG("Unsupported algorithm");
         break;
     }
 }
@@ -1212,6 +1217,7 @@ pgp_pubkey_free(pgp_pubkey_t *p)
         free_BN(&p->key.dsa.y);
         break;
 
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
@@ -1230,8 +1236,39 @@ pgp_pubkey_free(pgp_pubkey_t *p)
         break;
 
     default:
-        (void) fprintf(stderr, "pgp_pubkey_free: bad alg\n");
+        RNP_LOG("Unsupported algorithm");
     }
+}
+
+static bool
+parse_ecdsa_ecdh_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
+{
+    pgp_data_t OID = {0};
+    unsigned   OID_len = 0;
+    if (!limread_scalar(&OID_len, 1, region, stream) || (OID_len == 0x00) ||
+        (OID_len == 0xFF)) { // values reserved for future extensions
+        return false;
+    }
+
+    if (!limread_data(&OID, OID_len, region, stream)) {
+        return false;
+    }
+
+    if (!limread_mpi(&key->key.ecc.point, region, stream)) {
+        pgp_data_free(&OID);
+        return false;
+    }
+
+    const pgp_curve_t curve = find_curve_by_OID(OID.contents, OID.len);
+    if (PGP_CURVE_MAX == curve) {
+        RNP_LOG("Unsupported curve %u", curve);
+        pgp_data_free(&OID);
+        return false;
+    }
+
+    key->key.ecc.curve = curve;
+    pgp_data_free(&OID);
+    return true;
 }
 
 /**
@@ -1308,29 +1345,31 @@ parse_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
 
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
-    case PGP_PKA_SM2: {
-        pgp_data_t OID = {0};
-        unsigned   OID_len = 0;
-        if (!limread_scalar(&OID_len, 1, region, stream) || (OID_len == 0x00) ||
-            (OID_len == 0xFF)) { // values reserved for future extensions
+    case PGP_PKA_SM2:
+        if (!parse_ecdsa_ecdh_pubkey_data(key, region, stream)) {
+            return false;
+        }
+        break;
+
+    case PGP_PKA_ECDH: {
+        if (!parse_ecdsa_ecdh_pubkey_data(key, region, stream)) {
             return false;
         }
 
-        if (!limread_data(&OID, OID_len, region, stream) ||
-            !limread_mpi(&key->key.ecc.point, region, stream)) {
+        unsigned tmp = 0;
+        if (!limread_scalar(&tmp, 1, region, stream) || (tmp != 3)) {
             return false;
         }
-
-        const pgp_curve_t curve = find_curve_by_OID(OID.contents, OID.len);
-        if (PGP_CURVE_MAX == curve) {
-            RNP_LOG("Unsupported curve");
-            pgp_data_free(&OID);
+        if (!limread_scalar(&tmp, 1, region, stream) || (tmp != 1)) {
             return false;
         }
-        key->key.ecc.curve = curve;
-        pgp_data_free(&OID);
+        if (!limread_scalar(&key->key.ecdh.kdf.hash, 1, region, stream) ||
+            !limread_scalar(&key->key.ecdh.kdf.wrap_alg, 1, region, stream)) {
+            return false;
+        }
         break;
     }
+
     default:
         PGP_ERROR_1(&stream->errors,
                     PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG,
@@ -1366,7 +1405,7 @@ parse_pubkey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
     memset(&pkt, 0x00, sizeof(pgp_packet_t));
 
     if (!parse_pubkey_data(&pkt.u.pubkey, region, stream)) {
-        (void) fprintf(stderr, "parse_pubkey: parse_pubkey_data failed\n");
+        RNP_LOG("parse_pubkey_data failed");
         return false;
     }
 
@@ -2111,6 +2150,7 @@ parse_v4_sig(pgp_region_t *region, pgp_stream_t *stream)
     case PGP_PKA_EDDSA:
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_ECDH:
         if (!limread_mpi(&pkt.u.sig.info.sig.ecc.r, region, stream) ||
             !limread_mpi(&pkt.u.sig.info.sig.ecc.s, region, stream)) {
             free(pkt.u.sig.info.v4_hashed);
@@ -2411,6 +2451,7 @@ pgp_seckey_free(pgp_seckey_t *key)
         break;
 
     case PGP_PKA_EDDSA:
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
         free_BN(&key->key.ecc.x);
@@ -2687,6 +2728,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
     case PGP_PKA_EDDSA:
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_ECDH:
         if (!limread_mpi(&pkt.u.seckey.key.ecc.x, region, stream)) {
             ret = 0;
         }
@@ -2784,8 +2826,8 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
     uint8_t             c = 0x0;
     uint8_t             cs[2];
     unsigned            k;
-    BIGNUM *            g_to_k;
-    BIGNUM *            enc_m;
+    BIGNUM *            g_to_k = NULL;
+    BIGNUM *            enc_m = NULL;
     int                 n;
     uint8_t             unencoded_m_buf[1024];
 
@@ -2836,6 +2878,23 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
         enc_m = pkt.u.pk_sesskey.params.elgamal.encrypted_m;
         break;
 
+    case PGP_PKA_ECDH:
+        if (!limread_mpi(&pkt.u.pk_sesskey.params.ecdh.ephemeral_point, region, stream) ||
+            !limread_scalar(
+              &pkt.u.pk_sesskey.params.ecdh.encrypted_m_size, 1, region, stream) ||
+            (pkt.u.pk_sesskey.params.ecdh.encrypted_m_size > ECDH_WRAPPED_KEY_SIZE) ||
+            !limread(pkt.u.pk_sesskey.params.ecdh.encrypted_m,
+                     pkt.u.pk_sesskey.params.ecdh.encrypted_m_size,
+                     region,
+                     stream)) {
+            return false;
+        }
+        g_to_k = pkt.u.pk_sesskey.params.ecdh.ephemeral_point;
+        enc_m = BN_bin2bn(pkt.u.pk_sesskey.params.ecdh.encrypted_m,
+                          pkt.u.pk_sesskey.params.ecdh.encrypted_m_size,
+                          enc_m);
+        break;
+
     default:
         PGP_ERROR_1(&stream->errors,
                     PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG,
@@ -2862,6 +2921,7 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
         CALLBACK(PGP_PTAG_CT_ENCRYPTED_PK_SESSION_KEY, &stream->cbinfo, &pkt);
         return true;
     }
+
     n = pgp_decrypt_decode_mpi(
       unencoded_m_buf, (unsigned) sizeof(unencoded_m_buf), g_to_k, enc_m, secret);
 

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -348,6 +348,7 @@ numkeybits(const pgp_pubkey_t *pubkey)
     case PGP_PKA_ELGAMAL:
         return BN_num_bytes(pubkey->key.elgamal.y) * 8;
 
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
@@ -952,6 +953,7 @@ pgp_print_pubkey(const pgp_pubkey_t *pubkey)
         print_bn(0, "y", pubkey->key.elgamal.y);
         break;
     case PGP_PKA_ECDSA:
+    case PGP_PKA_ECDH:
         print_string(0, "curve", ec_curves[pubkey->key.ecc.curve].botan_name);
         print_bn(0, "public point", pubkey->key.ecc.point);
         break;
@@ -1004,6 +1006,7 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         break;
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_ECDH:
         cc += snprintf(&out[cc],
                        outsize - cc,
                        "curve=%s\npoint=%s\n",
@@ -1068,6 +1071,7 @@ print_seckey_verbose(const pgp_content_enum type, const pgp_seckey_t *seckey)
         break;
 
     case PGP_PKA_ECDSA:
+    case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
         print_bn(0, "x", seckey->key.ecc.x);

--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -212,7 +212,7 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_RSA_SIGN_ONLY, "RSA Sign-Only"},
   {PGP_PKA_ELGAMAL, "Elgamal (Encrypt-Only)"},
   {PGP_PKA_DSA, "DSA"},
-  {PGP_PKA_ECDH, "Reserved for Elliptic Curve"},
+  {PGP_PKA_ECDH, "ECDH"},
   {PGP_PKA_ECDSA, "ECDSA"},
   {PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN, "Reserved (formerly Elgamal Encrypt or Sign"},
   {PGP_PKA_RESERVED_DH, "Reserved for Diffie-Hellman (X9.42)"},

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -487,10 +487,8 @@ typedef struct {
  */
 typedef struct pgp_ecdh_pubkey_t {
     pgp_ecc_pubkey_t ec;
-    struct {
-        pgp_hash_alg_t hash;     /* Hash used by kdf */
-        pgp_symm_alg_t wrap_alg; /* Symmetric algorithm used to wrap KEK*/
-    } kdf;
+    pgp_hash_alg_t   kdf_hash_alg; /* Hash used by kdf */
+    pgp_symm_alg_t   key_wrap_alg; /* Symmetric algorithm used to wrap KEK*/
 } pgp_ecdh_pubkey_t;
 
 /** Version.

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -801,11 +801,12 @@ pgp_sig_write(pgp_output_t *      output,
         }
         break;
 
-    case PGP_PKA_EDDSA:
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
+    case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
         if (seckey->key.ecc.x == NULL) {
-            (void) fprintf(stderr, "pgp_sig_write: null ecc.x\n");
+            RNP_LOG("null ecc.x");
             return false;
         }
         break;
@@ -815,8 +816,9 @@ pgp_sig_write(pgp_output_t *      output,
         return false;
     }
 
+    // TODO: Is this correct at all?
     if (sig->hashlen == (unsigned) -1) {
-        (void) fprintf(stderr, "ops_write_sig: bad hashed data len\n");
+        RNP_LOG("bad hashed data len");
         return false;
     }
 
@@ -870,6 +872,11 @@ pgp_sig_write(pgp_output_t *      output,
         }
         break;
 
+    /*
+     * ECDH is signed with ECDSA. This must be changed when ECDH will support
+     * X25519, but I need to check how it should be done exactly.
+     */
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
         if (!ecdsa_sign(&sig->hash, &key->key.ecc, &seckey->key.ecc, sig->output)) {
             RNP_LOG("ecdsa sign failure");

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -61,6 +61,7 @@ __RCSID("$NetBSD: symmetric.c,v 1.18 2010/11/07 08:39:59 agc Exp $");
 
 #include <string.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include <botan/ffi.h>
 
@@ -304,6 +305,11 @@ pgp_block_size(pgp_symm_alg_t alg)
 unsigned
 pgp_key_size(pgp_symm_alg_t alg)
 {
+    /* Update MAX_SYMM_KEY_SIZE after adding algorithm
+     * with bigger key size.
+     */
+    static_assert(32 == MAX_SYMM_KEY_SIZE, "MAX_SYMM_KEY_SIZE must be updated");
+
     switch (alg) {
     case PGP_SA_IDEA:
     case PGP_SA_CAST5:

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -1013,7 +1013,9 @@ pgp_push_enc_se_ip(pgp_output_t *output, const pgp_key_t *pubkey, pgp_symm_alg_t
         free(se_ip);
         return false;
     }
-    pgp_write_pk_sesskey(output, encrypted_pk_sesskey);
+    if (!pgp_write_pk_sesskey(output, encrypted_pk_sesskey)) {
+        return 0;
+    }
 
     /* Setup the se_ip */
     if ((encrypted = calloc(1, sizeof(*encrypted))) == NULL) {

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -64,12 +64,12 @@ is_keygen_supported_for_alg(pgp_pubkey_alg_t id)
 {
     switch (id) {
     case PGP_PKA_RSA:
-    case PGP_PKA_ECDSA:
+    case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_ECDSA:
         // Not yet really supported (at least key generation)
         //
-        // case PGP_PKA_ECDH:
         // case PGP_PKA_ELGAMAL:
         // case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
         // case PGP_PKA_DSA:
@@ -109,7 +109,7 @@ ask_algorithm(FILE *input_fp)
     do {
         printf("Please select what kind of key you want:\n"
                "\t(1)  RSA (Encrypt or Sign)\n"
-               // "\t(18) ECDH\n"
+               "\t(18) ECDH\n"
                "\t(19) ECDSA\n"
                "\t(22) EDDSA\n"
                "\t(99) SM2\n"

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -1,8 +1,8 @@
 AM_CFLAGS		    = $(WARNCFLAGS)
 bin_PROGRAMS		= rnp_tests
 rnp_tests_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/lib $(JSONC_INCLUDES) $(BOTAN_INCLUDES) $(CMOCKA_INCLUDES)
-rnp_tests_LDADD		= ../lib/librnp.la ../rnpkeys/librnpkeys.la ../librekey/librekey.la $(JSONC_LIBS) $(CMOCKA_LIBS)
-rnp_tests_LDFLAGS	= $(JSONC_LDFLAGS) $(CMOCKA_LDFLAGS)
+rnp_tests_LDADD		= ../lib/librnp.la ../rnpkeys/librnpkeys.la ../librekey/librekey.la $(JSONC_LIBS) $(CMOCKA_LIBS) $(BOTAN_LIBS)
+rnp_tests_LDFLAGS	= $(JSONC_LDFLAGS) $(CMOCKA_LDFLAGS) $(BOTAN_LDFLAGS)
 rnp_tests_SOURCES   = \
     support.c \
     cipher.c \

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -578,8 +578,8 @@ ecdh_decryptionNegativeCases(void **state)
                                                 &ecdh_key1->sigfingerprint),
                          RNP_ERROR_SHORT_BUFFER);
 
-    int key_wrapping_alg = ecdh_key1->key.pubkey.key.ecdh.kdf.wrap_alg;
-    ecdh_key1->key.pubkey.key.ecdh.kdf.wrap_alg = PGP_SA_IDEA;
+    int key_wrapping_alg = ecdh_key1->key.pubkey.key.ecdh.key_wrap_alg;
+    ecdh_key1->key.pubkey.key.ecdh.key_wrap_alg = PGP_SA_IDEA;
     rnp_assert_int_equal(rstate,
                          pgp_ecdh_decrypt_pkcs5(result,
                                                 &result_len,
@@ -590,7 +590,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 &ecdh_key1->key.pubkey.key.ecdh,
                                                 &ecdh_key1->sigfingerprint),
                          RNP_ERROR_NOT_SUPPORTED);
-    ecdh_key1->key.pubkey.key.ecdh.kdf.wrap_alg = key_wrapping_alg;
+    ecdh_key1->key.pubkey.key.ecdh.key_wrap_alg = key_wrapping_alg;
 
     // Change ephemeral key, so that it fails to decrypt
     botan_mp_clear(tmp_eph_key);

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -434,10 +434,10 @@ ecdh_roundtrip(void **state)
     rnp_assert_int_equal(rstate, botan_mp_init(&tmp_eph_key), 0);
 
     for (int i = 0; i < ARRAY_SIZE(curves); i++) {
-        const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_ECDH,
-                                            .hash_alg = PGP_HASH_SHA512,
-                                            .sym_alg = PGP_SA_AES_256,
-                                            .ecc = {.curve = curves[i].id}};
+        const rnp_keygen_desc_t key_desc = {.crypto = {.key_alg = PGP_PKA_ECDH,
+                                                       .hash_alg = PGP_HASH_SHA512,
+                                                       .sym_alg = PGP_SA_AES_256,
+                                                       .ecc = {.curve = curves[i].id}}};
 
         const size_t expected_result_byte_size = curves[i].size * 2 + 1;
         pgp_key_t *  ecdh_key1 = pgp_generate_keypair(&key_desc, NULL);
@@ -489,10 +489,10 @@ ecdh_decryptionNegativeCases(void **state)
 
     rnp_assert_int_equal(rstate, botan_mp_init(&tmp_eph_key), 0);
 
-    const rnp_keygen_desc_t key_desc = {.key_alg = PGP_PKA_ECDH,
-                                        .hash_alg = PGP_HASH_SHA512,
-                                        .sym_alg = PGP_SA_AES_256,
-                                        .ecc = {.curve = PGP_CURVE_NIST_P_256}};
+    const rnp_keygen_desc_t key_desc = {.crypto = {.key_alg = PGP_PKA_ECDH,
+                                                   .hash_alg = PGP_HASH_SHA512,
+                                                   .sym_alg = PGP_SA_AES_256,
+                                                   .ecc = {.curve = PGP_CURVE_NIST_P_256}}};
 
     const size_t expected_result_byte_size = 32 * 2 + 1;
     pgp_key_t *  ecdh_key1 = pgp_generate_keypair(&key_desc, NULL);

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -549,6 +549,9 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_cfg_t         ops = {0};
 
     // Setup directories and cleanup context
+    static const char test_ecdh_256[] = "18\n1\n";
+    static const char test_ecdh_384[] = "18\n2\n";
+    static const char test_ecdh_521[] = "18\n3\n";
     static const char test_ecdsa_256[] = "19\n1\n";
     static const char test_ecdsa_384[] = "19\n2\n";
     static const char test_ecdsa_521[] = "19\n3\n";
@@ -559,11 +562,25 @@ rnpkeys_generatekey_testExpertMode(void **state)
 
     rnp_assert_true(rstate, rnp_cfg_setbool(&ops, CFG_EXPERT, true));
 
-    rnp_assert_true(rstate, ask_expert_details(&rnp, &ops, test_sm2, sizeof(test_sm2)));
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_SM2);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_SM2_P_256);
-    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SM3);
+    rnp_assert_true(rstate,
+                    ask_expert_details(&rnp, &ops, test_ecdh_256, sizeof(test_ecdh_256)));
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_ECDH);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_NIST_P_256);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA256);
+    rnp_end(&rnp);
+
+    rnp_assert_true(rstate,
+                    ask_expert_details(&rnp, &ops, test_ecdh_384, sizeof(test_ecdh_384)));
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_ECDH);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_NIST_P_384);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA384);
+    rnp_end(&rnp);
+
+    rnp_assert_true(rstate,
+                    ask_expert_details(&rnp, &ops, test_ecdh_521, sizeof(test_ecdh_521)));
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_ECDH);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_NIST_P_521);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SHA512);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
@@ -609,11 +626,17 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.rsa.modulus_bit_len, 4096);
     rnp_end(&rnp);
 
+    rnp_assert_true(rstate, ask_expert_details(&rnp, &ops, test_sm2, sizeof(test_sm2)));
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.key_alg, PGP_PKA_SM2);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.ecc.curve, PGP_CURVE_SM2_P_256);
+    rnp_assert_int_equal(rstate, rnp.action.generate_key_ctx.crypto.hash_alg, PGP_HASH_SM3);
+    rnp_end(&rnp);
+
     rnp_cfg_free(&ops);
 }
 
 void
-generatekey_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state)
+generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state)
 {
     rnp_test_state_t *rstate = *state;
     rnp_t             rnp;
@@ -632,7 +655,7 @@ generatekey_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state)
 }
 
 void
-generatekey_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
+generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
 {
     rnp_test_state_t *rstate = *state;
     rnp_t             rnp;
@@ -651,7 +674,7 @@ generatekey_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
 }
 
 void
-generatekey_explicitlySetWrongDigest_ShouldFail(void **state)
+generatekeyECDSA_explicitlySetWrongDigest_ShouldFail(void **state)
 {
     rnp_test_state_t *rstate = *state;
     rnp_t             rnp;

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -145,13 +145,14 @@ main(int argc, char *argv[])
       cmocka_unit_test(rnpkeys_generatekey_verifykeyHomeDirNoPermission),
       cmocka_unit_test(rnpkeys_exportkey_verifyUserId),
       cmocka_unit_test(rnpkeys_generatekey_testExpertMode),
-      cmocka_unit_test(generatekey_explicitlySetSmallOutputDigest_DigestAlgAdjusted),
-      cmocka_unit_test(generatekey_explicitlySetBiggerThanNeededDigest_ShouldSuceed),
-      cmocka_unit_test(generatekey_explicitlySetWrongDigest_ShouldFail),
+      cmocka_unit_test(generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted),
+      cmocka_unit_test(generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed),
+      cmocka_unit_test(generatekeyECDSA_explicitlySetWrongDigest_ShouldFail),
       cmocka_unit_test(test_utils_list),
       cmocka_unit_test(pgp_parse_keyrings_1_pubring),
       cmocka_unit_test(test_load_user_prefs),
-      cmocka_unit_test(ecdh_roundtrip)
+      cmocka_unit_test(ecdh_roundtrip),
+      cmocka_unit_test(ecdh_decryptionNegativeCases)
     };
 
     /* Each test entry will invoke setup_test before running

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -151,6 +151,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_utils_list),
       cmocka_unit_test(pgp_parse_keyrings_1_pubring),
       cmocka_unit_test(test_load_user_prefs),
+      cmocka_unit_test(ecdh_roundtrip)
     };
 
     /* Each test entry will invoke setup_test before running

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -65,11 +65,11 @@ void ecdsa_signverify_success(void **state);
 
 void rnpkeys_generatekey_testExpertMode(void **state);
 
-void generatekey_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state);
+void generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state);
 
-void generatekey_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state);
+void generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state);
 
-void generatekey_explicitlySetWrongDigest_ShouldFail(void **state);
+void generatekeyECDSA_explicitlySetWrongDigest_ShouldFail(void **state);
 
 void test_utils_list(void **state);
 
@@ -78,6 +78,8 @@ void pgp_parse_keyrings_1_pubring(void **state);
 void test_load_user_prefs(void **state);
 
 void ecdh_roundtrip(void **state);
+
+void ecdh_decryptionNegativeCases(void **state);
 
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -77,6 +77,8 @@ void pgp_parse_keyrings_1_pubring(void **state);
 
 void test_load_user_prefs(void **state);
 
+void ecdh_roundtrip(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \


### PR DESCRIPTION
This patch implements support for encryption with ECDH as specified in RFC 4880 bis 01.

Key can be generated with ``rnpkey --generate-key -expert``. Key can use any of NIST curves : P-256, P-384 or P-521.
Encryption/decryption can be done as usual with ``rnp --encrypt/--decrypt``. To do round trip one may use:
```
rnp --encrypt file.in --output file.out
rnp --decrypt file.out --output file.res

diff file.in file.res
```

Nevertheless, one more stepis needed in the development to support compatibility with ``gpg``. Currently we have 2 problems:
* GnuPG always expects that ECDH key is a subkey of ECDSA key. As it is not a case currently in ``rnp`` (and not part of RFC 4880 spec) it means we can't (yet) import key generated by ``rnp`` to ``gpg``. 
* There is also a problem in ``rnp`` when encryption key is a subkey. When we have a situation when master key is signature key and encryption key is a subkey of this key (like ECDSA and ECDH as subkey), then rnp wrongly chooses  ECDSA key to do encryption.

Those both problems require additional development and will be fixed in separated step.