### PR TITLE
Consolidate and remove duplicate armouring code

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -487,7 +487,7 @@ pgp_encrypt_file(rnp_ctx_t *         ctx,
 
     /* set armoured/not armoured here */
     if (ctx->armour) {
-        pgp_writer_push_armor_msg(output);
+        pgp_writer_push_armoured(output, PGP_PGP_MESSAGE);
     }
 
     /* Push the encrypted writer */
@@ -530,7 +530,7 @@ pgp_encrypt_buf(rnp_ctx_t *         ctx,
 
     /* set armoured/not armoured here */
     if (ctx->armour) {
-        pgp_writer_push_armor_msg(output);
+        pgp_writer_push_armoured(output, PGP_PGP_MESSAGE);
     }
 
     /* Push the encrypted writer */

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1272,7 +1272,7 @@ rnp_sign_file(rnp_ctx_t * ctx,
     return ret;
 }
 
-#define ARMOR_SIG_HEAD "-----BEGIN PGP (SIGNATURE|SIGNED MESSAGE)-----"
+#define ARMOR_SIG_HEAD "-----BEGIN PGP (SIGNATURE|SIGNED MESSAGE|MESSAGE)-----"
 
 /* verify a file */
 int

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -1127,13 +1127,13 @@ pgp_sign_file(rnp_ctx_t *         ctx,
     if (cleartext) {
         if (!pgp_writer_push_clearsigned(output, sig) ||
             !pgp_write(output, pgp_mem_data(infile), (unsigned) pgp_mem_len(infile)) ||
-            !pgp_writer_use_armored_sig(output)) {
+            !pgp_writer_push_armoured(output, PGP_PGP_CLEARTEXT_SIGNATURE)) {
             goto done;
         }
     } else {
         /* set armoured/not armoured here */
         if (ctx->armour) {
-            pgp_writer_push_armor_msg(output);
+            pgp_writer_push_armoured(output, PGP_PGP_MESSAGE);
         }
         /* hash file contents */
         hash = pgp_sig_get_hash(sig);
@@ -1229,14 +1229,14 @@ pgp_sign_buf(rnp_ctx_t *         ctx,
     if (cleartext) {
         if (!pgp_writer_push_clearsigned(output, sig) ||
             !pgp_write(output, input, (unsigned) insize) ||
-            !pgp_writer_use_armored_sig(output)) {
+            !pgp_writer_push_armoured(output, PGP_PGP_CLEARTEXT_SIGNATURE)) {
             goto done;
         }
 
     } else {
         /* set armoured/not armoured here */
         if (ctx->armour) {
-            pgp_writer_push_armor_msg(output);
+            pgp_writer_push_armoured(output, PGP_PGP_MESSAGE);
         }
         /* hash memory */
         hash = pgp_sig_get_hash(sig);
@@ -1313,7 +1313,7 @@ pgp_sign_detached(
     }
     /* set armoured/not armoured here */
     if (ctx->armour) {
-        pgp_writer_push_armor_msg(output);
+        pgp_writer_push_armoured(output, PGP_PGP_SIGNATURE);
     }
     pgp_sig_add_data(sig, pgp_mem_data(mem), pgp_mem_len(mem));
 

--- a/src/lib/signature.h
+++ b/src/lib/signature.h
@@ -143,7 +143,6 @@ void pgp_reader_push_dearmour(pgp_stream_t *);
 
 bool pgp_writer_push_clearsigned(pgp_output_t *, pgp_create_sig_t *);
 void pgp_reader_pop_dearmour(pgp_stream_t *);
-void pgp_writer_push_armor_msg(pgp_output_t *);
 
 typedef enum {
     PGP_PGP_MESSAGE = 1,
@@ -151,14 +150,13 @@ typedef enum {
     PGP_PGP_PRIVATE_KEY_BLOCK,
     PGP_PGP_MULTIPART_MESSAGE_PART_X_OF_Y,
     PGP_PGP_MULTIPART_MESSAGE_PART_X,
-    PGP_PGP_SIGNATURE
+    PGP_PGP_SIGNATURE,
+    PGP_PGP_CLEARTEXT_SIGNATURE
 } pgp_armor_type_t;
 
 #define CRC24_INIT 0xb704ceL
 
-bool pgp_writer_use_armored_sig(pgp_output_t *);
-
-void pgp_writer_push_armoured(pgp_output_t *, pgp_armor_type_t);
+bool pgp_writer_push_armoured(pgp_output_t *, pgp_armor_type_t);
 
 pgp_memory_t *pgp_sign_buf(
   rnp_ctx_t *, pgp_io_t *, const void *, const size_t, const pgp_seckey_t *, const bool);

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -541,6 +541,7 @@ typedef struct {
     unsigned pos;
     uint8_t  t;
     unsigned checksum;
+    pgp_armor_type_t type;
 } base64_t;
 
 static const char b64map[] =
@@ -593,43 +594,6 @@ base64_writer(const uint8_t *src, unsigned len, pgp_error_t **errors, pgp_writer
     return true;
 }
 
-static bool
-sig_finaliser(pgp_error_t **errors, pgp_writer_t *writer)
-{
-    static const char trail[] = "\r\n-----END PGP SIGNATURE-----\r\n";
-    base64_t *        base64;
-    uint8_t           c[3];
-
-    base64 = pgp_writer_get_arg(writer);
-    if (base64->pos) {
-        if (!stacked_write(writer, &b64map[base64->t], 1, errors)) {
-            return false;
-        }
-        if (base64->pos == 1 && !stacked_write(writer, "==", 2, errors)) {
-            return false;
-        }
-        if (base64->pos == 2 && !stacked_write(writer, "=", 1, errors)) {
-            return false;
-        }
-    }
-    /* Ready for the checksum */
-    if (!stacked_write(writer, "\r\n=", 3, errors)) {
-        return false;
-    }
-
-    base64->pos = 0; /* get ready to write the checksum */
-
-    c[0] = base64->checksum >> 16;
-    c[1] = base64->checksum >> 8;
-    c[2] = base64->checksum;
-    /* push the checksum through our own writer */
-    if (!base64_writer(c, 3, errors, writer)) {
-        return false;
-    }
-
-    return stacked_write(writer, trail, (unsigned) (sizeof(trail) - 1), errors);
-}
-
 /**
  * \struct linebreak_t
  */
@@ -664,54 +628,40 @@ linebreak_writer(const uint8_t *src, unsigned len, pgp_error_t **errors, pgp_wri
     return true;
 }
 
-/**
- * \ingroup Core_WritersNext
- * \brief Push armoured signature on stack
- * \param output
- */
-bool
-pgp_writer_use_armored_sig(pgp_output_t *output)
-{
-    static const char header[] =
-      "\r\n-----BEGIN PGP SIGNATURE-----\r\nVersion: " PACKAGE_STRING "\r\n\r\n";
-    linebreak_t *linebreak;
-    base64_t *   base64;
-
-    pgp_writer_pop(output);
-    if (pgp_write(output, header, (unsigned) (sizeof(header) - 1)) == 0) {
-        PGP_ERROR_1(&output->errors, PGP_E_W, "%s", "Error switching to armoured signature");
-        return false;
-    }
-    if ((linebreak = calloc(1, sizeof(*linebreak))) == NULL) {
-        PGP_ERROR_1(&output->errors, PGP_E_W, "%s", "pgp_writer_use_armored_sig: Bad alloc");
-        return false;
-    }
-    if (!pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak)) {
-        free(linebreak);
-        return false;
-    }
-    base64 = calloc(1, sizeof(*base64));
-    if (!base64) {
-        PGP_MEMORY_ERROR(&output->errors);
-        return false;
-    }
-    base64->checksum = CRC24_INIT;
-    if (!pgp_writer_push(output, base64_writer, sig_finaliser, generic_destroyer, base64)) {
-        free(base64);
-        return false;
-    }
-    return true;
-}
-
 static bool
 armoured_message_finaliser(pgp_error_t **errors, pgp_writer_t *writer)
 {
     /* TODO: This is same as sig_finaliser apart from trailer. */
-    static const char trailer[] = "\r\n-----END PGP MESSAGE-----\r\n";
+    static const char trl_message[] = "\r\n-----END PGP MESSAGE-----\r\n";
+    static const char trl_pubkey[] = "\r\n-----END PGP PUBLIC KEY BLOCK-----\r\n";
+    static const char trl_seckey[] = "\r\n-----END PGP PRIVATE KEY BLOCK-----\r\n";
+    static const char trl_signature[] = "\r\n-----END PGP SIGNATURE-----\r\n";
+    
     base64_t *        base64;
     uint8_t           c[3];
+    const char *      trailer = NULL;
 
     base64 = pgp_writer_get_arg(writer);
+
+    switch (base64->type) {
+    case PGP_PGP_MESSAGE:
+        trailer = trl_message;
+        break;
+    case PGP_PGP_PUBLIC_KEY_BLOCK:
+        trailer = trl_pubkey;
+        break;
+    case PGP_PGP_PRIVATE_KEY_BLOCK:
+        trailer = trl_seckey;
+        break;
+    case PGP_PGP_SIGNATURE:
+    case PGP_PGP_CLEARTEXT_SIGNATURE:
+        trailer = trl_signature;
+        break;
+    default:
+        fprintf(stderr, "armoured_message_finaliser: unusual type\n");
+        return false;
+    }
+
     if (base64->pos) {
         if (!stacked_write(writer, &b64map[base64->t], 1, errors)) {
             return false;
@@ -743,156 +693,82 @@ armoured_message_finaliser(pgp_error_t **errors, pgp_writer_t *writer)
 
 /**
  \ingroup Core_WritersNext
- \brief Write a PGP MESSAGE
- \todo replace with generic function
-*/
-void
-pgp_writer_push_armor_msg(pgp_output_t *output)
-{
-    static const char header[] = "-----BEGIN PGP MESSAGE-----\r\n";
-    linebreak_t *     linebreak;
-    base64_t *        base64;
-
-    pgp_write(output, header, (unsigned) (sizeof(header) - 1));
-    pgp_write(output, "\r\n", 2);
-    if ((linebreak = calloc(1, sizeof(*linebreak))) == NULL) {
-        (void) fprintf(stderr, "pgp_writer_push_armor_msg: bad lb alloc\n");
-        return;
-    }
-    if (!pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak)) {
-        free(linebreak);
-        return;
-    }
-    if ((base64 = calloc(1, sizeof(*base64))) == NULL) {
-        (void) fprintf(stderr, "pgp_writer_push_armor_msg: bad alloc\n");
-        return;
-    }
-    base64->checksum = CRC24_INIT;
-    if (!pgp_writer_push(
-          output, base64_writer, armoured_message_finaliser, generic_destroyer, base64)) {
-        free(base64);
-        return;
-    }
-}
-
-static bool
-armoured_finaliser(pgp_armor_type_t type, pgp_error_t **errors, pgp_writer_t *writer)
-{
-    static const char tail_pubkey[] = "\r\n-----END PGP PUBLIC KEY BLOCK-----\r\n";
-    static const char tail_private_key[] = "\r\n-----END PGP PRIVATE KEY BLOCK-----\r\n";
-    const char *      tail = NULL;
-    unsigned          tailsize = 0;
-    base64_t *        base64;
-    uint8_t           c[3];
-
-    switch (type) {
-    case PGP_PGP_PUBLIC_KEY_BLOCK:
-        tail = tail_pubkey;
-        tailsize = sizeof(tail_pubkey) - 1;
-        break;
-
-    case PGP_PGP_PRIVATE_KEY_BLOCK:
-        tail = tail_private_key;
-        tailsize = sizeof(tail_private_key) - 1;
-        break;
-
-    default:
-        (void) fprintf(stderr, "armoured_finaliser: unusual type\n");
-        return false;
-    }
-    base64 = pgp_writer_get_arg(writer);
-    if (base64->pos) {
-        if (!stacked_write(writer, &b64map[base64->t], 1, errors)) {
-            return false;
-        }
-        if (base64->pos == 1 && !stacked_write(writer, "==", 2, errors)) {
-            return false;
-        }
-        if (base64->pos == 2 && !stacked_write(writer, "=", 1, errors)) {
-            return false;
-        }
-    }
-    /* Ready for the checksum */
-    if (!stacked_write(writer, "\r\n=", 3, errors)) {
-        return false;
-    }
-    base64->pos = 0; /* get ready to write the checksum */
-    c[0] = base64->checksum >> 16;
-    c[1] = base64->checksum >> 8;
-    c[2] = base64->checksum;
-    /* push the checksum through our own writer */
-    if (!base64_writer(c, 3, errors, writer)) {
-        return false;
-    }
-    return stacked_write(writer, tail, tailsize, errors);
-}
-
-static bool
-armored_pubkey_fini(pgp_error_t **errors, pgp_writer_t *writer)
-{
-    return armoured_finaliser(PGP_PGP_PUBLIC_KEY_BLOCK, errors, writer);
-}
-
-static bool
-armored_privkey_fini(pgp_error_t **errors, pgp_writer_t *writer)
-{
-    return armoured_finaliser(PGP_PGP_PRIVATE_KEY_BLOCK, errors, writer);
-}
-
-/* \todo use this for other armoured types */
-/**
- \ingroup Core_WritersNext
  \brief Push Armoured Writer on stack (generic)
 */
-void
+bool
 pgp_writer_push_armoured(pgp_output_t *output, pgp_armor_type_t type)
 {
-    static char hdr_pubkey[] =
-      "-----BEGIN PGP PUBLIC KEY BLOCK-----\r\nVersion: " PACKAGE_STRING "\r\n\r\n";
-    static char hdr_private_key[] =
-      "-----BEGIN PGP PRIVATE KEY BLOCK-----\r\nVersion: " PACKAGE_STRING "\r\n\r\n";
-    unsigned hdrsize = 0;
-    bool (*finaliser)(pgp_error_t **, pgp_writer_t *);
+    static char hdr_pubkey[] = "-----BEGIN PGP PUBLIC KEY BLOCK-----\r\n";
+    static char hdr_privkey[] = "-----BEGIN PGP PRIVATE KEY BLOCK-----\r\n";
+    static char hdr_message[] = "-----BEGIN PGP MESSAGE-----\r\n";
+    static char hdr_signature[] = "-----BEGIN PGP SIGNATURE-----\r\n";
+    static char hdr_version[] = "Version: " PACKAGE_STRING "\r\n\r\n";
+    static char hdr_crlf[] = "\r\n";
+
     base64_t *   base64;
     linebreak_t *linebreak;
-    char *       header = NULL;
 
-    finaliser = NULL;
+    if ((linebreak = calloc(1, sizeof(*linebreak))) == NULL) {
+        (void) fprintf(stderr, "pgp_writer_push_armoured: bad alloc\n");
+        return false;
+    }
+
     switch (type) {
+    case PGP_PGP_MESSAGE:
+        pgp_write(output, hdr_message, sizeof(hdr_message) - 1);
+        pgp_write(output, hdr_crlf, sizeof(hdr_crlf) - 1);
+        break;
+
     case PGP_PGP_PUBLIC_KEY_BLOCK:
-        header = hdr_pubkey;
-        hdrsize = sizeof(hdr_pubkey) - 1;
-        finaliser = armored_pubkey_fini;
+        pgp_write(output, hdr_pubkey, sizeof(hdr_pubkey) - 1);
+        pgp_write(output, hdr_version, sizeof(hdr_version) - 1);
         break;
 
     case PGP_PGP_PRIVATE_KEY_BLOCK:
-        header = hdr_private_key;
-        hdrsize = sizeof(hdr_private_key) - 1;
-        finaliser = armored_privkey_fini;
+        pgp_write(output, hdr_privkey, sizeof(hdr_privkey) - 1);
+        pgp_write(output, hdr_version, sizeof(hdr_version) - 1);
+        break;
+
+    case PGP_PGP_SIGNATURE:
+        pgp_write(output, hdr_signature, sizeof(hdr_signature) - 1);
+        pgp_write(output, hdr_crlf, sizeof(hdr_crlf) - 1);
+        break;
+
+    case PGP_PGP_CLEARTEXT_SIGNATURE:
+        pgp_writer_pop(output);
+        if (!pgp_write(output, hdr_crlf, sizeof(hdr_crlf) - 1) ||
+            !pgp_write(output, hdr_signature, sizeof(hdr_signature) - 1) ||
+            !pgp_write(output, hdr_version, sizeof(hdr_version) - 1)) {
+            PGP_ERROR_1(&output->errors, PGP_E_W, "%s", "Error switching to armoured signature");
+            free(linebreak);
+            return false;
+        }
         break;
 
     default:
+        free(linebreak);
         (void) fprintf(stderr, "pgp_writer_push_armoured: unusual type\n");
-        return;
+        return false;
     }
-    if ((linebreak = calloc(1, sizeof(*linebreak))) == NULL) {
-        (void) fprintf(stderr, "pgp_writer_push_armoured: bad alloc\n");
-        return;
-    }
-    pgp_write(output, header, hdrsize);
+
     if (!pgp_writer_push(output, linebreak_writer, NULL, generic_destroyer, linebreak)) {
         free(linebreak);
-        return;
+        return false;
     }
+
     if ((base64 = calloc(1, sizeof(*base64))) == NULL) {
         (void) fprintf(stderr, "pgp_writer_push_armoured: bad alloc\n");
-        return;
+        return false;
     }
     base64->checksum = CRC24_INIT;
-    if (!pgp_writer_push(output, base64_writer, finaliser, generic_destroyer, base64)) {
+    base64->type = type;
+
+    if (!pgp_writer_push(output, base64_writer, armoured_message_finaliser, generic_destroyer, base64)) {
         free(base64);
-        return;
+        return false;
     }
+
+    return true;
 }
 
 /**************************************************************************/

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -82,8 +82,8 @@ r'gpg: Good signature from "(.*)".*'
 
 RE_RNP_GOOD_SIGNATURE = r'(?s)^.*' \
 r'Good signature for .* made .*' \
-r'signature.*' \
-r'Key fingerprint:.*' \
+r'using .* key .*' \
+r'signature .*' \
 r'uid\s+(.*)\s*$'
 
 def setup():


### PR DESCRIPTION
This PR was first targeted to solve issue #383 - problem with verification of armored messages with 'BEGIN PGP MESSAGE' header.
However together with it I consolidated all armored writers/finalizers and removed duplicated code.
I tested it mostly manually/with GPG - since looks like we have some major problems with dearmoring right now. Will write about it in other issue.
Also it has a minor CLI test update for signing/verification test.