### PR TITLE
Fix for incorrect output buffer offset handling in zlib_compressed_data_reader

### DIFF
--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -186,8 +186,8 @@ zlib_compressed_data_reader(pgp_stream_t *stream,
             return 0;
         }
         len = (size_t)(z->zstream.next_out - &z->out[z->offset]);
-        if (len > length) {
-            len = length;
+        if (len + cc > length) {
+            len = length - cc;
         }
         (void) memcpy(&cdest[cc], &z->out[z->offset], len);
         z->offset += len;


### PR DESCRIPTION
This short pull request fixes issue #378 
Actually, decompression didn't work well at all.