### PR TITLE
Subkey generation / rework

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -159,7 +159,7 @@ bool rnp_key_store_json(pgp_io_t *, const rnp_key_store_t *, json_object *, cons
 
 bool rnp_key_store_append_keyring(rnp_key_store_t *, rnp_key_store_t *);
 
-bool rnp_key_store_add_key(pgp_io_t *, rnp_key_store_t *, pgp_key_t *, pgp_content_enum);
+bool rnp_key_store_add_key(pgp_io_t *, rnp_key_store_t *, pgp_key_t *);
 bool rnp_key_store_add_keydata(
   pgp_io_t *, rnp_key_store_t *, pgp_keydata_key_t *, pgp_key_t **, pgp_content_enum);
 

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -80,7 +80,7 @@ bool  rnp_find_key(rnp_t *, const char *);
 char *rnp_get_key(rnp_t *, const char *, const char *);
 char *rnp_export_key(rnp_t *, const char *);
 int   rnp_import_key(rnp_t *, char *);
-int   rnp_generate_key(rnp_t *, const char *);
+int   rnp_generate_key(rnp_t *);
 int   rnp_secret_count(rnp_t *);
 int   rnp_public_count(rnp_t *);
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -16,6 +16,7 @@ librnp_la_SOURCES	= \
 	ecdsa.c \
 	eddsa.c \
 	elgamal.c \
+	generate-key.c \
 	hash.c \
 	list.c \
 	misc.c \

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -494,8 +494,11 @@ Encrypt a file
 \return true if OK
 */
 bool
-pgp_encrypt_file(
-  rnp_ctx_t *ctx, pgp_io_t *io, const char *infile, const char *outfile, const pgp_key_t *key)
+pgp_encrypt_file(rnp_ctx_t *         ctx,
+                 pgp_io_t *          io,
+                 const char *        infile,
+                 const char *        outfile,
+                 const pgp_pubkey_t *pubkey)
 {
     pgp_output_t *output;
     pgp_memory_t *inmem;
@@ -523,7 +526,7 @@ pgp_encrypt_file(
     }
 
     /* Push the encrypted writer */
-    if (!pgp_push_enc_se_ip(output, key, ctx->ealg)) {
+    if (!pgp_push_enc_se_ip(output, pubkey, ctx->ealg)) {
         pgp_memory_free(inmem);
         return false;
     }
@@ -540,11 +543,11 @@ pgp_encrypt_file(
 
 /* encrypt the contents of the input buffer, and return the mem structure */
 pgp_memory_t *
-pgp_encrypt_buf(rnp_ctx_t *      ctx,
-                pgp_io_t *       io,
-                const void *     input,
-                const size_t     insize,
-                const pgp_key_t *pubkey)
+pgp_encrypt_buf(rnp_ctx_t *         ctx,
+                pgp_io_t *          io,
+                const void *        input,
+                const size_t        insize,
+                const pgp_pubkey_t *pubkey)
 {
     pgp_output_t *output;
     pgp_memory_t *outmem;

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -393,10 +393,10 @@ pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
     if (!pgp_generate_seckey(&key_desc->crypto, seckey)) {
         goto end;
     }
-    if (!pgp_keyid(key->sigid, PGP_KEY_ID_SIZE, &key->key.seckey.pubkey)) {
+    if (!pgp_keyid(key->keyid, PGP_KEY_ID_SIZE, &key->key.seckey.pubkey)) {
         goto end;
     }
-    if (!pgp_fingerprint(&key->sigfingerprint, &key->key.seckey.pubkey)) {
+    if (!pgp_fingerprint(&key->fingerprint, &key->key.seckey.pubkey)) {
         goto end;
     }
     if (userid != NULL && !pgp_add_selfsigned_userid(key, userid)) {

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -98,6 +98,8 @@ __RCSID("$NetBSD: crypto.c,v 1.36 2014/02/17 07:39:19 agc Exp $");
  */
 // TODO: Check size of this array against PGP_CURVE_MAX with static assert
 const ec_curve_desc_t ec_curves[] = {
+  {PGP_CURVE_UNKNOWN, 0, {0}, 0, NULL, NULL},
+
   {PGP_CURVE_NIST_P_256,
    256,
    {0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07},
@@ -286,15 +288,15 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
 
     switch (seckey->pubkey.alg) {
     case PGP_PKA_RSA:
-    case PGP_PKA_RSA_ENCRYPT_ONLY:
-    case PGP_PKA_RSA_SIGN_ONLY:
         if (pgp_genkey_rsa(seckey, crypto->rsa.modulus_bit_len) != 1) {
+            RNP_LOG("failed to generate RSA key");
             goto end;
         }
         break;
 
     case PGP_PKA_EDDSA:
         if (pgp_genkey_eddsa(seckey, ec_curves[PGP_CURVE_ED25519].bitlen) != 1) {
+            RNP_LOG("failed to generate EDDSA key");
             goto end;
         }
         break;
@@ -303,12 +305,14 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
     case PGP_PKA_ECDH:
         seckey->pubkey.key.ecc.curve = crypto->ecc.curve;
         if (pgp_ecdh_ecdsa_genkeypair(seckey, seckey->pubkey.key.ecc.curve) != PGP_E_OK) {
+            RNP_LOG("failed to generate ECDSA key");
             goto end;
         }
         break;
     case PGP_PKA_SM2:
         seckey->pubkey.key.ecc.curve = crypto->ecc.curve;
         if (pgp_sm2_genkeypair(seckey, seckey->pubkey.key.ecc.curve) != PGP_E_OK) {
+            RNP_LOG("failed to generate SM2 key");
             goto end;
         }
         break;
@@ -344,6 +348,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
             !pgp_write_mpi(output, seckey->key.rsa.p) ||
             !pgp_write_mpi(output, seckey->key.rsa.q) ||
             !pgp_write_mpi(output, seckey->key.rsa.u)) {
+            RNP_LOG("failed to write MPIs");
             goto end;
         }
         break;
@@ -352,6 +357,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
         if (!pgp_write_mpi(output, seckey->key.ecc.x)) {
+            RNP_LOG("failed to write MPIs");
             goto end;
         }
         break;
@@ -372,47 +378,6 @@ end:
         pgp_seckey_free(seckey);
     }
     return ok;
-}
-
-pgp_key_t *
-pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid)
-{
-    pgp_seckey_t *seckey = NULL;
-    pgp_key_t *   key = NULL;
-    bool          ok = false;
-
-    key = pgp_key_new();
-    if (!key)
-        goto end;
-
-    pgp_key_init(key, PGP_PTAG_CT_SECRET_KEY);
-    seckey = pgp_get_writable_seckey(key);
-    if (!seckey)
-        goto end;
-
-    if (!pgp_generate_seckey(&key_desc->crypto, seckey)) {
-        goto end;
-    }
-    if (!pgp_keyid(key->keyid, PGP_KEY_ID_SIZE, &key->key.seckey.pubkey)) {
-        goto end;
-    }
-    if (!pgp_fingerprint(&key->fingerprint, &key->key.seckey.pubkey)) {
-        goto end;
-    }
-    if (userid != NULL && !pgp_add_selfsigned_userid(key, userid)) {
-        goto end;
-    }
-
-    ok = true;
-
-end:
-    if (!ok) {
-        if (key) {
-            pgp_key_free(key);
-        }
-        return NULL;
-    }
-    return key;
 }
 
 static pgp_cb_ret_t

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -93,7 +93,8 @@ int pgp_decrypt_decode_mpi(
 struct pgp_key_data;
 void pgp_writer_push_encrypt(pgp_output_t *, const struct pgp_key_data *);
 
-bool pgp_encrypt_file(rnp_ctx_t *, pgp_io_t *, const char *, const char *, const pgp_key_t *);
+bool pgp_encrypt_file(
+  rnp_ctx_t *, pgp_io_t *, const char *, const char *, const pgp_pubkey_t *);
 bool pgp_decrypt_file(pgp_io_t *,
                       const char *,
                       const char *,
@@ -107,7 +108,7 @@ bool pgp_decrypt_file(pgp_io_t *,
                       pgp_cbfunc_t *);
 
 pgp_memory_t *pgp_encrypt_buf(
-  rnp_ctx_t *, pgp_io_t *, const void *, const size_t, const pgp_key_t *);
+  rnp_ctx_t *, pgp_io_t *, const void *, const size_t, const pgp_pubkey_t *);
 pgp_memory_t *pgp_decrypt_buf(pgp_io_t *,
                               const void *,
                               const size_t,

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -77,7 +77,63 @@ void pgp_crypto_finish(void);
 /* raw key generation */
 bool pgp_generate_seckey(const rnp_keygen_crypto_params_t *params, pgp_seckey_t *seckey);
 
-pgp_key_t *pgp_generate_keypair(const rnp_keygen_desc_t *key_desc, const uint8_t *userid);
+/** generate a new primary key
+ *
+ *  @param desc keygen description
+ *  @param merge_defaults true if you want defaults to be set for unset
+ *         keygen description parameters.
+ *  @param primary_sec pointer to store the generated secret key, must not be NULL
+ *  @param primary_pub pointer to store the generated public key, must not be NULL
+ *  @param decrypted_seckey optional pointer to store the decrypted secret key
+ *         before encryption, may be NULL
+ *  @return true if successful, false otherwise.
+ **/
+bool pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
+                              bool                       merge_defaults,
+                              pgp_key_t *                primary_sec,
+                              pgp_key_t *                primary_pub,
+                              pgp_seckey_t *             decrypted_seckey);
+
+/** generate a new subkey
+ *
+ *  @param desc keygen description
+ *  @param merge_defaults true if you want defaults to be set for unset
+ *         keygen description parameters.
+ *  @param primary_sec pointer to the primary secret key that will own this
+ *         subkey, must not be NULL
+ *  @param primary_pub pointer to the primary public key that will own this
+ *         subkey, must not be NULL
+ *  @param primary_seckey the decrypted primary secret key that will be used to
+ *         create the subkey binding signature, must not be NULL
+ *  @param subkey_sec pointer to store the generated secret key, must not be NULL
+ *  @param subkey_pub pointer to store the generated public key, must not be NULL
+ *  @return true if successful, false otherwise.
+ **/
+bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *desc,
+                         bool                      merge_defaults,
+                         pgp_key_t *               primary_sec,
+                         pgp_key_t *               primary_pub,
+                         const pgp_seckey_t *      primary_decrypted,
+                         pgp_key_t *               subkey_sec,
+                         pgp_key_t *               subkey_pub);
+
+/** generate a new primary key and subkey
+ *
+ *  @param desc keygen description
+ *  @param merge_defaults true if you want defaults to be set for unset
+ *         keygen description parameters.
+ *  @param primary_sec pointer to store the generated secret key, must not be NULL
+ *  @param primary_pub pointer to store the generated public key, must not be NULL
+ *  @param subkey_sec pointer to store the generated secret key, must not be NULL
+ *  @param subkey_pub pointer to store the generated public key, must not be NULL
+ *  @return true if successful, false otherwise.
+ **/
+bool pgp_generate_keypair(rnp_keygen_desc_t *desc,
+                          bool               merge_defaults,
+                          pgp_key_t *        primary_sec,
+                          pgp_key_t *        primary_pub,
+                          pgp_key_t *        subkey_sec,
+                          pgp_key_t *        subkey_pub);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);

--- a/src/lib/ecdsa.c
+++ b/src/lib/ecdsa.c
@@ -40,11 +40,14 @@ extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
 
 /* Used by ECDH keys. Specifies which hash and wrapping algorithm
  * to be used (see point 15. of RFC 4880).
+ *
+ * Note: sync with ec_curves.
  */
 struct {
     pgp_hash_alg_t hash;     /* Hash used by kdf */
     pgp_symm_alg_t wrap_alg; /* Symmetric algorithm used to wrap KEK*/
 } ecdh_params[] = {
+  {0},
   // PGP_CURVE_NIST_P_256
   {.hash = PGP_HASH_SHA256, .wrap_alg = PGP_SA_AES_128},
   // PGP_CURVE_NIST_P_384
@@ -69,7 +72,7 @@ find_curve_by_OID(const uint8_t *oid, size_t oid_len)
 const ec_curve_desc_t *
 get_curve_desc(const pgp_curve_t curve_id)
 {
-    return (curve_id < PGP_CURVE_MAX) ? &ec_curves[curve_id] : NULL;
+    return (curve_id < PGP_CURVE_MAX && curve_id > 0) ? &ec_curves[curve_id] : NULL;
 }
 
 /*

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -1,0 +1,620 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <rekey/rnp_key_store.h>
+#include "../librekey/key_store_pgp.h"
+
+#include "readerwriter.h"
+#include "memory.h"
+#include "packet.h"
+#include "pgp-key.h"
+#include "packet-show.h"
+
+/* Shortcut to load a single key from memory. */
+static bool
+load_generated_key(pgp_output_t **output, pgp_memory_t **mem, pgp_key_t *dst)
+{
+    bool     ok = false;
+    pgp_io_t io = {.errs = stderr, .res = stdout, .outs = stdout};
+
+    // this would be better on the stack but the key store does not allow it
+    rnp_key_store_t *key_store = calloc(1, sizeof(*key_store));
+
+    if (!key_store) {
+        return false;
+    }
+    if (!rnp_key_store_pgp_read_from_mem(&io, key_store, 0, *mem) || key_store->keyc != 1) {
+        RNP_LOG("failed to read back generated key");
+        goto end;
+    }
+    memcpy(dst, &key_store->keys[0], sizeof(*dst));
+    // we don't want the key store to free the internal key data
+    rnp_key_store_remove_key(&io, key_store, &key_store->keys[0]);
+
+    ok = true;
+end:
+    rnp_key_store_free(key_store);
+    pgp_teardown_memory_write(*output, *mem);
+    *output = NULL;
+    *mem = NULL;
+    return ok;
+}
+
+static pgp_key_flags_t
+pk_alg_capabilities(pgp_pubkey_alg_t alg)
+{
+    switch (alg) {
+    case PGP_PKA_RSA:
+        return PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH | PGP_KF_ENCRYPT;
+
+    case PGP_PKA_RSA_SIGN_ONLY:           /* deprecated */
+    case PGP_PKA_RSA_ENCRYPT_ONLY:        /* deprecated */
+    case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN: /* deprecated */
+        return PGP_KF_NONE;
+
+    case PGP_PKA_DSA:
+        return PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH;
+
+    case PGP_PKA_ECDSA:
+    case PGP_PKA_EDDSA:
+    case PGP_PKA_SM2:
+        return PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH;
+
+    case PGP_PKA_ECDH:
+        return PGP_KF_ENCRYPT;
+
+    case PGP_PKA_ELGAMAL:
+        return PGP_KF_ENCRYPT;
+
+    default:
+        RNP_LOG("unknown pk alg: %d\n", alg);
+        return PGP_KF_NONE;
+    }
+}
+
+static uint8_t
+pk_alg_default_flags(pgp_pubkey_alg_t alg)
+{
+    // just use the full capabilities as the ultimate fallback
+    return pk_alg_capabilities(alg);
+}
+
+static void
+adjust_hash_to_curve(rnp_keygen_crypto_params_t *crypto)
+{
+    size_t digest_length = 0;
+    if (!pgp_digest_length(crypto->hash_alg, &digest_length)) {
+        return;
+    }
+
+    /*
+     * Adjust hash to curve - see point 14 of RFC 4880 bis 01
+     * and/or ECDSA spec.
+     *
+     * Minimal size of digest for curve:
+     *    P-256  32 bytes
+     *    P-384  48 bytes
+     *    P-521  64 bytes
+     */
+    switch (crypto->ecc.curve) {
+    case PGP_CURVE_NIST_P_256:
+        if (digest_length < 32) {
+            crypto->hash_alg = PGP_HASH_SHA256;
+        }
+        break;
+    case PGP_CURVE_NIST_P_384:
+        if (digest_length < 48) {
+            crypto->hash_alg = PGP_HASH_SHA384;
+        }
+        break;
+    case PGP_CURVE_NIST_P_521:
+        if (digest_length < 64) {
+            crypto->hash_alg = PGP_HASH_SHA512;
+        }
+        break;
+
+    default:
+        // TODO: if it's anything else, let the lower layers reject it?
+        break;
+    }
+}
+
+static void
+keygen_merge_crypto_defaults(rnp_keygen_crypto_params_t *crypto)
+{
+    // default to RSA
+    if (!crypto->key_alg) {
+        crypto->key_alg = PGP_PKA_RSA;
+    }
+
+    switch (crypto->key_alg) {
+    case PGP_PKA_RSA:
+        if (!crypto->rsa.modulus_bit_len) {
+            crypto->rsa.modulus_bit_len = DEFAULT_RSA_NUMBITS;
+        }
+        break;
+
+    case PGP_PKA_SM2:
+        if (!crypto->hash_alg) {
+            crypto->hash_alg = PGP_HASH_SM3;
+        }
+        if (!crypto->ecc.curve) {
+            crypto->ecc.curve = PGP_CURVE_SM2_P_256;
+        }
+        break;
+
+    case PGP_PKA_ECDH:
+    case PGP_PKA_ECDSA:
+        if (!crypto->hash_alg) {
+            crypto->hash_alg = DEFAULT_HASH_ALGS[0];
+        }
+        adjust_hash_to_curve(crypto);
+        break;
+
+    case PGP_PKA_EDDSA:
+        if (!crypto->ecc.curve) {
+            crypto->ecc.curve = PGP_CURVE_ED25519;
+        }
+        break;
+
+    default:
+        break;
+    }
+    if (!crypto->hash_alg) {
+        crypto->hash_alg = DEFAULT_HASH_ALGS[0];
+    }
+    if (!crypto->sym_alg) {
+        crypto->sym_alg = PGP_SA_DEFAULT_CIPHER;
+    }
+}
+
+static bool
+validate_keygen_primary(const rnp_keygen_primary_desc_t *desc)
+{
+    /* Confirm that the specified pk alg can certify.
+     * gpg requires this, though the RFC only says that a V4 primary
+     * key SHOULD be a key capable of certification.
+     */
+    if (!(pk_alg_capabilities(desc->crypto.key_alg) & PGP_KF_CERTIFY)) {
+        RNP_LOG("primary key alg (%d) must be able to sign", desc->crypto.key_alg);
+        // TODO (allowing for now)
+        // return false;
+    }
+
+    // check key flags
+    if (!desc->cert.key_flags) {
+        // these are probably not *technically* required
+        RNP_LOG("key flags are required");
+        return false;
+    } else if (desc->cert.key_flags & ~pk_alg_capabilities(desc->crypto.key_alg)) {
+        // check the flags against the alg capabilities
+        RNP_LOG("usage not permitted for pk algorithm");
+        // TODO: (allowing for now)
+        // return false;
+    }
+
+    // require a userid
+    if (!desc->cert.userid[0]) {
+        RNP_LOG("userid is required for primary key");
+        return false;
+    }
+
+    if (desc->crypto.passphrase[0] == '\0') {
+        // allow it, but warn
+        RNP_LOG("warning: blank passphrase");
+    }
+    return true;
+}
+
+extern ec_curve_desc_t ec_curves[PGP_CURVE_MAX];
+
+static uint32_t
+get_numbits(const rnp_keygen_crypto_params_t *crypto)
+{
+    switch (crypto->key_alg) {
+    case PGP_PKA_RSA:
+    case PGP_PKA_RSA_ENCRYPT_ONLY:
+    case PGP_PKA_RSA_SIGN_ONLY:
+        return crypto->rsa.modulus_bit_len;
+    case PGP_PKA_ECDSA:
+    case PGP_PKA_ECDH:
+    case PGP_PKA_EDDSA:
+    case PGP_PKA_SM2:
+        return ec_curves[crypto->ecc.curve].bitlen;
+    default:
+        return 0;
+    }
+}
+
+bool
+set_default_user_prefs(pgp_user_prefs_t *prefs)
+{
+    if (!prefs->symm_algs) {
+        for (int i = 0; i < ARRAY_SIZE(DEFAULT_SYMMETRIC_ALGS); i++) {
+            EXPAND_ARRAY(prefs, symm_alg);
+            if (!prefs->symm_algs) {
+                return false;
+            }
+            prefs->symm_algs[i] = DEFAULT_SYMMETRIC_ALGS[i];
+            prefs->symm_algc++;
+        }
+    }
+    if (!prefs->hash_algs) {
+        for (int i = 0; i < ARRAY_SIZE(DEFAULT_HASH_ALGS); i++) {
+            EXPAND_ARRAY(prefs, hash_alg);
+            if (!prefs->hash_algs) {
+                return false;
+            }
+            prefs->hash_algs[i] = DEFAULT_HASH_ALGS[i];
+            prefs->hash_algc++;
+        }
+    }
+    if (!prefs->compress_algs) {
+        for (int i = 0; i < ARRAY_SIZE(DEFAULT_COMPRESS_ALGS); i++) {
+            EXPAND_ARRAY(prefs, compress_alg);
+            if (!prefs->compress_algs) {
+                return false;
+            }
+            prefs->compress_algs[i] = DEFAULT_COMPRESS_ALGS[i];
+            prefs->compress_algc++;
+        }
+    }
+    return true;
+}
+
+static void
+keygen_primary_merge_defaults(rnp_keygen_primary_desc_t *desc)
+{
+    keygen_merge_crypto_defaults(&desc->crypto);
+    set_default_user_prefs(&desc->cert.prefs);
+
+    if (!desc->cert.key_flags) {
+        // set some default key flags if none are provided
+        desc->cert.key_flags = pk_alg_default_flags(desc->crypto.key_alg);
+    }
+    if (desc->cert.userid[0] == '\0') {
+        snprintf((char *) desc->cert.userid,
+                 sizeof(desc->cert.userid),
+                 "%s %d-bit key <%s@localhost>",
+                 pgp_show_pka(desc->crypto.key_alg),
+                 get_numbits(&desc->crypto),
+                 getenv("LOGNAME"));
+    }
+}
+
+bool
+pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
+                         bool                       merge_defaults,
+                         pgp_key_t *                primary_sec,
+                         pgp_key_t *                primary_pub,
+                         pgp_seckey_t *             decrypted_seckey)
+{
+    bool          ok = false;
+    pgp_output_t *output = NULL;
+    pgp_memory_t *mem = NULL;
+    pgp_seckey_t seckey;
+
+    memset(&seckey, 0, sizeof(seckey));
+
+    // validate args
+    if (!desc || !primary_pub || !primary_sec) {
+        goto end;
+    }
+    if (primary_sec->type || primary_pub->type) {
+        RNP_LOG("invalid parameters (should be zeroed)");
+        goto end;
+    }
+
+    // merge some defaults in, if requested
+    if (merge_defaults) {
+        keygen_primary_merge_defaults(desc);
+    }
+
+    // now validate the keygen fields
+    if (!validate_keygen_primary(desc)) {
+        goto end;
+    }
+
+    // generate the raw key pair
+    if (!pgp_generate_seckey(&desc->crypto, &seckey)) {
+        goto end;
+    }
+
+    // write the secret key, userid, and self-signature
+    if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
+        goto end;
+    }
+    if (!pgp_write_struct_seckey(
+          PGP_PTAG_CT_SECRET_KEY, &seckey, desc->crypto.passphrase, output) ||
+        !pgp_write_struct_userid(output, desc->cert.userid) ||
+        !pgp_write_selfsig_cert(output, &seckey, desc->crypto.hash_alg, &desc->cert)) {
+        RNP_LOG("failed to write out generated key+sigs");
+        goto end;
+    }
+    // load the secret key back in
+    if (!load_generated_key(&output, &mem, primary_sec)) {
+        goto end;
+    }
+
+    // write the public key, userid, and self-signature
+    if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
+        goto end;
+    }
+    if (!pgp_write_struct_pubkey(output, PGP_PTAG_CT_PUBLIC_KEY, &seckey.pubkey) ||
+        !pgp_write_struct_userid(output, desc->cert.userid) ||
+        !pgp_write_selfsig_cert(output, &seckey, desc->crypto.hash_alg, &desc->cert)) {
+        RNP_LOG("failed to write out generated key+sigs");
+        goto end;
+    }
+    // load the public key back in
+    if (!load_generated_key(&output, &mem, primary_pub)) {
+        goto end;
+    }
+
+    ok = true;
+end:
+    if (output && mem) {
+        pgp_teardown_memory_write(output, mem);
+        output = NULL;
+        mem = NULL;
+    }
+    if (decrypted_seckey) {
+        // caller wants a copy of the decrypted seckey
+        memcpy(decrypted_seckey, &seckey, sizeof(*decrypted_seckey));
+    } else {
+        // we don't need this as we have loaded the encrypted key
+        // into primary_sec
+        pgp_seckey_free(&seckey);
+    }
+    if (!ok) {
+        pgp_key_free_data(primary_pub);
+        pgp_key_free_data(primary_sec);
+    }
+    return ok;
+}
+
+static bool
+validate_keygen_subkey(rnp_keygen_subkey_desc_t *desc)
+{
+    if (!desc->binding.key_flags) {
+        RNP_LOG("key flags are required");
+        return false;
+    } else if (desc->binding.key_flags & ~pk_alg_capabilities(desc->crypto.key_alg)) {
+        // check the flags against the alg capabilities
+        RNP_LOG("usage not permitted for pk algorithm");
+        // TODO: (allowing for now)
+        // return false;
+    }
+
+    if (desc->crypto.passphrase[0] == '\0') {
+        // allow it, but warn
+        RNP_LOG("warning: blank passphrase");
+    }
+    return true;
+}
+
+static void
+keygen_subkey_merge_defaults(rnp_keygen_subkey_desc_t *desc)
+{
+    keygen_merge_crypto_defaults(&desc->crypto);
+    if (!desc->binding.key_flags) {
+        // set some default key flags if none are provided
+        desc->binding.key_flags = pk_alg_default_flags(desc->crypto.key_alg);
+    }
+}
+
+bool
+pgp_generate_subkey(rnp_keygen_subkey_desc_t *desc,
+                    bool                      merge_defaults,
+                    pgp_key_t *               primary_sec,
+                    pgp_key_t *               primary_pub,
+                    const pgp_seckey_t *      primary_decrypted,
+                    pgp_key_t *               subkey_sec,
+                    pgp_key_t *               subkey_pub)
+{
+    bool          ok = false;
+    pgp_output_t *output = NULL;
+    pgp_memory_t *mem = NULL;
+
+    // validate args
+    if (!desc || !primary_sec || !primary_pub || !primary_decrypted || !subkey_sec ||
+        !subkey_pub) {
+        RNP_LOG("NULL args");
+        goto end;
+    }
+    if (!pgp_key_is_primary_key(primary_sec) || !pgp_key_is_primary_key(primary_pub) ||
+        !pgp_is_key_secret(primary_sec) || !pgp_is_key_public(primary_pub)) {
+        RNP_LOG("invalid parameters");
+        goto end;
+    }
+    if (subkey_sec->type || subkey_pub->type) {
+        RNP_LOG("invalid parameters (should be zeroed)");
+        goto end;
+    }
+
+    // merge some defaults in, if requested
+    if (merge_defaults) {
+        keygen_subkey_merge_defaults(desc);
+    }
+
+    // now validate the keygen fields
+    if (!validate_keygen_subkey(desc)) {
+        goto end;
+    }
+
+    // prepare to add subkeys
+    EXPAND_ARRAY(primary_sec, subkey);
+    EXPAND_ARRAY(primary_pub, subkey);
+    if (!primary_sec->subkeys || !primary_pub->subkeys) {
+        goto end;
+    }
+
+    // generate the raw key pair
+    pgp_seckey_t seckey;
+    memset(&seckey, 0, sizeof(seckey));
+    if (!pgp_generate_seckey(&desc->crypto, &seckey)) {
+        goto end;
+    }
+
+    // write the secret subkey, userid, and binding self-signature
+    if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
+        goto end;
+    }
+    if (!pgp_write_struct_seckey(
+          PGP_PTAG_CT_SECRET_SUBKEY, &seckey, desc->crypto.passphrase, output) ||
+        !pgp_write_selfsig_binding(
+          output, primary_decrypted, desc->crypto.hash_alg, &seckey.pubkey, &desc->binding)) {
+        RNP_LOG("failed to write out generated key+sigs");
+        goto end;
+    }
+    // load the secret key back in
+    if (!load_generated_key(&output, &mem, subkey_sec)) {
+        goto end;
+    }
+    primary_sec->subkeys[primary_sec->subkeyc++] = subkey_sec;
+
+    // write the public subkey, userid, and binding self-signature
+    if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
+        goto end;
+    }
+    if (!pgp_write_struct_pubkey(output, PGP_PTAG_CT_PUBLIC_SUBKEY, &seckey.pubkey) ||
+        !pgp_write_selfsig_binding(
+          output, primary_decrypted, desc->crypto.hash_alg, &seckey.pubkey, &desc->binding)) {
+        RNP_LOG("failed to write out generated key+sigs");
+        goto end;
+    }
+    // load the public key back in
+    if (!load_generated_key(&output, &mem, subkey_pub)) {
+        goto end;
+    }
+    primary_pub->subkeys[primary_pub->subkeyc++] = subkey_pub;
+
+    ok = true;
+end:
+    pgp_seckey_free(&seckey);
+    if (!ok) {
+        pgp_key_free_data(subkey_pub);
+        pgp_key_free_data(subkey_sec);
+    }
+    return ok;
+}
+
+void
+keygen_merge_defaults(rnp_keygen_desc_t *desc)
+{
+    if (!desc->primary.cert.key_flags && !desc->subkey.binding.key_flags) {
+        // if no flags are set for either the primary key nor subkey,
+        // we can set up some typical defaults here (these are validated
+        // later against the alg capabilities)
+        desc->primary.cert.key_flags = PGP_KF_SIGN | PGP_KF_CERTIFY;
+        desc->subkey.binding.key_flags = PGP_KF_ENCRYPT;
+    }
+}
+
+void
+print_keygen_crypto(const rnp_keygen_crypto_params_t *crypto)
+{
+    printf("key_alg: %s (%d)\n", pgp_show_pka(crypto->key_alg), crypto->key_alg);
+    if (crypto->key_alg == PGP_PKA_RSA) {
+        printf("bits: %u\n", crypto->rsa.modulus_bit_len);
+    } else {
+        printf("curve: %d\n", crypto->ecc.curve);
+    }
+    printf("hash_alg: %s (%d)\n", pgp_show_hash_alg(crypto->hash_alg), crypto->hash_alg);
+    printf("sym_alg: %s (%d)\n", pgp_show_symm_alg(crypto->sym_alg), crypto->sym_alg);
+
+    // only for debugging!
+    // printf("passphrase: '%s'\n", (char *) crypto->passphrase);
+}
+
+void
+print_keygen_primary(const rnp_keygen_primary_desc_t *desc)
+{
+    printf("Keygen (primary)\n");
+    print_keygen_crypto(&desc->crypto);
+}
+
+void
+print_keygen_subkey(const rnp_keygen_subkey_desc_t *desc)
+{
+    printf("Keygen (subkey)\n");
+    print_keygen_crypto(&desc->crypto);
+}
+
+bool
+pgp_generate_keypair(rnp_keygen_desc_t *desc,
+                     bool               merge_defaults,
+                     pgp_key_t *        primary_sec,
+                     pgp_key_t *        primary_pub,
+                     pgp_key_t *        subkey_sec,
+                     pgp_key_t *        subkey_pub)
+{
+    bool         ok = false;
+    pgp_seckey_t decrypted_primary;
+
+    memset(&decrypted_primary, 0, sizeof(decrypted_primary));
+
+    if (rnp_get_debug(__FILE__)) {
+        print_keygen_primary(&desc->primary);
+        print_keygen_subkey(&desc->subkey);
+    }
+
+    // validate args
+    if (!desc || !primary_sec || !primary_pub || !subkey_sec || !subkey_pub) {
+        RNP_LOG("NULL args");
+        goto end;
+    }
+
+    // merge some defaults in, if requested
+    if (merge_defaults) {
+        keygen_merge_defaults(desc);
+    }
+
+    // generate the primary key
+    if (!pgp_generate_primary_key(
+          &desc->primary, merge_defaults, primary_sec, primary_pub, &decrypted_primary)) {
+        RNP_LOG("failed to generate primary key");
+        goto end;
+    }
+
+    // generate the subkey
+    if (!pgp_generate_subkey(&desc->subkey,
+                             merge_defaults,
+                             primary_sec,
+                             primary_pub,
+                             &decrypted_primary,
+                             subkey_sec,
+                             subkey_pub)) {
+        RNP_LOG("failed to generate subkey");
+        goto end;
+    }
+    ok = true;
+end:
+    // this will complain if it's still all zeroed, but it's safe (won't crash)
+    pgp_seckey_free(&decrypted_primary);
+    return ok;
+}

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -454,7 +454,9 @@ pgp_keyid(uint8_t *keyid, const size_t idlen, const pgp_pubkey_t *key)
         BN_bn2bin(key->key.rsa.n, bn);
         (void) memcpy(keyid, bn + n - idlen, idlen);
     } else {
-        pgp_fingerprint(&finger, key);
+        if (!pgp_fingerprint(&finger, key)) {
+            return false;
+        }
         (void) memcpy(keyid, finger.fingerprint + finger.length - idlen, idlen);
     }
     return true;

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -83,6 +83,8 @@ void pgp_build_pubkey(pgp_memory_t *, const pgp_pubkey_t *, unsigned);
 unsigned pgp_calc_sesskey_checksum(pgp_pk_sesskey_t *, uint8_t *);
 unsigned pgp_write_struct_userid(pgp_output_t *, const uint8_t *);
 unsigned pgp_write_ss_header(pgp_output_t *, unsigned, pgp_content_enum);
+
+bool     pgp_write_struct_pubkey(pgp_output_t *, pgp_content_enum, const pgp_pubkey_t *);
 unsigned pgp_write_struct_seckey(pgp_content_enum,
                                  const pgp_seckey_t *,
                                  const uint8_t *,
@@ -106,5 +108,15 @@ bool pgp_write_xfer_anykey(
 unsigned pgp_write_userid(const uint8_t *, pgp_output_t *);
 unsigned pgp_fileread_litdata(const char *, const pgp_litdata_enum, pgp_output_t *);
 unsigned pgp_write_symm_enc_data(const uint8_t *, const int, pgp_output_t *);
+
+bool pgp_write_selfsig_cert(pgp_output_t *               output,
+                            const pgp_seckey_t *         seckey,
+                            const pgp_hash_alg_t         hash_alg,
+                            const rnp_selfsig_cert_info *cert);
+bool pgp_write_selfsig_binding(pgp_output_t *                  output,
+                               const pgp_seckey_t *            primary_sec,
+                               const pgp_hash_alg_t            hash_alg,
+                               const pgp_pubkey_t *            subkey,
+                               const rnp_selfsig_binding_info *binding);
 
 #endif /* CREATE_H_ */

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -92,7 +92,7 @@ unsigned pgp_write_one_pass_sig(pgp_output_t *,
                                 const pgp_hash_alg_t,
                                 const pgp_sig_type_t);
 unsigned pgp_write_litdata(pgp_output_t *, const uint8_t *, const int, const pgp_litdata_enum);
-pgp_pk_sesskey_t *pgp_create_pk_sesskey(const pgp_key_t *, pgp_symm_alg_t);
+pgp_pk_sesskey_t *pgp_create_pk_sesskey(const pgp_pubkey_t *, pgp_symm_alg_t);
 bool              pgp_write_pk_sesskey(pgp_output_t *, pgp_pk_sesskey_t *);
 unsigned          pgp_write_xfer_pubkey(pgp_output_t *,
                                const pgp_key_t *,

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -1202,6 +1202,9 @@ pgp_pk_sesskey_free(pgp_pk_sesskey_t *sk)
 void
 pgp_pubkey_free(pgp_pubkey_t *p)
 {
+    if (!p) {
+        return;
+    }
     switch (p->alg) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
@@ -2434,6 +2437,9 @@ parse_litdata(pgp_region_t *region, pgp_stream_t *stream)
 void
 pgp_seckey_free(pgp_seckey_t *key)
 {
+    if (!key || !key->pubkey.alg) {
+        return;
+    }
     pgp_pubkey_free(&key->pubkey);
     switch (key->pubkey.alg) {
     case PGP_PKA_RSA:

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -1763,7 +1763,7 @@ pgp_export_key(pgp_io_t *io, const pgp_key_t *key, uint8_t *passphrase)
         return NULL;
     }
 
-    if (key->type == PGP_PTAG_CT_PUBLIC_KEY) {
+    if (pgp_is_key_public(key)) {
         pgp_write_xfer_pubkey(output, key, NULL, 1);
     } else {
         pgp_write_xfer_seckey(output, key, passphrase, NULL, 1);

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -1025,18 +1025,13 @@ typedef struct pgp_key_t {
     pgp_content_enum  type;            /* type of key */
     pgp_keydata_key_t key;             /* pubkey/seckey data */
     uint8_t           key_flags;       /* key flags */
-    pgp_pubkey_t      sigkey;          /* signature key */
-    uint8_t           sigid[PGP_KEY_ID_SIZE];
-    pgp_fingerprint_t sigfingerprint; /* pgp key fingerprint */
-    pgp_pubkey_t      enckey;         /* encryption key */
-    uint8_t           encid[PGP_KEY_ID_SIZE];
-    uint8_t           sig_grip[PGP_FINGERPRINT_SIZE];
-    uint8_t           enc_grip[PGP_FINGERPRINT_SIZE];
-    pgp_fingerprint_t encfingerprint; /* deprecated (see GH #277) */
-    uint32_t          uid0;           /* primary uid index in uids array */
-    uint8_t           revoked;        /* key has been revoked */
-    pgp_revoke_t      revocation;     /* revocation reason */
-    uint8_t           loaded;         /* key was loaded so has key packet in subpackets */
+    uint8_t           keyid[PGP_KEY_ID_SIZE];
+    pgp_fingerprint_t fingerprint;
+    uint8_t           grip[PGP_FINGERPRINT_SIZE];
+    uint32_t          uid0;       /* primary uid index in uids array */
+    uint8_t           revoked;    /* key has been revoked */
+    pgp_revoke_t      revocation; /* revocation reason */
+    uint8_t           loaded;     /* key was loaded so has key packet in subpackets */
     symmetric_key_t   session_key;
 } pgp_key_t;
 

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -59,6 +59,7 @@
 #include <time.h>
 #include <stdint.h>
 
+#include <rnp/rnp_def.h>
 #include "types.h"
 #include "defs.h"
 #include "hash.h"
@@ -399,7 +400,8 @@ typedef enum {
  * Values in this enum correspond to order in ec_curve array (in ec.c)
  */
 typedef enum {
-    PGP_CURVE_NIST_P_256 = 0,
+    PGP_CURVE_UNKNOWN = 0,
+    PGP_CURVE_NIST_P_256,
     PGP_CURVE_NIST_P_384,
     PGP_CURVE_NIST_P_521,
     PGP_CURVE_ED25519,
@@ -562,8 +564,6 @@ typedef enum {
     PGP_S2KS_SALTED = 1,
     PGP_S2KS_ITERATED_AND_SALTED = 3
 } pgp_s2k_specifier_t;
-
-#define PGP_SA_DEFAULT_CIPHER PGP_SA_CAST5
 
 void pgp_calc_mdc_hash(
   const uint8_t *, const size_t, const uint8_t *, const unsigned, uint8_t *);
@@ -1022,16 +1022,16 @@ typedef struct pgp_key_t {
     DYNARRAY(pgp_rawpacket_t, packet); /* array of raw packets */
     DYNARRAY(pgp_subsig_t, subsig);    /* array of signature subkeys */
     DYNARRAY(pgp_revoke_t, revoke);    /* array of signature revocations */
-    pgp_content_enum  type;            /* type of key */
-    pgp_keydata_key_t key;             /* pubkey/seckey data */
-    uint8_t           key_flags;       /* key flags */
+    DYNARRAY(struct pgp_key_t *, subkey);
+    pgp_content_enum  type;      /* type of key */
+    pgp_keydata_key_t key;       /* pubkey/seckey data */
+    uint8_t           key_flags; /* key flags */
     uint8_t           keyid[PGP_KEY_ID_SIZE];
     pgp_fingerprint_t fingerprint;
     uint8_t           grip[PGP_FINGERPRINT_SIZE];
     uint32_t          uid0;       /* primary uid index in uids array */
     uint8_t           revoked;    /* key has been revoked */
     pgp_revoke_t      revocation; /* revocation reason */
-    uint8_t           loaded;     /* key was loaded so has key packet in subpackets */
     symmetric_key_t   session_key;
 } pgp_key_t;
 
@@ -1051,10 +1051,46 @@ typedef struct rnp_keygen_crypto_params_t {
             uint32_t modulus_bit_len;
         } rsa;
     };
+
+    uint8_t passphrase[MAX_PASSPHRASE_LENGTH];
 } rnp_keygen_crypto_params_t;
 
-typedef struct rnp_keygen_desc_t {
+typedef struct rnp_selfsig_cert_info {
+    uint8_t          userid[MAX_ID_LENGTH]; /* userid, required */
+    uint8_t          key_flags;             /* key flags */
+    uint32_t         key_expiration;        /* key expiration time (sec), 0 = no expiration */
+    pgp_user_prefs_t prefs;                 /* user preferences, optional */
+    unsigned         primary : 1;           /* mark this as the primary user id */
+} rnp_selfsig_cert_info;
+
+typedef struct rnp_selfsig_binding_info {
+    uint8_t  key_flags;
+    uint32_t key_expiration;
+} rnp_selfsig_binding_info;
+
+typedef struct rnp_keygen_primary_desc_t {
     rnp_keygen_crypto_params_t crypto;
+    rnp_selfsig_cert_info      cert;
+} rnp_keygen_primary_desc_t;
+
+typedef struct rnp_keygen_subkey_desc_t {
+    rnp_keygen_crypto_params_t crypto;
+    rnp_selfsig_binding_info   binding;
+} rnp_keygen_subkey_desc_t;
+
+typedef struct rnp_keygen_desc_t {
+    rnp_keygen_primary_desc_t primary;
+    rnp_keygen_subkey_desc_t  subkey;
 } rnp_keygen_desc_t;
+
+#define DEFAULT_PK_ALG PGP_PKA_RSA
+#define DEFAULT_RSA_NUMBITS 2048
+static const pgp_symm_alg_t DEFAULT_SYMMETRIC_ALGS[] = {
+  PGP_SA_AES_256, PGP_SA_AES_192, PGP_SA_AES_128, PGP_SA_TRIPLEDES};
+static const pgp_hash_alg_t DEFAULT_HASH_ALGS[] = {
+  PGP_HASH_SHA256, PGP_HASH_SHA384, PGP_HASH_SHA512, PGP_HASH_SHA224, PGP_HASH_SHA1};
+static const pgp_compression_type_t DEFAULT_COMPRESS_ALGS[] = {
+  PGP_C_ZLIB, PGP_C_BZIP2, PGP_C_ZIP, PGP_C_NONE};
+#define PGP_SA_DEFAULT_CIPHER PGP_SA_AES_256
 
 #endif /* PACKET_H_ */

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -193,13 +193,13 @@ pgp_get_pubkey(const pgp_key_t *key)
 bool
 pgp_is_key_public(const pgp_key_t *key)
 {
-    return key->type == PGP_PTAG_CT_PUBLIC_KEY || key->type == PGP_PTAG_CT_PUBLIC_SUBKEY;
+    return pgp_is_public_key_tag(key->type);
 }
 
 bool
 pgp_is_key_secret(const pgp_key_t *key)
 {
-    return !pgp_is_key_public(key);
+    return pgp_is_secret_key_tag(key->type);
 }
 
 bool
@@ -218,6 +218,32 @@ bool
 pgp_key_can_encrypt(const pgp_key_t *key)
 {
     return key->key_flags & PGP_KF_ENCRYPT;
+}
+
+bool
+pgp_is_secret_key_tag(pgp_content_enum tag)
+{
+    switch (tag) {
+    case PGP_PTAG_CT_SECRET_KEY:
+    case PGP_PTAG_CT_SECRET_SUBKEY:
+    case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
+    case PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool
+pgp_is_public_key_tag(pgp_content_enum tag)
+{
+    switch (tag) {
+    case PGP_PTAG_CT_PUBLIC_KEY:
+    case PGP_PTAG_CT_PUBLIC_SUBKEY:
+        return true;
+    default:
+        return false;
+    }
 }
 
 bool
@@ -648,14 +674,14 @@ pgp_key_init(pgp_key_t *key, const pgp_content_enum type)
         (void) fprintf(stderr, "pgp_key_init: wrong key type\n");
     }
     switch (type) {
-      case PGP_PTAG_CT_PUBLIC_KEY:
-      case PGP_PTAG_CT_PUBLIC_SUBKEY:
-      case PGP_PTAG_CT_SECRET_KEY:
-      case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
-      case PGP_PTAG_CT_SECRET_SUBKEY:
-      case PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY:
+    case PGP_PTAG_CT_PUBLIC_KEY:
+    case PGP_PTAG_CT_PUBLIC_SUBKEY:
+    case PGP_PTAG_CT_SECRET_KEY:
+    case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
+    case PGP_PTAG_CT_SECRET_SUBKEY:
+    case PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY:
         break;
-      default:
+    default:
         RNP_LOG("invalid key type: %d", type);
         break;
     }

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -443,7 +443,7 @@ pgp_set_seckey(pgp_contents_t *cont, const pgp_key_t *key)
 const uint8_t *
 pgp_get_key_id(const pgp_key_t *key)
 {
-    return key->sigid;
+    return key->keyid;
 }
 
 /**
@@ -601,7 +601,7 @@ pgp_add_selfsigned_userid(pgp_key_t *key, const uint8_t *userid)
     pgp_sig_start_key_sig(
       sig, &key->key.seckey.pubkey, userid, PGP_CERT_POSITIVE, key->key.seckey.hash_alg);
     pgp_sig_add_time(sig, (int64_t) time(NULL), PGP_PTAG_SS_CREATION_TIME);
-    pgp_sig_add_issuer_keyid(sig, key->sigid);
+    pgp_sig_add_issuer_keyid(sig, key->keyid);
     pgp_sig_add_primary_userid(sig, 1);
     pgp_sig_end_hashed_subpkts(sig);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -86,6 +86,8 @@ bool pgp_key_can_encrypt(const pgp_key_t *key);
 
 bool pgp_is_primary_key_tag(pgp_content_enum tag);
 bool pgp_is_subkey_tag(pgp_content_enum tag);
+bool pgp_is_secret_key_tag(pgp_content_enum tag);
+bool pgp_is_public_key_tag(pgp_content_enum tag);
 
 bool pgp_key_is_primary_key(const pgp_key_t *key);
 bool pgp_key_is_subkey(const pgp_key_t *key);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -109,5 +109,4 @@ struct pgp_rawpacket_t *pgp_add_rawpacket(pgp_key_t *, const pgp_rawpacket_t *);
 bool pgp_add_selfsigned_userid(pgp_key_t *, const unsigned char *);
 
 void pgp_key_init(pgp_key_t *, const pgp_content_enum);
-
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -72,6 +72,8 @@ void pgp_key_free(pgp_key_t *);
  **/
 void pgp_key_free_data(pgp_key_t *);
 
+void pgp_free_user_prefs(pgp_user_prefs_t *prefs);
+
 const pgp_pubkey_t *pgp_get_pubkey(const pgp_key_t *);
 
 bool pgp_is_key_public(const pgp_key_t *);

--- a/src/lib/readerwriter.h
+++ b/src/lib/readerwriter.h
@@ -77,7 +77,7 @@ unsigned pgp_write_se_ip_pktset(pgp_output_t *,
                                 const unsigned,
                                 pgp_crypt_t *);
 void pgp_push_enc_crypt(pgp_output_t *, pgp_crypt_t *);
-bool pgp_push_enc_se_ip(pgp_output_t *, const pgp_key_t *, pgp_symm_alg_t);
+bool pgp_push_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t);
 
 /* Secret Key checksum */
 void     pgp_push_checksum_writer(pgp_output_t *, pgp_seckey_t *);

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1119,7 +1119,7 @@ rnp_encrypt_file(rnp_ctx_t *ctx, const char *userid, const char *f, const char *
         (void) snprintf(outname, sizeof(outname), "%s%s", f, suffix);
         out = outname;
     }
-    return (int) pgp_encrypt_file(ctx, ctx->rnp->io, f, out, key);
+    return (int) pgp_encrypt_file(ctx, ctx->rnp->io, f, out, pgp_get_pubkey(key));
 }
 
 #define ARMOR_HEAD "-----BEGIN PGP MESSAGE-----"
@@ -1445,7 +1445,7 @@ rnp_encrypt_memory(
         (void) fprintf(io->errs, "rnp_encrypt_buf: input size is larger than output size\n");
         return 0;
     }
-    enc = pgp_encrypt_buf(ctx, io, in, insize, keypair);
+    enc = pgp_encrypt_buf(ctx, io, in, insize, pgp_get_pubkey(keypair));
     m = MIN(pgp_mem_len(enc), outsize);
     (void) memcpy(out, pgp_mem_data(enc), m);
     pgp_memory_free(enc);

--- a/src/lib/validate.c
+++ b/src/lib/validate.c
@@ -303,7 +303,7 @@ pgp_validate_key_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
             }
             break;
         }
-        if (sigkey == &signer->enckey) {
+        if (sigkey == &signer->key.pubkey) {
             (void) fprintf(io->errs, "WARNING: signature made with encryption key\n");
         }
         switch (content->sig.info.type) {
@@ -484,7 +484,7 @@ validate_data_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
             }
             break;
         }
-        if (sigkey == &signer->enckey) {
+        if (sigkey == &signer->key.pubkey) {
             (void) fprintf(io->errs, "WARNING: signature made with encryption key\n");
         }
         if (content->sig.info.birthtime_set) {

--- a/src/lib/writer.h
+++ b/src/lib/writer.h
@@ -108,6 +108,6 @@ bool pgp_write_mpi(pgp_output_t *, const BIGNUM *);
 void     pgp_writer_info_delete(pgp_writer_t *);
 unsigned pgp_writer_info_finalise(pgp_error_t **, pgp_writer_t *);
 
-void pgp_push_stream_enc_se_ip(pgp_output_t *, const pgp_key_t *, pgp_symm_alg_t);
+void pgp_push_stream_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t);
 
 #endif /* WRITER_H_ */

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -32,6 +32,7 @@
 
 #include "key_store_pgp.h"
 #include "key_store_kbx.h"
+#include "pgp-key.h"
 
 #include "packet-create.h"
 
@@ -623,8 +624,20 @@ rnp_key_store_kbx_write_pgp(pgp_io_t *     io,
 
     pgp_writer_set_memory(&output, m);
 
-    if (!pgp_write_xfer_anykey(&output, key, passphrase, NULL, 0)) {
-        return false;
+    for (unsigned ipkt = 0; ipkt < key->packetc; ipkt++) {
+        pgp_rawpacket_t *pkt = &key->packets[ipkt];
+        if (!pgp_write(&output, pkt->raw, pkt->length)) {
+            return false;
+        }
+    }
+    for (unsigned isub = 0; isub < key->subkeyc; isub++) {
+        const pgp_key_t *subkey = key->subkeys[isub];
+        for (unsigned ipkt = 0; ipkt < subkey->packetc; ipkt++) {
+            pgp_rawpacket_t *pkt = &subkey->packets[ipkt];
+            if (!pgp_write(&output, pkt->raw, pkt->length)) {
+                return false;
+            }
+        }
     }
 
     rc = pgp_writer_close(&output);
@@ -704,6 +717,9 @@ rnp_key_store_kbx_to_mem(pgp_io_t *       io,
     }
 
     for (i = 0; i < key_store->keyc; i++) {
+        if (!pgp_key_is_primary_key(&key_store->keys[i])) {
+            continue;
+        }
         if (!rnp_key_store_kbx_write_pgp(io, &key_store->keys[i], passphrase, memory)) {
             RNP_LOG_FD(io->errs, "Can't write PGP blobs for key %d\n", i);
             return false;

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -520,7 +520,7 @@ rnp_key_store_kbx_write_pgp(pgp_io_t *     io,
         return false;
     }
 
-    if (!pgp_memory_add(m, key->sigfingerprint.fingerprint, PGP_FINGERPRINT_SIZE)) {
+    if (!pgp_memory_add(m, key->fingerprint.fingerprint, PGP_FINGERPRINT_SIZE)) {
         return false;
     }
 

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -496,7 +496,8 @@ rnp_key_store_ssh_from_file(pgp_io_t *io, rnp_key_store_t *keyring, const char *
 
     if (ssh2pubkey(io, filename, &key)) {
         (void) fprintf(io->errs, "rnp_key_store_ssh_from_file: it's pubkeys '%s'\n", filename);
-        rnp_key_store_add_key(io, keyring, &key, PGP_PTAG_CT_PUBLIC_KEY);
+        key.type = PGP_PTAG_CT_PUBLIC_KEY;
+        rnp_key_store_add_key(io, keyring, &key);
         return true;
     }
 
@@ -514,7 +515,8 @@ rnp_key_store_ssh_from_file(pgp_io_t *io, rnp_key_store_t *keyring, const char *
 
     if (ssh2seckey(io, filename, &key, &pubkey.key.pubkey)) {
         (void) fprintf(io->errs, "rnp_key_store_ssh_from_file: it's seckey '%s'\n", filename);
-        rnp_key_store_add_key(io, keyring, &key, PGP_PTAG_CT_SECRET_KEY);
+        key.type = PGP_PTAG_CT_SECRET_KEY;
+        rnp_key_store_add_key(io, keyring, &key);
         return true;
     }
 

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -360,9 +360,9 @@ ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key)
             snprintf(buffer, buffer_size, "%s (%s) <%s>", hostname, f, owner);
             userid = (uint8_t *) buffer;
         }
-        ssh_keyid(key->sigid, sizeof(key->sigid), pubkey);
+        ssh_keyid(key->keyid, sizeof(key->keyid), pubkey);
         pgp_add_userid(key, userid);
-        ssh_fingerprint(&key->sigfingerprint, pubkey);
+        ssh_fingerprint(&key->fingerprint, pubkey);
 
         free((void *) userid);
 
@@ -426,8 +426,8 @@ ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey)
     pgp_cipher_set_iv(&crypted, key->key.seckey.iv);
     pgp_cipher_set_key(&crypted, sesskey);
     pgp_encrypt_init(&crypted);
-    ssh_fingerprint(&key->sigfingerprint, pubkey);
-    ssh_keyid(key->sigid, sizeof(key->sigid), pubkey);
+    ssh_fingerprint(&key->fingerprint, pubkey);
+    ssh_keyid(key->keyid, sizeof(key->keyid), pubkey);
     return true;
 }
 

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -336,7 +336,7 @@ rnp_key_store_write_to_mem(rnp_t *          rnp,
  * buffer.
  *
  * buffer: the buffer to write into
- * sigid:  the PGP key ID to format
+ * keyid:  the PGP key ID to format
  * len:    the length of buffer, including the null terminator
  *
  * TODO: There is no error checking here.
@@ -344,7 +344,7 @@ rnp_key_store_write_to_mem(rnp_t *          rnp,
  */
 
 void
-rnp_key_store_format_key(char *buffer, uint8_t *sigid, int len)
+rnp_key_store_format_key(char *buffer, uint8_t *keyid, int len)
 {
     unsigned int i;
     unsigned int n;
@@ -359,7 +359,7 @@ rnp_key_store_format_key(char *buffer, uint8_t *sigid, int len)
      * this function.
      */
     for (i = 0, n = 0; i < PGP_KEY_ID_SIZE; i += 2) {
-        n += snprintf(&buffer[n], len - n, "%02x%02x", sigid[i], sigid[i + 1]);
+        n += snprintf(&buffer[n], len - n, "%02x%02x", keyid[i], keyid[i + 1]);
     }
     buffer[n] = 0x0;
 }
@@ -393,7 +393,7 @@ rnp_key_store_get_first_ring(rnp_key_store_t *ring, char *id, size_t len, int la
 
     memset(id, 0x0, len);
 
-    src = (uint8_t *) &ring->keys[(last) ? ring->keyc - 1 : 0].sigid;
+    src = (uint8_t *) &ring->keys[(last) ? ring->keyc - 1 : 0].keyid;
     rnp_key_store_format_key(id, src, len);
 
     return true;
@@ -473,7 +473,7 @@ rnp_key_store_list(pgp_io_t *io, const rnp_key_store_t *keyring, const int psigs
         if (pgp_is_key_secret(key)) {
             pgp_print_key(io, keyring, key, "sec", &key->key.seckey.pubkey, 0);
         } else {
-            pgp_print_key(io, keyring, key, "signature ", &key->key.pubkey, psigs);
+            pgp_print_key(io, keyring, key, "pub", &key->key.pubkey, psigs);
         }
         (void) fputc('\n', io->res);
     }
@@ -489,12 +489,17 @@ rnp_key_store_json(pgp_io_t *             io,
     pgp_key_t *key;
     unsigned   n;
     for (n = 0, key = keyring->keys; n < keyring->keyc; ++n, ++key) {
-        json_object *jso = json_object_new_object();
-        if (pgp_is_key_secret(key)) {
-            pgp_sprint_json(io, keyring, key, jso, "sec", &key->key.seckey.pubkey, psigs);
+        json_object * jso = json_object_new_object();
+        pgp_pubkey_t *pubkey = &key->key.pubkey;
+        const char *  header = NULL;
+        if (pgp_is_key_secret(key)) { /* secret key is always shown as "sec" */
+            header = "sec";
+        } else if (pgp_key_is_primary_key(key)) { /* top-level public key */
+            header = "pub";
         } else {
-            pgp_sprint_json(io, keyring, key, jso, "signature ", &key->key.pubkey, psigs);
+            header = "sub"; /* subkey */
         }
+        pgp_sprint_json(io, keyring, key, jso, header, pubkey, psigs);
         json_object_array_add(obj, jso);
     }
     return true;
@@ -608,48 +613,30 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
         fprintf(io->errs, "rnp_key_store_add_keydata to key_store: %p\n", keyring);
     }
 
-    if (tag != PGP_PTAG_CT_PUBLIC_SUBKEY) {
-        EXPAND_ARRAY(keyring, key);
-        if (keyring->keys == NULL) {
-            return false;
-        }
-        key = &keyring->keys[keyring->keyc++];
-        (void) memset(key, 0x0, sizeof(*key));
-        if (!pgp_keyid(key->sigid, PGP_KEY_ID_SIZE, &keydata->pubkey)) {
-            return false;
-        }
-        if (!pgp_fingerprint(&key->sigfingerprint, &keydata->pubkey)) {
-            return false;
-        }
-        if (!rnp_key_store_get_key_grip(&keydata->pubkey, key->sig_grip)) {
-            return false;
-        }
-        key->type = tag;
-        key->key = *keydata;
-        key->loaded = 1;
-    } else {
-        // it's is a subkey, adding as enckey to master that was before the key
-        // TODO: move to the right way — support multiple subkeys
-        key = &keyring->keys[keyring->keyc - 1];
-        if (!pgp_keyid(key->encid, PGP_KEY_ID_SIZE, &keydata->pubkey)) {
-            return false;
-        }
-        if (!pgp_fingerprint(&key->encfingerprint, &keydata->pubkey)) {
-            return false;
-        }
-        if (!rnp_key_store_get_key_grip(&keydata->pubkey, key->enc_grip)) {
-            return false;
-        }
-        (void) memcpy(&key->enckey, &keydata->pubkey, sizeof(key->enckey));
-        key->enckey.duration = key->key.pubkey.duration;
+    EXPAND_ARRAY(keyring, key);
+    if (keyring->keys == NULL) {
+        return false;
     }
+    key = &keyring->keys[keyring->keyc++];
+    (void) memset(key, 0x0, sizeof(*key));
+    if (!pgp_keyid(key->keyid, PGP_KEY_ID_SIZE, &keydata->pubkey)) {
+        return false;
+    }
+    if (!pgp_fingerprint(&key->fingerprint, &keydata->pubkey)) {
+        return false;
+    }
+    if (!rnp_key_store_get_key_grip(&keydata->pubkey, key->grip)) {
+        return false;
+    }
+    key->type = tag;
+    key->key = *keydata;
+    key->loaded = 1;
     if (inserted) {
         *inserted = key;
     }
 
     if (rnp_get_debug(__FILE__)) {
-        hexdump(io->errs, "added key->sigid", key->sigid, PGP_KEY_ID_SIZE);
-        hexdump(io->errs, "added key->encid", key->encid, PGP_KEY_ID_SIZE);
+        hexdump(io->errs, "added key->sigid", key->keyid, PGP_KEY_ID_SIZE);
         fprintf(io->errs, "rnp_key_store_add_keydata: keyc %u\n", keyring->keyc);
     }
 
@@ -711,36 +698,21 @@ rnp_key_store_get_key_by_id(pgp_io_t *             io,
                             unsigned *             from,
                             pgp_pubkey_t **        pubkey)
 {
-    uint8_t nullid[PGP_KEY_ID_SIZE];
-
     if (rnp_get_debug(__FILE__)) {
         fprintf(io->errs, "looking keyring %p\n", keyring);
     }
 
-    (void) memset(nullid, 0x0, sizeof(nullid));
     for (; keyring && *from < keyring->keyc; *from += 1) {
         if (rnp_get_debug(__FILE__)) {
-            hexdump(io->errs, "keyring keyid", keyring->keys[*from].sigid, PGP_KEY_ID_SIZE);
+            hexdump(io->errs, "keyring keyid", keyring->keys[*from].keyid, PGP_KEY_ID_SIZE);
             hexdump(io->errs, "keyid", keyid, PGP_KEY_ID_SIZE);
         }
-        if (memcmp(keyring->keys[*from].sigid, keyid, PGP_KEY_ID_SIZE) == 0 ||
-            memcmp(&keyring->keys[*from].sigid[PGP_KEY_ID_SIZE / 2],
+        if (memcmp(keyring->keys[*from].keyid, keyid, PGP_KEY_ID_SIZE) == 0 ||
+            memcmp(&keyring->keys[*from].keyid[PGP_KEY_ID_SIZE / 2],
                    keyid,
                    PGP_KEY_ID_SIZE / 2) == 0) {
             if (pubkey) {
                 *pubkey = &keyring->keys[*from].key.pubkey;
-            }
-            return &keyring->keys[*from];
-        }
-        if (memcmp(&keyring->keys[*from].encid, nullid, sizeof(nullid)) == 0) {
-            continue;
-        }
-        if (memcmp(&keyring->keys[*from].encid, keyid, PGP_KEY_ID_SIZE) == 0 ||
-            memcmp(&keyring->keys[*from].encid[PGP_KEY_ID_SIZE / 2],
-                   keyid,
-                   PGP_KEY_ID_SIZE / 2) == 0) {
-            if (pubkey) {
-                *pubkey = &keyring->keys[*from].enckey;
             }
             return &keyring->keys[*from];
         }
@@ -754,34 +726,20 @@ rnp_key_store_get_key_by_grip(pgp_io_t *             io,
                               const uint8_t *        grip,
                               pgp_pubkey_t **        pubkey)
 {
-    uint8_t nullid[PGP_FINGERPRINT_SIZE];
-
     if (rnp_get_debug(__FILE__)) {
         fprintf(io->errs, "looking keyring %p\n", keyring);
     }
 
-    (void) memset(nullid, 0x0, sizeof(nullid));
     *pubkey = NULL;
     for (int i = 0; keyring && i < keyring->keyc; i++) {
         if (rnp_get_debug(__FILE__)) {
             hexdump(io->errs, "looking for grip", grip, PGP_FINGERPRINT_SIZE);
             hexdump(
-              io->errs, "keyring sig_grip", keyring->keys[i].sig_grip, PGP_FINGERPRINT_SIZE);
-            hexdump(
-              io->errs, "keyring enc_grip", keyring->keys[i].enc_grip, PGP_FINGERPRINT_SIZE);
+              io->errs, "keyring grip", keyring->keys[i].grip, PGP_FINGERPRINT_SIZE);
         }
-        if (memcmp(keyring->keys[i].sig_grip, grip, PGP_FINGERPRINT_SIZE) == 0) {
+        if (memcmp(keyring->keys[i].grip, grip, PGP_FINGERPRINT_SIZE) == 0) {
             if (pubkey) {
                 *pubkey = &keyring->keys[i].key.pubkey;
-            }
-            return true;
-        }
-        if (memcmp(&keyring->keys[i].enc_grip, nullid, sizeof(nullid)) == 0) {
-            continue;
-        }
-        if (memcmp(&keyring->keys[i].enc_grip, grip, PGP_FINGERPRINT_SIZE) == 0) {
-            if (pubkey) {
-                *pubkey = &keyring->keys[i].enckey;
             }
             return true;
         }

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -181,17 +181,21 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
     case CMD_GENERATE_KEY:
         key = f ? f : rnp_cfg_get(cfg, CFG_USERID);
         rnp_keygen_desc_t *key_desc = &rnp->action.generate_key_ctx;
-        key_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
-        key_desc->crypto.sym_alg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
+        memset(key_desc, 0, sizeof(*key_desc));
+        if (key) {
+            strcpy((char *) key_desc->primary.cert.userid, key);
+        }
+        key_desc->primary.crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
+        key_desc->primary.crypto.sym_alg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
 
         if (!rnp_cfg_getbool(cfg, CFG_EXPERT)) {
-            key_desc->crypto.key_alg = PGP_PKA_RSA;
-            key_desc->crypto.rsa.modulus_bit_len = rnp_cfg_getint(cfg, CFG_NUMBITS);
+            key_desc->primary.crypto.key_alg = PGP_PKA_RSA;
+            key_desc->primary.crypto.rsa.modulus_bit_len = rnp_cfg_getint(cfg, CFG_NUMBITS);
         } else if (rnp_generate_key_expert_mode(rnp) != PGP_E_OK) {
             RNP_LOG("Critical error: Key generation failed");
             return false;
         }
-        return rnp_generate_key(rnp, key);
+        return rnp_generate_key(rnp);
     case CMD_GET_KEY:
         key = rnp_get_key(rnp, f, rnp_cfg_get(cfg, CFG_KEYFORMAT));
         if (key) {

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -87,8 +87,8 @@ ask_curve(FILE *input_fp)
     bool        ok = false;
     do {
         printf("Please select which elliptic curve you want:\n");
-        for (int i = 0; (i < PGP_CURVE_MAX) && (i != PGP_CURVE_ED25519); i++) {
-            printf("\t(%u) %s\n", i + 1, ec_curves[i].pgp_name);
+        for (int i = 1; (i < PGP_CURVE_MAX) && (i != PGP_CURVE_ED25519); i++) {
+            printf("\t(%u) %s\n", i, ec_curves[i].pgp_name);
         }
         printf("> ");
         ok = rnp_secure_get_long_from_fd(input_fp, &val);
@@ -96,7 +96,7 @@ ask_curve(FILE *input_fp)
     } while (!ok);
 
     if (ok) {
-        result = (pgp_curve_t)(val - 1);
+        result = (pgp_curve_t)(val);
     }
 
     return result;
@@ -152,7 +152,7 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
 {
     FILE *                      input_fd = rnp->user_input_fp ? rnp->user_input_fp : stdin;
     rnp_keygen_desc_t *         key_desc = &rnp->action.generate_key_ctx;
-    rnp_keygen_crypto_params_t *crypto = &key_desc->crypto;
+    rnp_keygen_crypto_params_t *crypto = &key_desc->primary.crypto;
 
     crypto->key_alg = (pgp_pubkey_alg_t) ask_algorithm(input_fd);
     // get more details about the key
@@ -216,6 +216,8 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
     default:
         return PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG;
     }
+    // TODO this is mostly to get tests passing
+    key_desc->subkey.crypto = key_desc->primary.crypto;
 
     return PGP_E_OK;
 }

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -452,7 +452,7 @@ ecdh_roundtrip(void **state)
                                                     &wrapped_key_len,
                                                     tmp_eph_key,
                                                     &ecdh_key1->key.pubkey.key.ecdh,
-                                                    &ecdh_key1->sigfingerprint),
+                                                    &ecdh_key1->fingerprint),
                              RNP_SUCCESS);
 
         size_t num_bytes = 0;
@@ -467,7 +467,7 @@ ecdh_roundtrip(void **state)
                                                     tmp_eph_key,
                                                     &ecdh_key1->key.seckey.key.ecc,
                                                     &ecdh_key1->key.pubkey.key.ecdh,
-                                                    &ecdh_key1->sigfingerprint),
+                                                    &ecdh_key1->fingerprint),
                              RNP_SUCCESS);
 
         rnp_assert_int_equal(rstate, plaintext_len, result_len);
@@ -507,7 +507,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 &wrapped_key_len,
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_SUCCESS);
 
     size_t num_bytes = 0;
@@ -522,7 +522,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_BAD_PARAMETERS);
 
     rnp_assert_int_equal(rstate,
@@ -533,7 +533,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 NULL,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_BAD_PARAMETERS);
 
     rnp_assert_int_equal(rstate,
@@ -544,7 +544,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_BAD_PARAMETERS);
 
     rnp_assert_int_equal(rstate,
@@ -555,7 +555,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_GENERIC);
 
     rnp_assert_int_equal(rstate,
@@ -566,7 +566,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_GENERIC);
 
     size_t tmp = result_len - 1;
@@ -578,7 +578,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_SHORT_BUFFER);
 
     int key_wrapping_alg = ecdh_key1->key.pubkey.key.ecdh.key_wrap_alg;
@@ -591,7 +591,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_NOT_SUPPORTED);
     ecdh_key1->key.pubkey.key.ecdh.key_wrap_alg = key_wrapping_alg;
 
@@ -605,7 +605,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 tmp_eph_key,
                                                 &ecdh_key1->key.seckey.key.ecc,
                                                 &ecdh_key1->key.pubkey.key.ecdh,
-                                                &ecdh_key1->sigfingerprint),
+                                                &ecdh_key1->fingerprint),
                          RNP_ERROR_GENERIC);
 
     rnp_assert_int_equal(rstate, plaintext_len, result_len);

--- a/src/tests/exportkey.c
+++ b/src/tests/exportkey.c
@@ -44,12 +44,12 @@ rnpkeys_exportkey_verifyUserId(void **state)
 
     /* Generate the key */
     set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_HASH_SHA256);
-    rnp_assert_ok(rstate, rnp_generate_key(&rnp, NULL));
+    rnp_assert_ok(rstate, rnp_generate_key(&rnp));
 
     /* Loading keyrings and checking whether they have correct key */
     rnp_assert_ok(rstate, rnp_key_store_load_keys(&rnp, 1));
-    rnp_assert_ok(rstate, rnp_secret_count(&rnp));
-    rnp_assert_ok(rstate, rnp_public_count(&rnp));
+    rnp_assert_int_not_equal(rstate, 0, rnp_secret_count(&rnp));
+    rnp_assert_int_not_equal(rstate, 0, rnp_public_count(&rnp));
     rnp_assert_true(rstate, rnp_find_key(&rnp, getenv("LOGNAME")));
 
     /* Try to export the key without passing userid from the interface : this should fail*/

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -109,6 +109,7 @@ int test_value_equal(const char *  what,
  */
 char *uint_to_string(char *buff, const int buffsize, unsigned int num, int base);
 
+bool write_pass_to_pipe(int fd, size_t count);
 /* Setup readable pipe with default passphrase inside */
 int setupPassphrasefd(int *pipefd);
 

--- a/src/tests/user-prefs.c
+++ b/src/tests/user-prefs.c
@@ -29,8 +29,9 @@
 #include "rnp_tests.h"
 #include "support.h"
 
-static const pgp_subsig_t*
-find_subsig(const pgp_key_t *key, const char *userid) {
+static const pgp_subsig_t *
+find_subsig(const pgp_key_t *key, const char *userid)
+{
     // find the userid index
     int uididx = -1;
     for (int i = 0; i < key->uidc; i++) {
@@ -68,7 +69,7 @@ test_load_user_prefs(void **state)
 
     rnp_assert_ok(rstate, setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, homedir, pipefd));
     rnp_assert_ok(rstate, rnp_key_store_load_keys(&rnp, false));
-    rnp_assert_true(rstate, rnp_secret_count(&rnp) == 0 && rnp_public_count(&rnp) == 2);
+    rnp_assert_true(rstate, rnp_secret_count(&rnp) == 0 && rnp_public_count(&rnp) == 7);
 
     {
         const char *userid = "key1-uid0";
@@ -110,7 +111,7 @@ test_load_user_prefs(void **state)
         }
         // preferred key server
         {
-            static const char* expected = "hkp://pgp.mit.edu";
+            static const char *expected = "hkp://pgp.mit.edu";
             assert_non_null(prefs->key_server);
             assert_int_equal(0, memcmp(prefs->key_server, expected, strlen(expected) + 1));
         }
@@ -132,13 +133,22 @@ test_load_user_prefs(void **state)
 
         // symm algs
         {
-            static const uint8_t expected[] = {PGP_SA_AES_256, PGP_SA_AES_192, PGP_SA_AES_128, PGP_SA_CAST5, PGP_SA_TRIPLEDES, PGP_SA_IDEA};
+            static const uint8_t expected[] = {PGP_SA_AES_256,
+                                               PGP_SA_AES_192,
+                                               PGP_SA_AES_128,
+                                               PGP_SA_CAST5,
+                                               PGP_SA_TRIPLEDES,
+                                               PGP_SA_IDEA};
             assert_int_equal(prefs->symm_algc, ARRAY_SIZE(expected));
             assert_int_equal(0, memcmp(prefs->symm_algs, expected, sizeof(expected)));
         }
         // hash algs
         {
-            static const uint8_t expected[] = {PGP_HASH_SHA256, PGP_HASH_SHA1, PGP_HASH_SHA384, PGP_HASH_SHA512, PGP_HASH_SHA224};
+            static const uint8_t expected[] = {PGP_HASH_SHA256,
+                                               PGP_HASH_SHA1,
+                                               PGP_HASH_SHA384,
+                                               PGP_HASH_SHA512,
+                                               PGP_HASH_SHA224};
             assert_int_equal(prefs->hash_algc, ARRAY_SIZE(expected));
             assert_int_equal(0, memcmp(prefs->hash_algs, expected, sizeof(expected)));
         }


### PR DESCRIPTION
EDIT: I'm continuing to split some of these fixes in to separate PRs.

I don't know if this will end up merged, as it only really works with GPG/KBX keystore formats (no G10/GPG21). I've had to rework this branch too many times with all the recent PRs, so I figure I better at least get input.

It also reworks the key listings to match gpg more.

```
$ src/rnpkeys/rnpkeys --gen-key --keystore-format=GPG
Generating a new key...
Enter passphrase for new primary key: 
Repeat passphrase for new primary key: 
Enter passphrase for new subkey: 
Repeat passphrase for new subkey: 
pub 2048/RSA (Encrypt or Sign) a1c91f6a6800dc5d 2017-08-05 [SC] 
                 aea9 1b0a ec72 2023 cd4f 1666 a1c9 1f6a 6800 dc5d 
uid              RSA (Encrypt or Sign) 2048-bit key <daniel@localhost>
sub 2048/RSA (Encrypt or Sign) 90ef443358269873 2017-08-05 [E] 
                 bb4d b248 66f4 d76e dbe6 a738 90ef 4433 5826 9873 
```

```
$ src/rnpkeys/rnpkeys --list-keys --keystore-format=GPG
2 keys found

pub   2048/RSA (Encrypt or Sign) a1c91f6a6800dc5d 2017-08-05 [SC]
      aea91b0aec722023cd4f1666a1c91f6a6800dc5d
uid           RSA (Encrypt or Sign) 2048-bit key <daniel@localhost>
sub   2048/RSA (Encrypt or Sign) 90ef443358269873 2017-08-05 [E]
      bb4db24866f4d76edbe6a73890ef443358269873

$ src/rnpkeys/rnpkeys --list-sigs --keystore-format=GPG
2 keys found

pub   2048/RSA (Encrypt or Sign) a1c91f6a6800dc5d 2017-08-05 [SC]
      aea91b0aec722023cd4f1666a1c91f6a6800dc5d
uid           RSA (Encrypt or Sign) 2048-bit key <daniel@localhost>
sig           a1c91f6a6800dc5d 2017-08-05 RSA (Encrypt or Sign) 2048-bit key <daniel@localhost>
sub   2048/RSA (Encrypt or Sign) 90ef443358269873 2017-08-05 [E]
      bb4db24866f4d76edbe6a73890ef443358269873
```

### Pros
* Full key+subkey generation. I haven't actually tested "only primary key" generation or "only subkey generation", but generating both works well, is compatible with gpg, etc.
* Fixes round-trip reading+writing out unencrypted .gpg/.asc keys. (We still can't generate and write these, but that may not matter)
* Fixes incorrect transferable key writing. Transferable keys are only supposed
  to contain certain packets.
* Fixes all key MPIs leaking on key store free (probably inherited from netpgp)
### Cons
* As mentioned, this really only supports .gpg/.asc/.kbx. (And since KBX is never used without G10 with GPG, KBX alone doesn't count for much)
* rnpkeys expert mode would need some work.
* To save time, I used a lot of bools and don't return error codes back to callers (I did use RNP_LOG a lot though)