### PR TITLE
Take care of of pgp_sig_write unchecked return values

### DIFF
--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -335,9 +335,11 @@ pgp_writer_pop(pgp_output_t *output)
 unsigned
 pgp_writer_close(pgp_output_t *output)
 {
-    unsigned ret;
+    if (!output) {
+        return 0;
+    }
 
-    ret = pgp_writer_info_finalise(&output->errors, &output->writer);
+    unsigned ret = pgp_writer_info_finalise(&output->errors, &output->writer);
     pgp_writer_info_delete(&output->writer);
     return ret;
 }


### PR DESCRIPTION
Fixes #206 (actually that is already fixed but this aims to be more thorough)

I was able to condense/simplify a lot of the code in here as well since the cleartext and non-cleartext signature cases have few differences. I suspect a lot of this can be factored out further (like `pgp_sign_buf` and `pgp_sign_file` could probably use a shared function for the bulk of the operation), but did not attempt this for now.

This also fixes some memory leaks for certain cases with `pgp_create_sig_delete`.

We don't appear to have test coverage for `pgp_sign_file` or `pgp_sign_detached` so I did some quick checks with rnp and gpg manually. No tests added because I'm trying to focus on password handling and FFI.