### PR TITLE
tests: Fix random failures in ecdsa_signverify_success.

### DIFF
--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -362,7 +362,6 @@ void
 ecdsa_signverify_success(void **state)
 {
     rnp_test_state_t *rstate = *state;
-    uint8_t           message[64];
 
     struct curve {
         pgp_curve_t id;
@@ -371,6 +370,7 @@ ecdsa_signverify_success(void **state)
       {PGP_CURVE_NIST_P_256, 32}, {PGP_CURVE_NIST_P_384, 48}, {PGP_CURVE_NIST_P_521, 64}};
 
     for (int i = 0; i < ARRAY_SIZE(curves); i++) {
+        uint8_t                 message[64] = {0xAA};
         pgp_ecc_sig_t           sig = {NULL, NULL};
         const rnp_keygen_desc_t key_desc = {.crypto = {.key_alg = PGP_PKA_ECDSA,
                                                        .hash_alg = PGP_HASH_SHA512,


### PR DESCRIPTION
The message was uninitialized garbage and when it happened to be
all zeroes, the signing process would (rightfully) fail in botan.