### PR TITLE
Ensure pgp_forget always zeros things

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,6 @@ AC_REVISION([m4_esyscmd_s([git describe --always])])
 AC_DEFINE([GIT_REVISION],["m4_esyscmd_s([git describe --always])"],
 [Git revision generated when autoreconf was called])
 
-
 AS_SHELL_SANITIZE
 
 AC_CONFIG_SRCDIR([src/rnp/rnp.c])
@@ -91,6 +90,18 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT64_T
 AC_TYPE_UINT8_T
 
+# Check for a secure memory wipe implementation.
+AC_CHECK_FUNCS([explicit_bzero explicit_memset memset_s])
+AS_IF([test $ac_cv_func_explicit_bzero = no &&
+       test $ac_cv_func_explicit_memset = no &&
+       test $ac_cv_func_memset_s = no],
+      [
+        AM_CONDITIONAL([USE_BUNDLED_EXPLICIT_BZERO], [true])
+        AC_DEFINE([USE_BUNDLED_EXPLICIT_BZERO], [1], [use the bundled explicit_bzero])
+      ], [
+        AM_CONDITIONAL([USE_BUNDLED_EXPLICIT_BZERO], [false])
+      ])
+
 # Check for Botan
 AX_CHECK_BOTAN(, [AC_MSG_ERROR([Missing Botan])])
 AX_CHECK_BOTAN_DEFINES()
@@ -111,6 +122,7 @@ AC_CONFIG_FILES([
         Makefile
         include/Makefile
         src/Makefile
+        src/compat/Makefile
         src/librekey/Makefile
         src/lib/Makefile
         src/rnp/Makefile

--- a/remove_artifacts.sh
+++ b/remove_artifacts.sh
@@ -16,6 +16,7 @@ artifacts="
   m4/ltsugar.m4
   m4/ltversion.m4
   src/Makefile.in
+  src/compat/Makefile.in
   src/tests/Makefile.in
   src/lib/Makefile.in
   src/lib/config.h.in

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,7 @@
-SUBDIRS = librekey lib rnp rnpkeys tests fuzzing
+SUBDIRS =
+
+if USE_BUNDLED_EXPLICIT_BZERO
+SUBDIRS += compat
+endif
+
+SUBDIRS += librekey lib rnp rnpkeys tests fuzzing

--- a/src/compat/Makefile.am
+++ b/src/compat/Makefile.am
@@ -1,0 +1,6 @@
+AM_CFLAGS =
+noinst_LTLIBRARIES = libcompatnoopt.la
+libcompatnoopt_la_CPPFLAGS =
+libcompatnoopt_la_CFLAGS = -O0
+libcompatnoopt_la_LIBADD =
+libcompatnoopt_la_SOURCES = explicit_bzero.c

--- a/src/compat/explicit_bzero.c
+++ b/src/compat/explicit_bzero.c
@@ -1,0 +1,19 @@
+/*	$OpenBSD: explicit_bzero.c,v 1.4 2015/08/31 02:53:57 guenther Exp $ */
+/*
+ * Public domain.
+ * Written by Matthew Dempsky.
+ */
+
+#include <string.h>
+
+__attribute__((weak)) void
+__explicit_bzero_hook(void *buf, size_t len)
+{
+}
+
+void
+explicit_bzero(void *buf, size_t len)
+{
+    memset(buf, 0, len);
+    __explicit_bzero_hook(buf, len);
+}

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -5,6 +5,11 @@ AM_LDFLAGS          = $(BOTAN_LDFLAGS) $(JSONC_LDFLAGS)
 lib_LTLIBRARIES		= librnp.la
 librnp_la_CPPFLAGS	= -I$(top_srcdir)/include
 librnp_la_LIBADD	= $(BOTAN_LIBS) $(JSONC_LIBS) ../librekey/librekey.la
+
+if USE_BUNDLED_EXPLICIT_BZERO
+librnp_la_LIBADD	+= ../compat/libcompatnoopt.la
+endif
+
 dist_man_MANS		= librnp.3
 librnp_la_SOURCES	= \
 	bn.c \

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -461,9 +461,6 @@ static bool
 find_passphrase(FILE *passfp, const char *id, char *passphrase, size_t size, int attempts)
 {
     char  prompt[BUFSIZ];
-    char  buf[128];
-    char *cp;
-    int   i;
 
     if (passfp) {
         memset(passphrase, 0, size);
@@ -481,24 +478,29 @@ find_passphrase(FILE *passfp, const char *id, char *passphrase, size_t size, int
         // may be a blank passphrase, but allow it
         return true;
     }
-    for (i = 0; i < attempts; i++) {
+
+    char  buf[128];
+    char *cp;
+    for (int i = 0; i < attempts; i++) {
         (void) snprintf(prompt, sizeof(prompt), "Enter passphrase for %.16s: ", id);
         if ((cp = getpass(prompt)) == NULL) {
             break;
         }
         snprintf(buf, sizeof(buf), "%s", cp);
+        pgp_forget(cp, strlen(cp));
         (void) snprintf(prompt, sizeof(prompt), "Repeat passphrase for %.16s: ", id);
         if ((cp = getpass(prompt)) == NULL) {
             break;
         }
         snprintf(passphrase, size, "%s", cp);
+        pgp_forget(cp, strlen(cp));
         if (strcmp(buf, passphrase) == 0) {
-            (void) memset(buf, 0x0, sizeof(buf));
+            pgp_forget(buf, sizeof(buf));
             return true;
         }
     }
-    (void) memset(buf, 0x0, sizeof(buf));
-    (void) memset(passphrase, 0x0, size);
+    pgp_forget(buf, sizeof(buf));
+    pgp_forget(passphrase, size);
     return false;
 }
 


### PR DESCRIPTION
Fixes #263 

Two things here:

* Use `explicit_bzero`/`explicit_memset`/`memset_s` in `pgp_forget` to ensure that the crucial piece of code is not optimized out. I pulled in a public domain implementation of `explicit_bzero` from libressl as a fallback. It's built as a separate static lib with no optimization (you'll probably see both -O2 and -O0 on the command line but the last option takes effect - room for improvement there). Most BSDs and Linux w/glibc >= 2.25 have `explicit_bzero` or `explicit_memset` available. I *think* macOS has `memset_s`. For Windows we'll probably eventually want to use `SecureZeroMemory`. None of these functions are very portable, but it's a start.
* Add a few more `pgp_forget` calls in to `find_passphrase`. The `find_passphrase` function is still a bit wonky and could definitely be improved but I'm thinking I may rework it as part of #39.