### PR TITLE
librekey step two

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -122,8 +122,12 @@ enum key_store_format_t {
 #define RNP_KEYSTORE_SSH "SSH" /* SSH keystore format */
 #define RNP_KEYSTORE_G10 "G10" /* G10 keystore format */
 
+// combinated keystores
+#define RNP_KEYSTORE_GPG21 "GPG21" /* KBX + G10 keystore format */
+
 typedef struct {
     const char *            path;
+    const char *            format_label;
     enum key_store_format_t format;
 
     DYNARRAY(pgp_key_t, key);

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -175,4 +175,10 @@ bool rnp_key_store_get_key_by_name(pgp_io_t *,
 bool rnp_key_store_get_next_key_by_name(
   pgp_io_t *, const rnp_key_store_t *, const char *, unsigned *, const pgp_key_t **);
 
+bool rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
+bool rnp_key_store_get_key_by_grip(pgp_io_t *,
+                                   const rnp_key_store_t *,
+                                   const uint8_t *,
+                                   pgp_pubkey_t **);
+
 #endif /* KEY_STORE_H_ */

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -43,7 +43,6 @@ typedef struct rnp_t {
     char *    defkey;        /* default key id */
     int       pswdtries;     /* number of password tries, -1 for unlimited */
 
-    const char *ks_format;
     union {
         rnp_keygen_desc_t generate_key_ctx;
     } action;
@@ -60,7 +59,6 @@ typedef struct rnp_params_t {
     const char *errs;   /* error stream : may be <stdout> */
     const char *ress;   /* results stream : maye be <stdout>, <stderr> or file name/path */
 
-    const char *ks_format;     /* format of any key store */
     const char *ks_pub_format; /* format of the public key store */
     const char *ks_sec_format; /* format of the secret key store */
     char *      pubpath;       /* public keystore path */

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1048,6 +1048,8 @@ typedef struct pgp_key_t {
     pgp_fingerprint_t sigfingerprint; /* pgp key fingerprint */
     pgp_pubkey_t      enckey;         /* encryption key */
     uint8_t           encid[PGP_KEY_ID_SIZE];
+    uint8_t           sig_grip[PGP_FINGERPRINT_SIZE];
+    uint8_t           enc_grip[PGP_FINGERPRINT_SIZE];
     pgp_fingerprint_t encfingerprint; /* deprecated (see GH #277) */
     uint32_t          uid0;           /* primary uid index in uids array */
     uint8_t           revoked;        /* key has been revoked */

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -327,6 +327,11 @@ pgp_decrypt_seckey(const pgp_key_t *key, FILE *passfp)
     const int     printerrors = 1;
     decrypt_t     decrypt;
 
+    // key hasn't got raw packets, so, we can't decrypt it
+    if (key->packetc == 0) {
+        return (pgp_seckey_t *) &key->key.seckey;
+    }
+
     /* XXX first try with an empty passphrase */
     (void) memset(&decrypt, 0x0, sizeof(decrypt));
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -96,6 +96,7 @@ __RCSID("$NetBSD: rnp.c,v 1.98 2016/06/28 16:34:40 christos Exp $");
 
 #include "rnp/rnp_obsolete_defs.h"
 #include <json.h>
+#include <rnp.h>
 
 extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
 
@@ -671,18 +672,13 @@ rnp_init(rnp_t *rnp, const rnp_params_t *params)
     rnp->pswdtries = MAX_PASSPHRASE_ATTEMPTS;
 
     /* set keystore type and pathes */
-    rnp->ks_format = params->ks_format;
-    rnp->pubring = rnp_key_store_new(params->ks_pub_format == NULL ? params->ks_format :
-                                                                     params->ks_pub_format,
-                                     params->pubpath);
+    rnp->pubring = rnp_key_store_new(params->ks_pub_format, params->pubpath);
     if (rnp->pubring == NULL) {
         fputs("rnp: can't create empty pubring keystore\n", io->errs);
         return RNP_FAIL;
     }
 
-    rnp->secring = rnp_key_store_new(params->ks_sec_format == NULL ? params->ks_format :
-                                                                     params->ks_sec_format,
-                                     params->secpath);
+    rnp->secring = rnp_key_store_new(params->ks_sec_format, params->secpath);
     if (rnp->secring == NULL) {
         fputs("rnp: can't create empty secring keystore\n", io->errs);
         return RNP_FAIL;
@@ -992,7 +988,8 @@ rnp_import_key(rnp_t *rnp, char *f)
         return RNP_FAIL;
     }
 
-    rnp_key_store_t *new_keystore = rnp_key_store_new(rnp->ks_format, f);
+    rnp_key_store_t *new_keystore =
+      rnp_key_store_new(((rnp_key_store_t *) rnp->pubring)->format_label, f);
     if (new_keystore == NULL) {
         return RNP_FAIL;
     }

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -385,7 +385,7 @@ parse_seckey(pgp_keydata_key_t *keydata, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
     keydata->seckey.s2k_usage = PGP_S2KU_NONE;
     keydata->seckey.alg = PGP_SA_DEFAULT_CIPHER;
-    keydata->seckey.hash_alg = PGP_DEFAULT_HASH_ALGORITHM;
+    keydata->seckey.hash_alg = PGP_HASH_UNKNOWN;
 
     switch (alg) {
     case PGP_PKA_DSA:

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -442,7 +442,10 @@ parse_seckey(pgp_keydata_key_t *keydata, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 }
 
 bool
-rnp_key_store_g10_from_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_t *memory)
+rnp_key_store_g10_from_mem(pgp_io_t *       io,
+                           rnp_key_store_t *pubring,
+                           rnp_key_store_t *key_store,
+                           pgp_memory_t *   memory)
 {
     s_exp_t     s_exp = {};
     size_t      length = memory->length;
@@ -565,6 +568,18 @@ rnp_key_store_g10_from_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_
     }
 
     if (private_key) {
+        // lookup for exsited key from KBX storage for example to update metadata
+        if (pubring != NULL) {
+            uint8_t       grip[PGP_FINGERPRINT_SIZE];
+            pgp_pubkey_t *pubkey = NULL;
+            if (!rnp_key_store_get_key_grip(&keydata.pubkey, grip)) {
+                return false;
+            }
+            if (rnp_key_store_get_key_by_grip(io, pubring, grip, &pubkey)) {
+                keydata.pubkey.birthtime = pubkey->birthtime;
+                keydata.pubkey.duration = pubkey->duration;
+            }
+        }
         if (!parse_seckey(&keydata, algorithm_s_exp, alg)) {
             destroy_s_exp(&s_exp);
             return false;
@@ -576,7 +591,7 @@ rnp_key_store_g10_from_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_
     if (rnp_get_debug(__FILE__)) {
         uint8_t grip[PGP_FINGERPRINT_SIZE];
         char    grips[PGP_FINGERPRINT_HEX_SIZE];
-        if (!rnp_key_store_g10_key_grip(&keydata.pubkey, grip)) {
+        if (!rnp_key_store_get_key_grip(&keydata.pubkey, grip)) {
             return false;
         }
         fprintf(
@@ -814,89 +829,4 @@ rnp_key_store_g10_key_to_mem(pgp_io_t *     io,
     rc = write_sexp(&s_exp, memory);
     destroy_s_exp(&s_exp);
     return rc;
-}
-
-bool
-grip_hash_bignum(pgp_hash_t *hash, const BIGNUM *bignum)
-{
-    uint8_t *bn;
-    size_t   len;
-    int      padbyte;
-
-    if (BN_is_zero(bignum)) {
-        pgp_hash_add(hash, (const uint8_t *) &"\0", 1);
-        return true;
-    }
-    if ((len = (size_t) BN_num_bytes(bignum)) < 1) {
-        (void) fprintf(stderr, "grip_hash_bignum: bad size: %zu\n", len);
-        return false;
-    }
-    if ((bn = calloc(1, len + 1)) == NULL) {
-        (void) fprintf(stderr, "grip_hash_bignum: bad bn alloc\n");
-        return false;
-    }
-    BN_bn2bin(bignum, bn + 1);
-    bn[0] = 0x0;
-    padbyte = (bn[1] & 0x80) ? 1 : 0;
-    pgp_hash_add(hash, bn, (unsigned) (len + padbyte));
-    free(bn);
-    return true;
-}
-
-/* keygrip is subjectKeyHash from pkcs#15. */
-bool
-rnp_key_store_g10_key_grip(pgp_pubkey_t *key, uint8_t *grip)
-{
-    pgp_hash_t hash = {0};
-
-    if (!pgp_hash_create(&hash, PGP_HASH_SHA1)) {
-        (void) fprintf(stderr, "rnp_key_store_g10_key_grip: bad md5 alloc\n");
-        return false;
-    }
-
-    switch (key->alg) {
-    case PGP_PKA_RSA:
-    case PGP_PKA_RSA_SIGN_ONLY:
-    case PGP_PKA_RSA_ENCRYPT_ONLY:
-        if (!grip_hash_bignum(&hash, key->key.rsa.n)) {
-            return false;
-        }
-        break;
-
-    case PGP_PKA_DSA:
-        if (!grip_hash_bignum(&hash, key->key.dsa.p)) {
-            return false;
-        }
-        if (!grip_hash_bignum(&hash, key->key.dsa.q)) {
-            return false;
-        }
-        if (!grip_hash_bignum(&hash, key->key.dsa.g)) {
-            return false;
-        }
-        if (!grip_hash_bignum(&hash, key->key.dsa.y)) {
-            return false;
-        }
-        break;
-
-    case PGP_PKA_ELGAMAL:
-        if (!grip_hash_bignum(&hash, key->key.elgamal.p)) {
-            return false;
-        }
-        if (!grip_hash_bignum(&hash, key->key.elgamal.g)) {
-            return false;
-        }
-        if (!grip_hash_bignum(&hash, key->key.elgamal.y)) {
-            return false;
-        }
-        break;
-
-    default:
-        (void) fprintf(stderr,
-                       "rnp_key_store_g10_key_grip: unsupported public-key algorithm %d\n",
-                       key->alg);
-        pgp_hash_finish(&hash, grip);
-        return false;
-    }
-
-    return pgp_hash_finish(&hash, grip) == PGP_FINGERPRINT_SIZE;
 }

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -368,7 +368,7 @@ parse_pubkey(pgp_keydata_key_t *keydata, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
     default:
         fprintf(stderr, "Unsupported public key algorithm: %d\n", alg);
-        return NULL;
+        return false;
     }
 
     return true;
@@ -377,12 +377,15 @@ parse_pubkey(pgp_keydata_key_t *keydata, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 static bool
 parse_seckey(pgp_keydata_key_t *keydata, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 {
-    keydata->seckey.pubkey.version = PGP_V4;
-    keydata->seckey.pubkey.birthtime = time(NULL);
-    keydata->seckey.pubkey.duration = 0;
-    keydata->seckey.pubkey.alg = alg;
+    if (keydata->seckey.pubkey.version != PGP_V2 && keydata->seckey.pubkey.version != PGP_V3 &&
+        keydata->seckey.pubkey.version != PGP_V4) {
+        fprintf(stderr, "You should run parse_seckey only after parse_pubkey\n");
+        return false;
+    }
 
     keydata->seckey.s2k_usage = PGP_S2KU_NONE;
+    keydata->seckey.alg = PGP_SA_DEFAULT_CIPHER;
+    keydata->seckey.hash_alg = PGP_DEFAULT_HASH_ALGORITHM;
 
     switch (alg) {
     case PGP_PKA_DSA:
@@ -432,7 +435,7 @@ parse_seckey(pgp_keydata_key_t *keydata, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
     default:
         fprintf(stderr, "Unsupported public key algorithm: %d\n", alg);
-        return NULL;
+        return false;
     }
 
     return true;

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -573,6 +573,16 @@ rnp_key_store_g10_from_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_
 
     destroy_s_exp(&s_exp);
 
+    if (rnp_get_debug(__FILE__)) {
+        uint8_t grip[PGP_FINGERPRINT_SIZE];
+        char    grips[PGP_FINGERPRINT_HEX_SIZE];
+        if (!rnp_key_store_g10_key_grip(&keydata.pubkey, grip)) {
+            return false;
+        }
+        fprintf(
+          io->errs, "loaded G10 key with GRIP: %s\n", rnp_strhexdump(grips, grip, 20, ""));
+    }
+
     return rnp_key_store_add_keydata(io,
                                      key_store,
                                      &keydata,

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -30,9 +30,10 @@
 #include <rnp/rnp.h>
 #include <rekey/rnp_key_store.h>
 
-bool rnp_key_store_g10_from_mem(pgp_io_t *, rnp_key_store_t *, pgp_memory_t *);
+bool rnp_key_store_g10_from_mem(pgp_io_t *,
+                                rnp_key_store_t *,
+                                rnp_key_store_t *,
+                                pgp_memory_t *);
 bool rnp_key_store_g10_key_to_mem(pgp_io_t *, pgp_key_t *, const uint8_t *, pgp_memory_t *);
-
-bool rnp_key_store_g10_key_grip(pgp_pubkey_t *, uint8_t *);
 
 #endif // RNP_KEY_STORE_G10_H

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -87,6 +87,7 @@ rnp_key_store_new(const char *format, const char *path)
     }
 
     key_store->format = key_store_format;
+    key_store->format_label = strdup(format);
     key_store->path = strdup(path);
 
     return key_store;
@@ -436,6 +437,7 @@ rnp_key_store_free(rnp_key_store_t *keyring)
     FREE_ARRAY(keyring, blob);
 
     free((void *) keyring->path);
+    free((void *) keyring->format_label);
 
     free(keyring);
 }

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -183,6 +183,10 @@ rnp_key_store_load_from_file(rnp_t *rnp, rnp_key_store_t *key_store, const unsig
 
             memset(&mem, 0, sizeof(mem));
 
+            if (rnp_get_debug(__FILE__)) {
+                fprintf(rnp->io->errs, "Loading G10 key from file '%s'\n", path);
+            }
+
             if (!pgp_mem_readfile(&mem, path)) {
                 fprintf(rnp->io->errs, "Can't read file '%s' to memory\n", path);
                 continue;
@@ -600,7 +604,7 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
     pgp_key_t *key;
 
     if (rnp_get_debug(__FILE__)) {
-        fprintf(io->errs, "rnp_key_store_add_keydata\n");
+        fprintf(io->errs, "rnp_key_store_add_keydata to key_store: %p\n", keyring);
     }
 
     if (tag != PGP_PTAG_CT_PUBLIC_SUBKEY) {
@@ -629,6 +633,8 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
     }
 
     if (rnp_get_debug(__FILE__)) {
+        hexdump(io->errs, "added key->sigid", key->sigid, PGP_KEY_ID_SIZE);
+        hexdump(io->errs, "added key->encid", key->encid, PGP_KEY_ID_SIZE);
         fprintf(io->errs, "rnp_key_store_add_keydata: keyc %u\n", keyring->keyc);
     }
 
@@ -691,6 +697,10 @@ rnp_key_store_get_key_by_id(pgp_io_t *             io,
                             pgp_pubkey_t **        pubkey)
 {
     uint8_t nullid[PGP_KEY_ID_SIZE];
+
+    if (rnp_get_debug(__FILE__)) {
+        fprintf(io->errs, "looking keyring %p\n", keyring);
+    }
 
     (void) memset(nullid, 0x0, sizeof(nullid));
     for (; keyring && *from < keyring->keyc; *from += 1) {

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -999,6 +999,7 @@ rnp_key_store_get_key_grip(pgp_pubkey_t *key, uint8_t *grip)
         }
         break;
 
+    case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -999,6 +999,14 @@ rnp_key_store_get_key_grip(pgp_pubkey_t *key, uint8_t *grip)
         }
         break;
 
+    case PGP_PKA_ECDSA:
+    case PGP_PKA_EDDSA:
+    case PGP_PKA_SM2:
+        if (!grip_hash_bignum(&hash, key->key.ecc.point)) {
+            return false;
+        }
+        break;
+
     default:
         (void) fprintf(stderr,
                        "rnp_key_store_get_key_grip: unsupported public-key algorithm %d\n",

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -377,13 +377,14 @@ rnpkeys_init(rnp_cfg_t *cfg, rnp_t *rnp, const rnp_cfg_t *override_cfg, bool is_
     rnp_cfg_set(cfg, CFG_KEYFORMAT, "human");
     rnp_cfg_copy(cfg, override_cfg);
 
+    memset(rnp, '\0', sizeof(rnp_t));
+
     if (!rnp_cfg_apply(cfg, &rnp_params)) {
         fputs("fatal: cannot apply configuration\n", stderr);
         ret = false;
         goto end;
     }
 
-    memset(rnp, '\0', sizeof(rnp_t));
     if (!rnp_init(rnp, &rnp_params)) {
         fputs("fatal: failed to initialize rnpkeys\n", stderr);
         ret = false;

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -243,9 +243,10 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
 
     rnp_test_state_t *rstate = *state;
     const char *hashAlg[] = {"MD5", "SHA1", "SHA256", "SHA384", "SHA512", "SHA224", "SM3"};
-    const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_KBX, RNP_KEYSTORE_G10};
-    rnp_t       rnp;
-    int         pipefd[2];
+    const char *keystores[] = {
+      RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX, RNP_KEYSTORE_G10};
+    rnp_t rnp;
+    int   pipefd[2];
 
     for (int i = 0; i < sizeof(hashAlg) / sizeof(hashAlg[0]); i++) {
         for (int j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
@@ -293,9 +294,10 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
                              "rnpkeys_generatekey_verifyUserIdOption_SHA512",
                              "rnpkeys_generatekey_verifyUserIdOption_SHA224"};
 
-    const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_KBX, RNP_KEYSTORE_G10};
-    rnp_t       rnp;
-    int         pipefd[2];
+    const char *keystores[] = {
+      RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX, RNP_KEYSTORE_G10};
+    rnp_t rnp;
+    int   pipefd[2];
 
     for (int i = 0; i < sizeof(userIds) / sizeof(userIds[0]); i++) {
         for (int j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {

--- a/src/tests/support.c
+++ b/src/tests/support.c
@@ -363,6 +363,9 @@ setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pi
         return false;
     }
 
+    params.ks_pub_format = ks_format;
+    params.ks_sec_format = ks_format;
+
     if (strcmp(ks_format, RNP_KEYSTORE_GPG) == 0) {
         paths_concat(pubpath, MAXPATHLEN, homedir, PUBRING_GPG, NULL);
         paths_concat(secpath, MAXPATHLEN, homedir, SECRING_GPG, NULL);
@@ -372,15 +375,17 @@ setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pi
     } else if (strcmp(ks_format, RNP_KEYSTORE_G10) == 0) {
         paths_concat(pubpath, MAXPATHLEN, homedir, PUBRING_G10, NULL);
         paths_concat(secpath, MAXPATHLEN, homedir, SECRING_G10, NULL);
+    } else if (strcmp(ks_format, RNP_KEYSTORE_GPG21) == 0) {
+        paths_concat(pubpath, MAXPATHLEN, homedir, PUBRING_KBX, NULL);
+        paths_concat(secpath, MAXPATHLEN, homedir, SECRING_G10, NULL);
+        params.ks_pub_format = RNP_KEYSTORE_KBX;
+        params.ks_sec_format = RNP_KEYSTORE_G10;
     } else {
         return false;
     }
 
     params.pubpath = strdup(pubpath);
     params.secpath = strdup(secpath);
-    params.ks_format = ks_format;
-    params.ks_pub_format = ks_format;
-    params.ks_sec_format = ks_format;
 
     /*initialize the basic RNP structure. */
     memset(rnp, '\0', sizeof(*rnp));


### PR DESCRIPTION
Hey,

It is second step of implementation librekey with GnuPG 2.1+ format support.

Right now it can use a raw key (= without password) that was generated by GnuPG 2.1+.

So, the next step is implementing support protected keys.

@dewyatt can I ask you to confirm that I did https://github.com/riboseinc/rnp/commit/c1f57ec3f5e269e4d6fd98fa7a23c68bb40d4378 in right way?

An example:
```
➜  rnp git:(librekey) ✗ rm -rf ~/.rnp                                    
➜  rnp git:(librekey) ✗ mkdir ~/.rnp 
➜  rnp git:(librekey) ✗ gpg-agent --homedir ~/.rnp --daemon
gpg-agent[83105]: directory '/Users/catap/.rnp/private-keys-v1.d' created
gpg-agent[83106]: gpg-agent (GnuPG) 2.1.21 started
➜  rnp git:(librekey) ✗ cat > gpg-script                                 
Key-Type: 1
Key-Length: 2048
Subkey-Type: 1
Subkey-Length: 2048
Name-Real: Kir Test without password
Name-Email: kir@test.no.password
%no-protection
Expire-Date: 0
➜  rnp git:(librekey) ✗ gpg --homedir ~/.rnp --batch --gen-key gpg-script
gpg: WARNING: unsafe permissions on homedir '/Users/catap/.rnp'
gpg: keybox '/Users/catap/.rnp/pubring.kbx' created
gpg: /Users/catap/.rnp/trustdb.gpg: trustdb created
gpg: key C88F2E6E5173DF45 marked as ultimately trusted
gpg: directory '/Users/catap/.rnp/openpgp-revocs.d' created
gpg: revocation certificate stored as '/Users/catap/.rnp/openpgp-revocs.d/C25CB0B26CAC0CE82CBE41B1C88F2E6E5173DF45.rev'
➜  rnp git:(librekey) ✗ ./src/rnpkeys/rnpkeys --list-keys 
1 key found
signature  2048/RSA (Encrypt or Sign) c88f2e6e5173df45 2017-08-02 [ESA]
Key fingerprint: c25cb0b26cac0ce82cbe41b1c88f2e6e5173df45
uid              Kir Test without password <kir@test.no.password> 
encryption 2048/RSA (Encrypt or Sign) 4fc456a740caf404 2017-08-02 [ESA]

➜  rnp git:(librekey) ✗ cp README.md test                
➜  rnp git:(librekey) ✗ ./src/rnp/rnp --encrypt test                     
➜  rnp git:(librekey) ✗ ./src/rnp/rnp --decrypt test.gpg
signature  2048/RSA (Encrypt or Sign) c88f2e6e5173df45 2017-08-02 [ESA] 
Key fingerprint: c25c b0b2 6cac 0ce8 2cbe 41b1 c88f 2e6e 5173 df45 
uid              Kir Test without password <kir@test.no.password>
encryption 2048/RSA (Encrypt or Sign) 4fc456a740caf404 2017-08-02 [ESA] 
➜  rnp git:(librekey) ✗ diff README.md test                                
➜  rnp git:(librekey) ✗ 
```