### PR TITLE
Add support for SM2 encryption

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -170,6 +170,23 @@ pgp_decrypt_decode_mpi(uint8_t *           buf,
             hexdump(stderr, "decoded m", buf, n);
         }
         return n;
+    case PGP_PKA_SM2_ENCRYPT:
+        BN_bn2bin(encmpi, encmpibuf);
+
+        size_t out_len = buflen;
+        pgp_errcode_t err = pgp_sm2_decrypt(buf,
+                                            &out_len,
+                                            encmpibuf,
+                                            BITS_TO_BYTES(BN_num_bits(encmpi)),
+                                            &seckey->key.ecc,
+                                            &seckey->pubkey.key.ecc);
+
+        if (err != PGP_E_OK) {
+            RNP_LOG("Error in SM2 decryption");
+            return -1;
+        }
+        return out_len;
+
     case PGP_PKA_DSA:
     case PGP_PKA_ELGAMAL:
         (void) BN_bn2bin(g_to_k, gkbuf);
@@ -310,6 +327,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
         }
         break;
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         seckey->pubkey.key.ecc.curve = crypto->ecc.curve;
         if (pgp_sm2_genkeypair(seckey, seckey->pubkey.key.ecc.curve) != PGP_E_OK) {
             RNP_LOG("failed to generate SM2 key");
@@ -356,6 +374,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
     case PGP_PKA_EDDSA:
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         if (!pgp_write_mpi(output, seckey->key.ecc.x)) {
             RNP_LOG("failed to write MPIs");
             goto end;

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -174,14 +174,14 @@ pgp_decrypt_decode_mpi(uint8_t *           buf,
         BN_bn2bin(encmpi, encmpibuf);
 
         size_t out_len = buflen;
-        pgp_errcode_t err = pgp_sm2_decrypt(buf,
-                                            &out_len,
-                                            encmpibuf,
-                                            BITS_TO_BYTES(BN_num_bits(encmpi)),
-                                            &seckey->key.ecc,
-                                            &seckey->pubkey.key.ecc);
+        rnp_result err = pgp_sm2_decrypt(buf,
+                                         &out_len,
+                                         encmpibuf,
+                                         BITS_TO_BYTES(BN_num_bits(encmpi)),
+                                         &seckey->key.ecc,
+                                         &seckey->pubkey.key.ecc);
 
-        if (err != PGP_E_OK) {
+        if (err != RNP_SUCCESS) {
             RNP_LOG("Error in SM2 decryption");
             return -1;
         }
@@ -329,7 +329,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
     case PGP_PKA_SM2:
     case PGP_PKA_SM2_ENCRYPT:
         seckey->pubkey.key.ecc.curve = crypto->ecc.curve;
-        if (pgp_sm2_genkeypair(seckey, seckey->pubkey.key.ecc.curve) != PGP_E_OK) {
+        if (pgp_sm2_genkeypair(seckey, seckey->pubkey.key.ecc.curve) != RNP_SUCCESS) {
             RNP_LOG("failed to generate SM2 key");
             goto end;
         }

--- a/src/lib/crypto/sm2.c
+++ b/src/lib/crypto/sm2.c
@@ -61,6 +61,10 @@ pgp_sm2_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve)
         goto end;
     }
 
+    /*
+    * SM2 encryption and signature keys share the same form, only difference
+    * is the OID used for the X.509 encoding (which is not used by OpenPGP).
+    */
     if (botan_privkey_create(&pr_key, "SM2_Sig", ec_curves[curve].botan_name, rng)) {
         goto end;
     }
@@ -268,4 +272,125 @@ end:
     botan_pubkey_destroy(pub);
     botan_pk_op_verify_destroy(verifier);
     return ret;
+}
+
+pgp_errcode_t
+pgp_sm2_encrypt(uint8_t *               out,
+                size_t *                out_len,
+                const uint8_t *         key,
+                size_t                  key_len,
+                const pgp_ecc_pubkey_t *pubkey)
+{
+    pgp_errcode_t retval = PGP_E_FAIL;
+
+    botan_mp_t            public_x = NULL;
+    botan_mp_t            public_y = NULL;
+    botan_pubkey_t        sm2_key = NULL;
+    botan_pk_op_encrypt_t enc_op = NULL;
+    botan_rng_t           rng = NULL;
+
+    const size_t point_len = BITS_TO_BYTES(ec_curves[pubkey->curve].bitlen);
+    uint8_t      point_bytes[BITS_TO_BYTES(521) * 2 + 1] = {0};
+    uint8_t *    ctext_buf = NULL;
+
+    /*
+    * Format of SM2 ciphertext is a point (1+point_len*2) plus
+    * the masked ciphertext (out_len) plus a SM3 hash (32 bytes)
+    */
+    const size_t ctext_len = 1 + point_len * 2 + key_len + 32;
+
+    if (*out_len < ctext_len) {
+        RNP_LOG("output buffer for SM2 encryption too short");
+        goto done;
+    }
+
+    ctext_buf = malloc(ctext_len);
+    if (ctext_buf == NULL) {
+        RNP_LOG("malloc failed");
+        goto done;
+    }
+
+    if ((BN_num_bytes(pubkey->point) > sizeof(point_bytes)) ||
+        BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
+        RNP_LOG("Failed to load public key");
+        goto done;
+    }
+
+    if (botan_mp_init(&public_x) || botan_mp_init(&public_y) ||
+        botan_mp_from_bin(public_x, &point_bytes[1], point_len) ||
+        botan_mp_from_bin(public_y, &point_bytes[1 + point_len], point_len)) {
+        goto done;
+    }
+
+    const char *curve_name = ec_curves[pubkey->curve].botan_name;
+    if (botan_pubkey_load_sm2_enc(&sm2_key, public_x, public_y, curve_name)) {
+        RNP_LOG("Failed to load public key");
+        goto done;
+    }
+
+    if (botan_rng_init(&rng, NULL) != 0) {
+        goto done;
+    }
+
+    if (botan_pubkey_check_key(sm2_key, rng, 1) != 0) {
+        goto done;
+    }
+
+    /*
+    SM2 encryption doesn't have any kind of format specifier because it's
+    an all in one scheme
+    */
+    if (botan_pk_op_encrypt_create(&enc_op, sm2_key, "", 0) != 0) {
+        goto done;
+    }
+
+    if (botan_pk_op_encrypt(enc_op, rng, out, out_len, key, key_len) == 0) {
+        retval = PGP_E_OK;
+    }
+
+done:
+    free(ctext_buf);
+    botan_pk_op_encrypt_destroy(enc_op);
+    botan_pubkey_destroy(sm2_key);
+    botan_rng_destroy(rng);
+
+    return retval;
+}
+
+pgp_errcode_t
+pgp_sm2_decrypt(uint8_t *               out,
+                size_t *                out_len,
+                const uint8_t *         ctext,
+                size_t                  ctext_len,
+                const pgp_ecc_seckey_t *privkey,
+                const pgp_ecc_pubkey_t *pubkey)
+{
+    botan_pk_op_decrypt_t decrypt_op = NULL;
+    botan_privkey_t       key = NULL;
+    botan_rng_t           rng = NULL;
+    pgp_errcode_t         retval = PGP_E_FAIL;
+
+    if (botan_privkey_load_sm2_enc(
+          &key, privkey->x->mp, ec_curves[pubkey->curve].botan_name)) {
+        RNP_LOG("Can't load private key");
+        goto done;
+    }
+
+    if (botan_rng_init(&rng, NULL)) {
+        goto done;
+    }
+
+    if (botan_pk_op_decrypt_create(&decrypt_op, key, "", 0) != 0) {
+        goto done;
+    }
+
+    if (botan_pk_op_decrypt(decrypt_op, out, out_len, ctext, ctext_len) == 0) {
+        retval = PGP_E_OK;
+    }
+
+done:
+    botan_rng_destroy(rng);
+    botan_privkey_destroy(key);
+    botan_pk_op_decrypt_destroy(decrypt_op);
+    return retval;
 }

--- a/src/lib/crypto/sm2.h
+++ b/src/lib/crypto/sm2.h
@@ -42,30 +42,30 @@
  * @returns success PGP_E_OK, error code otherwise
  *
 -------------------------------------------------------------------------------- */
-pgp_errcode_t pgp_sm2_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve);
+rnp_result pgp_sm2_genkeypair(pgp_seckey_t *seckey, pgp_curve_t curve);
 
-pgp_errcode_t pgp_sm2_sign_hash(pgp_ecc_sig_t *         sign,
-                                const uint8_t *         hashbuf,
-                                size_t                  hash_len,
-                                const pgp_ecc_seckey_t *prvkey,
-                                const pgp_ecc_pubkey_t *pubkey);
+rnp_result pgp_sm2_sign_hash(pgp_ecc_sig_t *         sign,
+                             const uint8_t *         hashbuf,
+                             size_t                  hash_len,
+                             const pgp_ecc_seckey_t *prvkey,
+                             const pgp_ecc_pubkey_t *pubkey);
 
-pgp_errcode_t pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
-                                  const uint8_t *         hash,
-                                  size_t                  hash_len,
-                                  const pgp_ecc_pubkey_t *pubkey);
+rnp_result pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
+                               const uint8_t *         hash,
+                               size_t                  hash_len,
+                               const pgp_ecc_pubkey_t *pubkey);
 
-pgp_errcode_t pgp_sm2_encrypt(uint8_t *               out,
-                              size_t *                out_len,
-                              const uint8_t *         key,
-                              size_t                  key_len,
-                              const pgp_ecc_pubkey_t *pubkey);
+rnp_result pgp_sm2_encrypt(uint8_t *               out,
+                           size_t *                out_len,
+                           const uint8_t *         key,
+                           size_t                  key_len,
+                           const pgp_ecc_pubkey_t *pubkey);
 
-pgp_errcode_t pgp_sm2_decrypt(uint8_t *               out,
-                              size_t *                out_len,
-                              const uint8_t *         ciphertext,
-                              size_t                  ciphertext_len,
-                              const pgp_ecc_seckey_t *privkey,
-                              const pgp_ecc_pubkey_t *pubkey);
+rnp_result pgp_sm2_decrypt(uint8_t *               out,
+                           size_t *                out_len,
+                           const uint8_t *         ciphertext,
+                           size_t                  ciphertext_len,
+                           const pgp_ecc_seckey_t *privkey,
+                           const pgp_ecc_pubkey_t *pubkey);
 
 #endif // SM2_H_

--- a/src/lib/crypto/sm2.h
+++ b/src/lib/crypto/sm2.h
@@ -34,7 +34,7 @@
 #include "packet.h"
 
 /* -----------------------------------------------------------------------------
- * @brief   Generate SM2 keypair
+ * @brief   Generate SM2 keypair (can be used for either encryption or signing)
  *
  * @param   seckey[out] private part of the key
  * @param   curve       underlying ECC curve ID
@@ -55,4 +55,17 @@ pgp_errcode_t pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
                                   size_t                  hash_len,
                                   const pgp_ecc_pubkey_t *pubkey);
 
-#endif // EC_H_
+pgp_errcode_t pgp_sm2_encrypt(uint8_t *               out,
+                              size_t *                out_len,
+                              const uint8_t *         key,
+                              size_t                  key_len,
+                              const pgp_ecc_pubkey_t *pubkey);
+
+pgp_errcode_t pgp_sm2_decrypt(uint8_t *               out,
+                              size_t *                out_len,
+                              const uint8_t *         ciphertext,
+                              size_t                  ciphertext_len,
+                              const pgp_ecc_seckey_t *privkey,
+                              const pgp_ecc_pubkey_t *pubkey);
+
+#endif // SM2_H_

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -127,6 +127,7 @@ keygen_merge_crypto_defaults(rnp_keygen_crypto_params_t *crypto)
         break;
 
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         if (!crypto->hash_alg) {
             crypto->hash_alg = PGP_HASH_SM3;
         }
@@ -212,6 +213,7 @@ get_numbits(const rnp_keygen_crypto_params_t *crypto)
     case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         return ec_curves[crypto->ecc.curve].bitlen;
     default:
         return 0;

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -86,6 +86,7 @@ __RCSID("$NetBSD: create.c,v 1.38 2010/11/15 08:03:39 agc Exp $");
 #include "packet.h"
 #include "signature.h"
 #include "crypto/s2k.h"
+#include "crypto/sm2.h"
 #include "writer.h"
 #include "readerwriter.h"
 #include "memory.h"
@@ -171,6 +172,7 @@ pubkey_length(const pgp_pubkey_t *key)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         return 1 + // length of curve OID
                +ec_curves[key->key.ecc.curve].OIDhex_len + mpi_length(key->key.ecc.point);
 
@@ -194,6 +196,7 @@ seckey_length(const pgp_seckey_t *key)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         return mpi_length(key->key.ecc.x) + pubkey_length(&key->pubkey);
     case PGP_PKA_DSA:
         return (unsigned) (mpi_length(key->key.dsa.x) + pubkey_length(&key->pubkey));
@@ -237,6 +240,7 @@ write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         return ec_serialize_pubkey(output, &key->key.ecc);
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
@@ -316,6 +320,7 @@ hash_key_material(const pgp_seckey_t *key, uint8_t *result)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         hash_bn(&hash, key->key.ecc.x);
         break;
     case PGP_PKA_ELGAMAL:
@@ -469,6 +474,7 @@ write_seckey_body(const pgp_seckey_t *key, const uint8_t *passphrase, pgp_output
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
     case PGP_PKA_ECDH:
         if (!pgp_write_mpi(output, key->key.ecc.x))
             return false;
@@ -904,6 +910,7 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
     case PGP_PKA_DSA:
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ECDH:
+    case PGP_PKA_SM2_ENCRYPT:
         break;
     default:
         RNP_LOG("Bad public key encryption algorithm");
@@ -978,6 +985,24 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
             hexdump(stderr, "encrypted mpi", encmpibuf, n);
         }
     } break;
+
+    case PGP_PKA_SM2_ENCRYPT: {
+       uint8_t encmpibuf[RNP_BUFSIZ];
+       size_t out_len = sizeof(encmpibuf);
+       pgp_errcode_t err = pgp_sm2_encrypt(encmpibuf,
+                                           &out_len,
+                                           encoded_key,
+                                           sz_encoded_key,
+                                           &pubkey->key.ecc);
+
+       if (err != PGP_E_OK) {
+          goto done;
+       }
+
+       sesskey->params.sm2.encrypted_m = BN_bin2bn(encmpibuf, out_len, NULL);
+
+    } break;
+
 
     case PGP_PKA_ECDH: {
         uint8_t           encmpibuf[ECDH_WRAPPED_KEY_SIZE] = {0};
@@ -1078,6 +1103,16 @@ pgp_write_pk_sesskey(pgp_output_t *output, pgp_pk_sesskey_t *pksk)
                pgp_write_mpi(output, pksk->params.rsa.encrypted_m)
           /* ??    && pgp_write_scalar(output, 0, 2); */
           ;
+    case PGP_PKA_SM2_ENCRYPT:
+        return pgp_write_ptag(output, PGP_PTAG_CT_PK_SESSION_KEY) &&
+               pgp_write_length(
+                 output,
+                 (unsigned) (1 + 8 + 1 + BN_num_bytes(pksk->params.rsa.encrypted_m) + 2)) &&
+               pgp_write_scalar(output, (unsigned) pksk->version, 1) &&
+               pgp_write(output, pksk->key_id, 8) &&
+               pgp_write_scalar(output, (unsigned) pksk->alg, 1) &&
+               pgp_write_mpi(output, pksk->params.sm2.encrypted_m);
+
     case PGP_PKA_DSA:
     case PGP_PKA_ELGAMAL:
         return pgp_write_ptag(output, PGP_PTAG_CT_PK_SESSION_KEY) &&

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -989,13 +989,13 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
     case PGP_PKA_SM2_ENCRYPT: {
        uint8_t encmpibuf[RNP_BUFSIZ];
        size_t out_len = sizeof(encmpibuf);
-       pgp_errcode_t err = pgp_sm2_encrypt(encmpibuf,
-                                           &out_len,
-                                           encoded_key,
-                                           sz_encoded_key,
-                                           &pubkey->key.ecc);
+       rnp_result err = pgp_sm2_encrypt(encmpibuf,
+                                        &out_len,
+                                        encoded_key,
+                                        sz_encoded_key,
+                                        &pubkey->key.ecc);
 
-       if (err != PGP_E_OK) {
+       if (err != RNP_SUCCESS) {
           goto done;
        }
 

--- a/src/lib/packet-print.c
+++ b/src/lib/packet-print.c
@@ -352,6 +352,7 @@ numkeybits(const pgp_pubkey_t *pubkey)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         // BN_num_bytes returns value <= curve order
         return ec_curves[pubkey->key.ecc.curve].bitlen;
 
@@ -1009,6 +1010,7 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         break;
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
     case PGP_PKA_ECDH:
         cc += snprintf(&out[cc],
                        outsize - cc,
@@ -1077,6 +1079,7 @@ print_seckey_verbose(const pgp_content_enum type, const pgp_seckey_t *seckey)
     case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         print_bn(0, "x", seckey->key.ecc.x);
         break;
 

--- a/src/lib/packet-show.c
+++ b/src/lib/packet-show.c
@@ -218,6 +218,7 @@ static pgp_map_t pubkey_alg_map[] = {
   {PGP_PKA_RESERVED_DH, "Reserved for Diffie-Hellman (X9.42)"},
   {PGP_PKA_EDDSA, "EdDSA"},
   {PGP_PKA_SM2, "SM2"},
+  {PGP_PKA_SM2_ENCRYPT, "SM2 Encryption"},
   {PGP_PKA_PRIVATE00, "Private/Experimental"},
   {PGP_PKA_PRIVATE01, "Private/Experimental"},
   {PGP_PKA_PRIVATE02, "Private/Experimental"},

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -377,6 +377,7 @@ typedef enum {
                                * IETF-S/MIME) */
     PGP_PKA_EDDSA = 22,       /* EdDSA from draft-ietf-openpgp-rfc4880bis */
 
+    PGP_PKA_SM2_ENCRYPT = 98, /* SM2 encryption */
     PGP_PKA_SM2 = 99, /* SM2 signatures */
 
     PGP_PKA_PRIVATE00 = 100, /* Private/Experimental Algorithm */
@@ -847,6 +848,11 @@ typedef struct {
     BIGNUM *encrypted_m;
 } pgp_pk_sesskey_params_elgamal_t;
 
+/** pgp_pk_sesskey_params_sm2_t */
+typedef struct {
+    BIGNUM *encrypted_m;
+} pgp_pk_sesskey_params_sm2_t;
+
 /** pgp_pk_sesskey_params_elgamal_t */
 typedef struct {
     uint8_t  encrypted_m[48];  // wrapped_key
@@ -859,6 +865,7 @@ typedef union {
     pgp_pk_sesskey_params_rsa_t     rsa;
     pgp_pk_sesskey_params_elgamal_t elgamal;
     pgp_pk_sesskey_params_ecdh_t    ecdh;
+    pgp_pk_sesskey_params_sm2_t     sm2;
 } pgp_pk_sesskey_params_t;
 
 /** pgp_pk_sesskey_t */

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -720,6 +720,9 @@ pgp_pk_alg_capabilities(pgp_pubkey_alg_t alg)
     case PGP_PKA_SM2:
         return PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH;
 
+    case PGP_PKA_SM2_ENCRYPT:
+        return PGP_KF_ENCRYPT;
+
     case PGP_PKA_ECDH:
         return PGP_KF_ENCRYPT;
 

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -276,7 +276,7 @@ sm2_sign(pgp_hash_t *            hash,
         return false;
 
     /* write signature to buf */
-    if (pgp_sm2_sign_hash(&sig, hashbuf, hashsize, prv_key, pub_key) != PGP_E_OK) {
+    if (pgp_sm2_sign_hash(&sig, hashbuf, hashsize, prv_key, pub_key) != RNP_SUCCESS) {
         return false;
     }
 
@@ -436,7 +436,7 @@ pgp_check_sig(const uint8_t *     hash,
 
     case PGP_PKA_SM2:
         ret = pgp_sm2_verify_hash(&sig->info.sig.ecdsa, hash, length, &signer->key.ecc) ==
-              PGP_E_OK;
+              RNP_SUCCESS;
         break;
 
     case PGP_PKA_RSA:

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -913,6 +913,7 @@ rnp_key_store_get_key_grip(pgp_pubkey_t *key, uint8_t *grip)
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         if (!grip_hash_bignum(&hash, key->key.ecc.point)) {
             return false;
         }

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -67,6 +67,7 @@ is_keygen_supported_for_alg(pgp_pubkey_alg_t id)
     case PGP_PKA_ECDH:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
     case PGP_PKA_ECDSA:
         // Not yet really supported (at least key generation)
         //
@@ -210,6 +211,7 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
         crypto->ecc.curve = PGP_CURVE_ED25519;
         break;
     case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
         crypto->hash_alg = PGP_HASH_SM3;
         crypto->ecc.curve = PGP_CURVE_SM2_P_256;
         break;
@@ -218,6 +220,9 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
     }
     // TODO this is mostly to get tests passing
     key_desc->subkey.crypto = key_desc->primary.crypto;
+
+    if(crypto->key_alg == PGP_PKA_SM2)
+       key_desc->subkey.crypto.key_alg = PGP_PKA_SM2_ENCRYPT;
 
     return PGP_E_OK;
 }

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -626,22 +626,23 @@ ecdh_decryptionNegativeCases(void **state)
     botan_mp_destroy(tmp_eph_key);
 }
 
-void sm2_roundtrip(void** state) {
+void
+sm2_roundtrip(void **state)
+{
     rnp_test_state_t *rstate = *state;
 
-    uint8_t key[32] = { 0 };
+    uint8_t key[32] = {0};
     pgp_random(key, sizeof(key));
 
     uint8_t ctext_buf[1024];
     uint8_t decrypted[32];
-
 
     const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_SM2_ENCRYPT,
                                                  .hash_alg = PGP_HASH_SM3,
                                                  .sym_alg = PGP_SA_SM4,
                                                  .ecc = {.curve = PGP_CURVE_SM2_P_256}};
 
-    pgp_seckey_t *      sec_key = calloc(1, sizeof(*sec_key));
+    pgp_seckey_t *sec_key = calloc(1, sizeof(*sec_key));
     assert_non_null(sec_key);
     assert_true(pgp_generate_seckey(&key_desc, sec_key));
 
@@ -653,20 +654,20 @@ void sm2_roundtrip(void** state) {
     const pgp_ecc_pubkey_t *pub_ecc = &pub_key->key.ecc;
     const pgp_ecc_seckey_t *sec_ecc = &sec_key->key.ecc;
 
-    size_t ctext_size = sizeof(ctext_buf);
-    pgp_errcode_t enc_result = pgp_sm2_encrypt(ctext_buf, &ctext_size, key, sizeof(key), pub_ecc);
+    size_t        ctext_size = sizeof(ctext_buf);
+    pgp_errcode_t enc_result =
+      pgp_sm2_encrypt(ctext_buf, &ctext_size, key, sizeof(key), pub_ecc);
     rnp_assert_int_equal(rstate, enc_result, PGP_E_OK);
 
     memset(decrypted, 0, sizeof(decrypted));
-    size_t decrypted_size = sizeof(decrypted);
-    pgp_errcode_t dec_result = pgp_sm2_decrypt(decrypted, &decrypted_size, ctext_buf, ctext_size, sec_ecc, pub_ecc);
+    size_t        decrypted_size = sizeof(decrypted);
+    pgp_errcode_t dec_result =
+      pgp_sm2_decrypt(decrypted, &decrypted_size, ctext_buf, ctext_size, sec_ecc, pub_ecc);
     rnp_assert_int_equal(rstate, dec_result, PGP_E_OK);
 
     rnp_assert_int_equal(rstate, decrypted_size, sizeof(key));
-    for(size_t i = 0; i != decrypted_size; ++i)
-       rnp_assert_int_equal(rstate, key[i], decrypted[i]);
+    for (size_t i = 0; i != decrypted_size; ++i)
+        rnp_assert_int_equal(rstate, key[i], decrypted[i]);
     pgp_seckey_free(sec_key);
     free(sec_key);
-
-
 }

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -154,6 +154,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_load_user_prefs),
       cmocka_unit_test(ecdh_roundtrip),
       cmocka_unit_test(ecdh_decryptionNegativeCases),
+      cmocka_unit_test(sm2_roundtrip),
       cmocka_unit_test(test_load_v3_keyring_pgp),
       cmocka_unit_test(test_load_v4_keyring_pgp)};
 

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -81,6 +81,8 @@ void ecdh_roundtrip(void **state);
 
 void ecdh_decryptionNegativeCases(void **state);
 
+void sm2_roundtrip(void **state);
+
 void test_load_v3_keyring_pgp(void **state);
 
 void test_load_v4_keyring_pgp(void **state);


### PR DESCRIPTION
Adds support for SM2 encryption. (#127)

The SM2 ciphertext has a specific form (it's a triplet of an ECC point, the masked plaintext, and a SM3 hash that serves as an authenticator). However here it's just formatted as a BIGNUM holding an opaque block of bits. Which I think is fairly consistent with OpenPGPs approach to such things (eg using a single BIGNUM to hold ECC points).

Testing on the command line, keygen and encrypt/decrypt round trip work ok. Of course there is no other implementation to test this against. so maybe I made some dumb mistake.

I changed `rnpkeys` so SM2 signature key get an encryption subkey. I'm not totally sure this is the correct approach.
