### PR TITLE
Cleanups in symmetric cipher code

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -173,7 +173,7 @@ pgp_decrypt_decode_mpi(uint8_t *           buf,
     case PGP_PKA_SM2_ENCRYPT:
         BN_bn2bin(encmpi, encmpibuf);
 
-        size_t out_len = buflen;
+        size_t     out_len = buflen;
         rnp_result err = pgp_sm2_decrypt(buf,
                                          &out_len,
                                          encmpibuf,

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -286,7 +286,7 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
     bool          ok = false;
     pgp_output_t *output = NULL;
     pgp_memory_t *mem = NULL;
-    pgp_seckey_t seckey;
+    pgp_seckey_t  seckey;
 
     memset(&seckey, 0, sizeof(seckey));
 

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -443,10 +443,7 @@ write_seckey_body(const pgp_seckey_t *key, const uint8_t *passphrase, pgp_output
         RNP_LOG("Memory allcoation failed");
         return false;
     }
-    pgp_crypt_any(crypted, key->alg);
-    pgp_cipher_set_iv(crypted, key->iv);
-    pgp_cipher_set_key(crypted, sesskey);
-    pgp_encrypt_init(crypted);
+    pgp_cipher_start(crypted, key->alg, sesskey, key->iv);
 
     if (rnp_get_debug(__FILE__)) {
         hexdump(stderr, "writing: iv=", key->iv, pgp_block_size(key->alg));
@@ -854,7 +851,7 @@ pgp_calc_sesskey_checksum(pgp_pk_sesskey_t *sesskey, uint8_t cs[2])
 }
 
 static unsigned
-create_unencoded_m_buf(pgp_pk_sesskey_t *sesskey, pgp_crypt_t *cipherinfo, uint8_t *m_buf)
+create_unencoded_m_buf(pgp_pk_sesskey_t *sesskey, size_t cipher_key_len, uint8_t *m_buf)
 {
     unsigned i;
 
@@ -868,13 +865,13 @@ create_unencoded_m_buf(pgp_pk_sesskey_t *sesskey, pgp_crypt_t *cipherinfo, uint8
      *   m = symm_alg_ID || session key || checksum
      */
     m_buf[0] = sesskey->symm_alg;
-    for (i = 0; i < cipherinfo->keysize; i++) {
+    for (i = 0; i < cipher_key_len; i++) {
         /* XXX - Flexelint - Warning 679: Suspicious Truncation in arithmetic expression
          * combining with pointer */
         m_buf[1 + i] = sesskey->key[i];
     }
 
-    return pgp_calc_sesskey_checksum(sesskey, m_buf + 1 + cipherinfo->keysize);
+    return pgp_calc_sesskey_checksum(sesskey, m_buf + 1 + cipher_key_len);
 }
 
 /**
@@ -895,10 +892,10 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
      * can be any, we're hardcoding RSA for now
      */
 
-    pgp_crypt_t       cipherinfo;
     pgp_pk_sesskey_t *sesskey = NULL;
     uint8_t *         encoded_key = NULL;
     size_t            sz_encoded_key = 0;
+    size_t            sz_cipher_key = 0;
 
     if (pubkey == NULL) {
         (void) fprintf(stderr, "pgp_create_pk_sesskey: bad pub key\n");
@@ -917,17 +914,13 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
         return NULL;
     }
 
-    (void) memset(&cipherinfo, 0x0, sizeof(cipherinfo));
-
-    if (pgp_crypt_any(&cipherinfo, cipher) == 0) {
-        return NULL;
-    }
+    sz_cipher_key = pgp_key_size(cipher);
 
     /* allocate encoded_key here */
 
     /* The buffer stores the key plus alg_id (1 byte) + checksum (2 bytes) */
 
-    sz_encoded_key = cipherinfo.keysize + 1 + 2;
+    sz_encoded_key = sz_cipher_key + 1 + 2;
     encoded_key = calloc(1, sz_encoded_key);
     if (encoded_key == NULL) {
         (void) fprintf(stderr, "pgp_create_pk_sesskey: can't allocate\n");
@@ -945,12 +938,12 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
     }
     sesskey->alg = pubkey->alg;
     sesskey->symm_alg = cipher;
-    if (pgp_random(sesskey->key, cipherinfo.keysize)) {
+    if (pgp_random(sesskey->key, sz_cipher_key)) {
         (void) fprintf(stderr, "pgp_random failed\n");
         goto error;
     }
 
-    if (create_unencoded_m_buf(sesskey, &cipherinfo, &encoded_key[0]) == 0) {
+    if (create_unencoded_m_buf(sesskey, sz_cipher_key, &encoded_key[0]) == 0) {
         free(sesskey);
         sesskey = NULL;
         goto done;
@@ -958,8 +951,8 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
 
     if (rnp_get_debug(__FILE__)) {
         hexdump(stderr, "Encrypting for keyid", sesskey->key_id, sizeof(sesskey->key_id));
-        hexdump(stderr, "sesskey created", sesskey->key, cipherinfo.keysize);
-        hexdump(stderr, "encoded key buf", encoded_key, cipherinfo.keysize + 1 + 2);
+        hexdump(stderr, "sesskey created", sesskey->key, sz_cipher_key);
+        hexdump(stderr, "encoded key buf", encoded_key, sz_cipher_key + 1 + 2);
     }
 
     /* and encrypt it */
@@ -1274,45 +1267,6 @@ pgp_filewrite(const char *   filename,
     }
 
     return (close(fd) == 0);
-}
-
-/**
-\ingroup Core_WritePackets
-\brief Write Symmetrically Encrypted packet
-\param data Data to encrypt
-\param len Length of data
-\param output Write settings
-\return 1 if OK; else 0
-\note Hard-coded to use AES256
-*/
-unsigned
-pgp_write_symm_enc_data(const uint8_t *data, const int len, pgp_output_t *output)
-{
-    pgp_crypt_t crypt_info;
-    uint8_t *   encrypted = (uint8_t *) NULL;
-    size_t      encrypted_sz;
-    int         done = 0;
-
-    /* \todo assume AES256 for now */
-    pgp_crypt_any(&crypt_info, PGP_SA_AES_256);
-    pgp_encrypt_init(&crypt_info);
-
-    encrypted_sz = (size_t)(len + crypt_info.blocksize + 2);
-    if ((encrypted = calloc(1, encrypted_sz)) == NULL) {
-        (void) fprintf(stderr, "can't allocate %" PRIsize "d\n", encrypted_sz);
-        return false;
-    }
-
-    done = (int) pgp_encrypt_se(&crypt_info, encrypted, data, (unsigned) len);
-    if (done != len) {
-        (void) fprintf(stderr, "pgp_write_symm_enc_data: done != len\n");
-        free(encrypted);
-        return false;
-    }
-
-    return pgp_write_ptag(output, PGP_PTAG_CT_SE_DATA) &&
-           pgp_write_length(output, (unsigned) (1 + encrypted_sz)) &&
-           pgp_write(output, data, (unsigned) len);
 }
 
 /**

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -107,7 +107,6 @@ bool pgp_write_xfer_anykey(
 
 unsigned pgp_write_userid(const uint8_t *, pgp_output_t *);
 unsigned pgp_fileread_litdata(const char *, const pgp_litdata_enum, pgp_output_t *);
-unsigned pgp_write_symm_enc_data(const uint8_t *, const int, pgp_output_t *);
 
 bool pgp_write_selfsig_cert(pgp_output_t *               output,
                             const pgp_seckey_t *         seckey,

--- a/src/lib/packet-parse.c
+++ b/src/lib/packet-parse.c
@@ -2669,13 +2669,12 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
 
         pgp_forget(passphrase, strlen(passphrase));
 
-        pgp_crypt_any(&decrypt, pkt.u.seckey.alg);
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "input iv", pkt.u.seckey.iv, pgp_block_size(pkt.u.seckey.alg));
             hexdump(stderr, "key", derived_key, keysize);
         }
-        pgp_cipher_set_iv(&decrypt, pkt.u.seckey.iv);
-        pgp_cipher_set_key(&decrypt, derived_key);
+
+        pgp_cipher_start(&decrypt, pkt.u.seckey.alg, derived_key, pkt.u.seckey.iv);
 
         /* now read encrypted data */
 
@@ -2836,7 +2835,6 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
     const pgp_seckey_t *secret;
     pgp_packet_t        sesskey;
     pgp_packet_t        pkt;
-    uint8_t *           iv;
     uint8_t             c = 0x0;
     uint8_t             cs[2];
     unsigned            k;
@@ -3017,16 +3015,8 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
         (void) fprintf(stderr, "got pk session key via callback\n");
     }
 
-    pgp_crypt_any(&stream->decrypt, pkt.u.pk_sesskey.symm_alg);
-    iv = calloc(1, stream->decrypt.blocksize);
-    if (iv == NULL) {
-        (void) fprintf(stderr, "parse_pk_sesskey: bad alloc\n");
-        return false;
-    }
-    pgp_cipher_set_iv(&stream->decrypt, iv);
-    pgp_cipher_set_key(&stream->decrypt, pkt.u.pk_sesskey.key);
-    pgp_encrypt_init(&stream->decrypt);
-    free(iv);
+    pgp_cipher_start(&stream->decrypt, pkt.u.pk_sesskey.symm_alg, pkt.u.pk_sesskey.key, NULL);
+
     return true;
 }
 
@@ -3040,7 +3030,7 @@ decrypt_se_data(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream
     decrypt = pgp_get_decrypt(stream);
     if (decrypt) {
         pgp_region_t encregion;
-        unsigned     b = (unsigned) decrypt->blocksize;
+        unsigned     b = (unsigned) pgp_cipher_block_size(decrypt);
         uint8_t      buf[PGP_MAX_BLOCK_SIZE + 2] = "";
 
         pgp_reader_push_decrypt(stream, decrypt, region);

--- a/src/lib/packet-parse.h
+++ b/src/lib/packet-parse.h
@@ -110,7 +110,6 @@ typedef void pgp_reader_destroyer_t(pgp_reader_t *);
 
 void         pgp_stream_delete(pgp_stream_t *);
 pgp_error_t *pgp_stream_get_errors(pgp_stream_t *);
-pgp_crypt_t *pgp_get_decrypt(pgp_stream_t *);
 
 void  pgp_set_callback(pgp_stream_t *, pgp_cbfunc_t *, void *);
 void  pgp_callback_push(pgp_stream_t *, pgp_cbfunc_t *, void *);

--- a/src/lib/packet.h
+++ b/src/lib/packet.h
@@ -378,7 +378,7 @@ typedef enum {
     PGP_PKA_EDDSA = 22,       /* EdDSA from draft-ietf-openpgp-rfc4880bis */
 
     PGP_PKA_SM2_ENCRYPT = 98, /* SM2 encryption */
-    PGP_PKA_SM2 = 99, /* SM2 signatures */
+    PGP_PKA_SM2 = 99,         /* SM2 signatures */
 
     PGP_PKA_PRIVATE00 = 100, /* Private/Experimental Algorithm */
     PGP_PKA_PRIVATE01 = 101, /* Private/Experimental Algorithm */

--- a/src/lib/reader.c
+++ b/src/lib/reader.c
@@ -1345,6 +1345,12 @@ encrypted_data_reader(pgp_stream_t *stream,
 
     encrypted = pgp_reader_get_arg(readinfo);
     saved = (int) length;
+
+    if (!pgp_is_sa_supported(encrypted->decrypt->alg)) {
+        RNP_LOG("Unsupported symmetric cipher algorithm");
+        return 0;
+    }
+
     /*
      * V3 MPIs have the count plain and the cipher is reset after each
      * count
@@ -1412,8 +1418,8 @@ encrypted_data_reader(pgp_stream_t *stream,
                 return -1;
             }
             if (!readinfo->parent->reading_v3_secret || !readinfo->parent->reading_mpi_len) {
-                encrypted->c =
-                  pgp_decrypt_se_ip(encrypted->decrypt, encrypted->decrypted, buffer, n);
+                pgp_cipher_cfb_decrypt(encrypted->decrypt, encrypted->decrypted, buffer, n);
+                encrypted->c = n;
 
                 if (rnp_get_debug(__FILE__)) {
                     hexdump(stderr, "encrypted", buffer, 16);
@@ -1457,7 +1463,6 @@ pgp_reader_push_decrypt(pgp_stream_t *stream, pgp_crypt_t *decrypt, pgp_region_t
     } else {
         encrypted->decrypt = decrypt;
         encrypted->region = region;
-        pgp_decrypt_init(encrypted->decrypt);
         if (!pgp_reader_push(
               stream, encrypted_data_reader, encrypted_data_destroyer, encrypted)) {
             free(encrypted);
@@ -1521,7 +1526,6 @@ se_ip_data_reader(pgp_stream_t *stream,
         uint8_t *  mdc;
         uint8_t *  mdc_hash;
         pgp_hash_t hash = {0};
-        size_t     b;
         size_t     sz_preamble;
         size_t     sz_mdc_hash;
         size_t     sz_mdc;
@@ -1553,18 +1557,19 @@ se_ip_data_reader(pgp_stream_t *stream,
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "SE IP packet", buf, decrypted_region.length);
         }
+        const size_t blocksize = pgp_cipher_block_size(se_ip->decrypt);
+
         /* verify leading preamble */
         if (rnp_get_debug(__FILE__)) {
-            hexdump(stderr, "preamble", buf, se_ip->decrypt->blocksize);
+            hexdump(stderr, "preamble", buf, blocksize);
         }
-        b = se_ip->decrypt->blocksize;
-        if (buf[b - 2] != buf[b] || buf[b - 1] != buf[b + 1]) {
+        if (buf[blocksize - 2] != buf[blocksize] || buf[blocksize - 1] != buf[blocksize + 1]) {
             fprintf(stderr,
                     "Bad symmetric decrypt (%02x%02x vs %02x%02x)\n",
-                    buf[b - 2],
-                    buf[b - 1],
-                    buf[b],
-                    buf[b + 1]);
+                    buf[blocksize - 2],
+                    buf[blocksize - 1],
+                    buf[blocksize],
+                    buf[blocksize + 1]);
             PGP_ERROR_1(errors,
                         PGP_E_PROTO_BAD_SYMMETRIC_DECRYPT,
                         "%s",
@@ -1575,7 +1580,7 @@ se_ip_data_reader(pgp_stream_t *stream,
         }
         /* Verify trailing MDC hash */
 
-        sz_preamble = se_ip->decrypt->blocksize + 2;
+        sz_preamble = blocksize + 2;
         sz_mdc_hash = PGP_SHA1_HASH_SIZE;
         sz_mdc = 1 + 1 + sz_mdc_hash;
         sz_plaintext = (decrypted_region.length - sz_preamble) - sz_mdc;

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -335,12 +335,12 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
             int count = json_object_array_length(tmp);
             for (int i = 0; i < count; i++) {
                 json_object *str = json_object_array_get_idx(tmp, i);
-                char buff[2] = {0};
+                char         buff[2] = {0};
                 buff[0] = toupper(*json_object_get_string(str));
                 p(fp, buff, NULL);
             }
             p(fp, "]", NULL);
-         }
+        }
 
         if (json_object_object_get_ex(obj, "duration", &tmp)) {
             duration = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
@@ -469,7 +469,7 @@ formatbignum(char *buffer, BIGNUM *bn)
 static bool
 find_passphrase(FILE *passfp, const char *id, char *passphrase, size_t size, int attempts)
 {
-    char  prompt[BUFSIZ];
+    char prompt[BUFSIZ];
 
     if (passfp) {
         memset(passphrase, 0, size);

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -222,30 +222,6 @@ pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     return 0;
 }
 
-size_t
-pgp_encrypt_se(pgp_crypt_t *encrypt, void *outvoid, const void *invoid, size_t count)
-{
-    const size_t   saved_count = count;
-    const uint8_t *in = invoid;
-    uint8_t *      out = outvoid;
-
-    /*
-     * in order to support v3's weird resyncing we have to implement CFB
-     * mode ourselves
-     */
-    while (count-- > 0) {
-        if (encrypt->offset == encrypt->blocksize) {
-            (void) memcpy(encrypt->siv, encrypt->civ, encrypt->blocksize);
-            botan_block_cipher_encrypt_blocks(encrypt->obj, encrypt->civ, encrypt->civ, 1);
-            encrypt->offset = 0;
-        }
-        encrypt->civ[encrypt->offset] = *out++ = encrypt->civ[encrypt->offset] ^ *in++;
-        ++encrypt->offset;
-    }
-
-    return saved_count;
-}
-
 pgp_symm_alg_t
 pgp_cipher_alg_id(pgp_crypt_t *cipher)
 {

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -48,152 +48,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "crypto.h"
 #include "config.h"
-
-#ifdef HAVE_SYS_CDEFS_H
-#include <sys/cdefs.h>
-#endif
-
-#if defined(__NetBSD__)
-__COPYRIGHT("@(#) Copyright (c) 2009 The NetBSD Foundation, Inc. All rights reserved.");
-__RCSID("$NetBSD: symmetric.c,v 1.18 2010/11/07 08:39:59 agc Exp $");
-#endif
+#include <rnp/rnp_sdk.h>
 
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
-
 #include <botan/ffi.h>
 
-#include "crypto.h"
-#include "packet-show.h"
-#include "utils.h"
-#include <rnp/rnp_sdk.h>
-
-int
-pgp_cipher_set_iv(pgp_crypt_t *cipher, const uint8_t *iv)
-{
-    (void) memcpy(cipher->iv, iv, cipher->blocksize);
-    cipher->num = 0;
-    return 0;
-}
-
-int
-pgp_cipher_set_key(pgp_crypt_t *cipher, const uint8_t *key)
-{
-    (void) memcpy(cipher->key, key, cipher->keysize);
-    return 0;
-}
-
-int
-pgp_cipher_cfb_resync(pgp_crypt_t *decrypt)
-{
-    if ((size_t) decrypt->num == decrypt->blocksize) {
-        return 0;
-    }
-
-    memmove(
-      decrypt->civ + decrypt->blocksize - decrypt->num, decrypt->civ, (unsigned) decrypt->num);
-    (void) memcpy(
-      decrypt->civ, decrypt->siv + decrypt->num, decrypt->blocksize - decrypt->num);
-    decrypt->num = 0;
-    return 0;
-}
-
-int
-pgp_cipher_finish(pgp_crypt_t *crypt)
-{
-    if (crypt->block_cipher_obj) {
-        botan_block_cipher_destroy(crypt->block_cipher_obj);
-        crypt->block_cipher_obj = NULL;
-    }
-    return 0;
-}
-
-int
-pgp_cipher_block_encrypt(const pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
-{
-    if (botan_block_cipher_encrypt_blocks(crypt->block_cipher_obj, in, out, 1) == 0)
-        return 0;
-    return -1;
-}
-
-int
-pgp_cipher_block_decrypt(const pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
-{
-    if (botan_block_cipher_decrypt_blocks(crypt->block_cipher_obj, in, out, 1) == 0)
-        return 0;
-    return -1;
-}
-
-int
-pgp_cipher_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
-{
-    for (size_t i = 0; i < bytes; ++i) {
-        if (crypt->num == 0) {
-            botan_block_cipher_encrypt_blocks(
-              crypt->block_cipher_obj, crypt->iv, crypt->iv, 1);
-        }
-        out[i] = in[i] ^ crypt->iv[crypt->num];
-        crypt->iv[crypt->num] = out[i];
-
-        crypt->num = (crypt->num + 1) % crypt->blocksize;
-    }
-    return 0;
-}
-
-int
-pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
-{
-    for (size_t i = 0; i < bytes; ++i) {
-        uint8_t ciphertext = in[i];
-
-        if (crypt->num == 0) {
-            botan_block_cipher_encrypt_blocks(
-              crypt->block_cipher_obj, crypt->iv, crypt->iv, 1);
-        }
-
-        out[i] = in[i] ^ crypt->iv[crypt->num];
-        crypt->iv[crypt->num] = ciphertext;
-
-        crypt->num = (crypt->num + 1) % crypt->blocksize;
-    }
-    return 0;
-}
-
-/* structure to map string to cipher def */
-typedef struct str2cipher_t {
-    const char *   s; /* cipher name */
-    pgp_symm_alg_t i; /* cipher def */
-} str2cipher_t;
-
-static str2cipher_t str2cipher[] = {{"cast5", PGP_SA_CAST5},
-                                    {"idea", PGP_SA_IDEA},
-                                    {"blowfish", PGP_SA_BLOWFISH},
-                                    {"twofish", PGP_SA_TWOFISH},
-                                    {"sm4", PGP_SA_SM4},
-                                    {"aes128", PGP_SA_AES_128},
-                                    {"aes192", PGP_SA_AES_192},
-                                    {"aes256", PGP_SA_AES_256},
-                                    {"camellia128", PGP_SA_CAMELLIA_128},
-                                    {"camellia192", PGP_SA_CAMELLIA_192},
-                                    {"camellia256", PGP_SA_CAMELLIA_256},
-                                    {"tripledes", PGP_SA_TRIPLEDES},
-                                    {NULL, 0}};
-
-/* convert from a string to a cipher definition */
-pgp_symm_alg_t
-pgp_str_to_cipher(const char *cipher)
-{
-    str2cipher_t *sp;
-
-    for (sp = str2cipher; cipher && sp->s; sp++) {
-        if (rnp_strcasecmp(cipher, sp->s) == 0) {
-            return sp->i;
-        }
-    }
-    return PGP_SA_DEFAULT_CIPHER;
-}
+//#include "utils.h"
 
 static const char *
 pgp_sa_to_botan_string(pgp_symm_alg_t alg)
@@ -256,24 +121,183 @@ pgp_sa_to_botan_string(pgp_symm_alg_t alg)
 }
 
 bool
-pgp_crypt_any(pgp_crypt_t *crypt, pgp_symm_alg_t alg)
+pgp_cipher_start(pgp_crypt_t *crypt, pgp_symm_alg_t alg, const uint8_t *key, const uint8_t *iv)
 {
+    memset(crypt, 0x0, sizeof(*crypt));
+
     const char *cipher_name = pgp_sa_to_botan_string(alg);
     if (cipher_name == NULL)
         return false;
 
-    memset(crypt, 0x0, sizeof(*crypt));
-
+    crypt->num = 0;
     crypt->alg = alg;
     crypt->blocksize = pgp_block_size(alg);
-    crypt->keysize = pgp_key_size(alg);
 
+    // This shouldn't happen if pgp_sa_to_botan_string returned a ptr
     if (botan_block_cipher_init(&(crypt->block_cipher_obj), cipher_name) != 0) {
         (void) fprintf(stderr, "Block cipher '%s' not available\n", cipher_name);
         return false;
     }
 
+    const size_t keysize = pgp_key_size(alg);
+
+    if (botan_block_cipher_set_key(crypt->block_cipher_obj, key, keysize) != 0) {
+        (void) fprintf(stderr, "Failure setting key on block cipher object\n");
+        return false;
+    }
+
+    if (iv != NULL) {
+        // Otherwise left as all zeros via memset at start of function
+        memcpy(crypt->iv, iv, crypt->blocksize);
+    }
+
+    pgp_cipher_block_encrypt(crypt, crypt->siv, crypt->iv);
+    (void) memcpy(crypt->civ, crypt->siv, crypt->blocksize);
     return true;
+}
+
+int
+pgp_cipher_cfb_resync(pgp_crypt_t *decrypt)
+{
+    if ((size_t) decrypt->num == decrypt->blocksize) {
+        return 0;
+    }
+
+    memmove(
+      decrypt->civ + decrypt->blocksize - decrypt->num, decrypt->civ, (unsigned) decrypt->num);
+    (void) memcpy(
+      decrypt->civ, decrypt->siv + decrypt->num, decrypt->blocksize - decrypt->num);
+    decrypt->num = 0;
+    return 0;
+}
+
+int
+pgp_cipher_finish(pgp_crypt_t *crypt)
+{
+    if (crypt->block_cipher_obj) {
+        botan_block_cipher_destroy(crypt->block_cipher_obj);
+        crypt->block_cipher_obj = NULL;
+    }
+    return 0;
+}
+
+int
+pgp_cipher_block_encrypt(const pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in)
+{
+    if (botan_block_cipher_encrypt_blocks(crypt->block_cipher_obj, in, out, 1) == 0)
+        return 0;
+    return -1;
+}
+
+int
+pgp_cipher_cfb_encrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
+{
+    for (size_t i = 0; i < bytes; ++i) {
+        if (crypt->num == 0) {
+            botan_block_cipher_encrypt_blocks(
+              crypt->block_cipher_obj, crypt->iv, crypt->iv, 1);
+        }
+        out[i] = in[i] ^ crypt->iv[crypt->num];
+        crypt->iv[crypt->num] = out[i];
+
+        crypt->num = (crypt->num + 1) % crypt->blocksize;
+    }
+    return 0;
+}
+
+int
+pgp_cipher_cfb_decrypt(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t bytes)
+{
+    for (size_t i = 0; i < bytes; ++i) {
+        uint8_t ciphertext = in[i];
+
+        if (crypt->num == 0) {
+            botan_block_cipher_encrypt_blocks(
+              crypt->block_cipher_obj, crypt->iv, crypt->iv, 1);
+        }
+
+        out[i] = in[i] ^ crypt->iv[crypt->num];
+        crypt->iv[crypt->num] = ciphertext;
+
+        crypt->num = (crypt->num + 1) % crypt->blocksize;
+    }
+    return 0;
+}
+
+size_t
+pgp_encrypt_se(pgp_crypt_t *encrypt, void *outvoid, const void *invoid, size_t count)
+{
+    const uint8_t *in = invoid;
+    uint8_t *      out = outvoid;
+    int            saved = (int) count;
+
+    /*
+     * in order to support v3's weird resyncing we have to implement CFB
+     * mode ourselves
+     */
+    while (count-- > 0) {
+        if ((size_t) encrypt->num == encrypt->blocksize) {
+            (void) memcpy(encrypt->siv, encrypt->civ, encrypt->blocksize);
+            pgp_cipher_block_encrypt(encrypt, encrypt->civ, encrypt->civ);
+            encrypt->num = 0;
+        }
+        encrypt->civ[encrypt->num] = *out++ = encrypt->civ[encrypt->num] ^ *in++;
+        ++encrypt->num;
+    }
+
+    return (size_t) saved;
+}
+
+pgp_symm_alg_t
+pgp_cipher_alg_id(pgp_crypt_t *cipher)
+{
+    return cipher->alg;
+}
+
+int
+pgp_cipher_block_size(pgp_crypt_t *cipher)
+{
+    return pgp_block_size(pgp_cipher_alg_id(cipher));
+}
+
+int
+pgp_cipher_key_size(pgp_crypt_t *cipher)
+{
+    return pgp_key_size(pgp_cipher_alg_id(cipher));
+}
+
+/* structure to map string to cipher def */
+typedef struct str2cipher_t {
+    const char *   s; /* cipher name */
+    pgp_symm_alg_t i; /* cipher def */
+} str2cipher_t;
+
+static str2cipher_t str2cipher[] = {{"cast5", PGP_SA_CAST5},
+                                    {"idea", PGP_SA_IDEA},
+                                    {"blowfish", PGP_SA_BLOWFISH},
+                                    {"twofish", PGP_SA_TWOFISH},
+                                    {"sm4", PGP_SA_SM4},
+                                    {"aes128", PGP_SA_AES_128},
+                                    {"aes192", PGP_SA_AES_192},
+                                    {"aes256", PGP_SA_AES_256},
+                                    {"camellia128", PGP_SA_CAMELLIA_128},
+                                    {"camellia192", PGP_SA_CAMELLIA_192},
+                                    {"camellia256", PGP_SA_CAMELLIA_256},
+                                    {"tripledes", PGP_SA_TRIPLEDES},
+                                    {NULL, 0}};
+
+/* convert from a string to a cipher definition */
+pgp_symm_alg_t
+pgp_str_to_cipher(const char *cipher)
+{
+    str2cipher_t *sp;
+
+    for (sp = str2cipher; cipher && sp->s; sp++) {
+        if (rnp_strcasecmp(cipher, sp->s) == 0) {
+            return sp->i;
+        }
+    }
+    return PGP_SA_DEFAULT_CIPHER;
 }
 
 unsigned
@@ -334,77 +358,6 @@ pgp_key_size(pgp_symm_alg_t alg)
     }
 }
 
-bool
-pgp_encrypt_init(pgp_crypt_t *encrypt)
-{
-    /* \todo should there be a separate pgp_encrypt_init? */
-    return pgp_decrypt_init(encrypt);
-}
-
-bool
-pgp_decrypt_init(pgp_crypt_t *crypt)
-{
-    if (botan_block_cipher_set_key(crypt->block_cipher_obj, crypt->key, crypt->keysize) != 0) {
-        (void) fprintf(stderr, "Failure setting key on block cipher object\n");
-        return false;
-    }
-
-    pgp_cipher_block_encrypt(crypt, crypt->siv, crypt->iv);
-    (void) memcpy(crypt->civ, crypt->siv, crypt->blocksize);
-    crypt->num = 0;
-    return true;
-}
-
-size_t
-pgp_decrypt_se(pgp_crypt_t *decrypt, void *outvoid, const void *invoid, size_t count)
-{
-    const uint8_t *in = invoid;
-    uint8_t *      out = outvoid;
-    int            saved = (int) count;
-
-    /*
-     * in order to support v3's weird resyncing we have to implement CFB
-     * mode ourselves
-     */
-    while (count-- > 0) {
-        uint8_t t;
-
-        if ((size_t) decrypt->num == decrypt->blocksize) {
-            (void) memcpy(decrypt->siv, decrypt->civ, decrypt->blocksize);
-            pgp_cipher_block_decrypt(decrypt, decrypt->civ, decrypt->civ);
-            decrypt->num = 0;
-        }
-        t = decrypt->civ[decrypt->num];
-        *out++ = t ^ (decrypt->civ[decrypt->num++] = *in++);
-    }
-
-    return (size_t) saved;
-}
-
-size_t
-pgp_encrypt_se(pgp_crypt_t *encrypt, void *outvoid, const void *invoid, size_t count)
-{
-    const uint8_t *in = invoid;
-    uint8_t *      out = outvoid;
-    int            saved = (int) count;
-
-    /*
-     * in order to support v3's weird resyncing we have to implement CFB
-     * mode ourselves
-     */
-    while (count-- > 0) {
-        if ((size_t) encrypt->num == encrypt->blocksize) {
-            (void) memcpy(encrypt->siv, encrypt->civ, encrypt->blocksize);
-            pgp_cipher_block_encrypt(encrypt, encrypt->civ, encrypt->civ);
-            encrypt->num = 0;
-        }
-        encrypt->civ[encrypt->num] = *out++ = encrypt->civ[encrypt->num] ^ *in++;
-        ++encrypt->num;
-    }
-
-    return (size_t) saved;
-}
-
 /**
 \ingroup HighLevel_Supported
 \brief Is this Symmetric Algorithm supported?
@@ -418,32 +371,6 @@ pgp_is_sa_supported(pgp_symm_alg_t alg)
     if (cipher_name != NULL)
         return true;
 
-    fprintf(stderr, "\nWarning: %s not supported\n", pgp_show_symm_alg(alg));
+    fprintf(stderr, "\nWarning: cipher %d not supported", (int) alg);
     return false;
-}
-
-size_t
-pgp_encrypt_se_ip(pgp_crypt_t *crypt, void *out, const void *in, size_t count)
-{
-    if (!pgp_is_sa_supported(crypt->alg)) {
-        return 0;
-    }
-
-    pgp_cipher_cfb_encrypt(crypt, out, in, count);
-
-    /* \todo test this number was encrypted */
-    return count;
-}
-
-size_t
-pgp_decrypt_se_ip(pgp_crypt_t *crypt, void *out, const void *in, size_t count)
-{
-    if (!pgp_is_sa_supported(crypt->alg)) {
-        return 0;
-    }
-
-    pgp_cipher_cfb_decrypt(crypt, out, in, count);
-
-    /* \todo check this number was in fact decrypted */
-    return count;
 }

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -54,16 +54,15 @@
 
 /** pgp_crypt_t */
 struct pgp_crypt_t {
-    pgp_symm_alg_t alg;
-    size_t         blocksize;
-    size_t         num; // offset for CFB
+    pgp_symm_alg_t                    alg;
+    size_t                            blocksize;
+    size_t                            offset; // offset for CFB
+    struct botan_block_cipher_struct *obj;
 
     uint8_t iv[PGP_MAX_BLOCK_SIZE];
     uint8_t civ[PGP_MAX_BLOCK_SIZE];
     uint8_t siv[PGP_MAX_BLOCK_SIZE];
     /* siv is needed for weird v3 resync */
-
-    struct botan_block_cipher_struct *block_cipher_obj;
 };
 
 pgp_symm_alg_t pgp_str_to_cipher(const char *name);
@@ -84,17 +83,14 @@ bool pgp_cipher_start(pgp_crypt_t *  cipher,
 int pgp_cipher_finish(pgp_crypt_t *cipher);
 
 int pgp_cipher_block_size(pgp_crypt_t *cipher);
-int pgp_cipher_key_size(pgp_crypt_t *cipher);
 pgp_symm_alg_t pgp_cipher_alg_id(pgp_crypt_t *cipher);
-
-// Encrypt a single block
-int pgp_cipher_block_encrypt(const pgp_crypt_t *cipher, uint8_t *out, const uint8_t *in);
 
 // CFB encryption/decryption
 int pgp_cipher_cfb_encrypt(pgp_crypt_t *cipher, uint8_t *out, const uint8_t *in, size_t len);
 int pgp_cipher_cfb_decrypt(pgp_crypt_t *cipher, uint8_t *out, const uint8_t *in, size_t len);
 
 int pgp_cipher_cfb_resync(pgp_crypt_t *cipher);
+int pgp_cipher_cfb_resync_v2(pgp_crypt_t *cipher);
 
 // Higher level operations
 size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -92,8 +92,4 @@ int pgp_cipher_cfb_decrypt(pgp_crypt_t *cipher, uint8_t *out, const uint8_t *in,
 int pgp_cipher_cfb_resync(pgp_crypt_t *cipher);
 int pgp_cipher_cfb_resync_v2(pgp_crypt_t *cipher);
 
-// Higher level operations
-size_t pgp_encrypt_se(pgp_crypt_t *, void *, const void *, size_t);
-size_t pgp_decrypt_se_ip(pgp_crypt_t *, void *, const void *, size_t);
-
 #endif

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -537,9 +537,9 @@ pgp_writer_push_clearsigned(pgp_output_t *output, pgp_create_sig_t *sig)
  * \struct base64_t
  */
 typedef struct {
-    unsigned pos;
-    uint8_t  t;
-    unsigned checksum;
+    unsigned         pos;
+    uint8_t          t;
+    unsigned         checksum;
     pgp_armor_type_t type;
 } base64_t;
 
@@ -635,10 +635,10 @@ armoured_message_finaliser(pgp_error_t **errors, pgp_writer_t *writer)
     static const char trl_pubkey[] = "\r\n-----END PGP PUBLIC KEY BLOCK-----\r\n";
     static const char trl_seckey[] = "\r\n-----END PGP PRIVATE KEY BLOCK-----\r\n";
     static const char trl_signature[] = "\r\n-----END PGP SIGNATURE-----\r\n";
-    
-    base64_t *        base64;
-    uint8_t           c[3];
-    const char *      trailer = NULL;
+
+    base64_t *  base64;
+    uint8_t     c[3];
+    const char *trailer = NULL;
 
     base64 = pgp_writer_get_arg(writer);
 
@@ -738,7 +738,8 @@ pgp_writer_push_armoured(pgp_output_t *output, pgp_armor_type_t type)
         if (!pgp_write(output, hdr_crlf, sizeof(hdr_crlf) - 1) ||
             !pgp_write(output, hdr_signature, sizeof(hdr_signature) - 1) ||
             !pgp_write(output, hdr_version, sizeof(hdr_version) - 1)) {
-            PGP_ERROR_1(&output->errors, PGP_E_W, "%s", "Error switching to armoured signature");
+            PGP_ERROR_1(
+              &output->errors, PGP_E_W, "%s", "Error switching to armoured signature");
             free(linebreak);
             return false;
         }
@@ -762,7 +763,8 @@ pgp_writer_push_armoured(pgp_output_t *output, pgp_armor_type_t type)
     base64->checksum = CRC24_INIT;
     base64->type = type;
 
-    if (!pgp_writer_push(output, base64_writer, armoured_message_finaliser, generic_destroyer, base64)) {
+    if (!pgp_writer_push(
+          output, base64_writer, armoured_message_finaliser, generic_destroyer, base64)) {
         free(base64);
         return false;
     }
@@ -793,10 +795,6 @@ encrypt_writer(const uint8_t *src, unsigned len, pgp_error_t **errors, pgp_write
 
     remaining = len;
     pgp_encrypt = (crypt_t *) pgp_writer_get_arg(writer);
-    if (!pgp_is_sa_supported(pgp_encrypt->crypt->alg)) {
-        (void) fprintf(stderr, "encrypt_writer: not supported\n");
-        return false;
-    }
     while (remaining > 0) {
         unsigned size = (remaining < BUFSZ) ? remaining : BUFSZ;
 
@@ -903,8 +901,14 @@ pgp_push_enc_se_ip(pgp_output_t *output, const pgp_pubkey_t *pubkey, pgp_symm_al
         return false;
     }
 
-    pgp_cipher_start(encrypted, encrypted_pk_sesskey->symm_alg,
-                     &encrypted_pk_sesskey->key[0], NULL);
+    if (!pgp_cipher_start(
+          encrypted, encrypted_pk_sesskey->symm_alg, &encrypted_pk_sesskey->key[0], NULL)) {
+        free(se_ip);
+        pgp_pk_sesskey_free(encrypted_pk_sesskey);
+        free(encrypted_pk_sesskey);
+        free(encrypted);
+        return false;
+    }
 
     se_ip->crypt = encrypted;
 
@@ -1304,8 +1308,12 @@ pgp_push_stream_enc_se_ip(pgp_output_t *      output,
         (void) fprintf(stderr, "pgp_push_stream_enc_se_ip: bad alloc\n");
         return;
     }
-    pgp_cipher_start(encrypted, encrypted_pk_sesskey->symm_alg,
-                     &encrypted_pk_sesskey->key[0], NULL);
+
+    if (!pgp_cipher_start(
+          encrypted, encrypted_pk_sesskey->symm_alg, &encrypted_pk_sesskey->key[0], NULL)) {
+        free(se_ip);
+        return;
+    }
 
     se_ip->crypt = encrypted;
 
@@ -1480,10 +1488,10 @@ stream_write_se_ip_first(pgp_output_t *   output,
                          unsigned         len,
                          str_enc_se_ip_t *se_ip)
 {
-    uint8_t *preamble;
-    size_t   preamblesize;
-    size_t   sz_towrite;
-    size_t   sz_pd;
+    uint8_t *    preamble;
+    size_t       preamblesize;
+    size_t       sz_towrite;
+    size_t       sz_pd;
     const size_t blocksize = pgp_cipher_block_size(se_ip->crypt);
 
     preamblesize = blocksize + 2;

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -422,10 +422,7 @@ ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey)
         return false;
     }
 
-    pgp_crypt_any(&crypted, key->key.seckey.alg);
-    pgp_cipher_set_iv(&crypted, key->key.seckey.iv);
-    pgp_cipher_set_key(&crypted, sesskey);
-    pgp_encrypt_init(&crypted);
+    pgp_cipher_start(&crypted, key->key.seckey.alg, sesskey, key->key.seckey.iv);
     ssh_fingerprint(&key->fingerprint, pubkey);
     ssh_keyid(key->keyid, sizeof(key->keyid), pubkey);
     return true;

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -99,14 +99,10 @@ cipher_test_success(void **state)
 
     uint8_t block[16] = {0};
     uint8_t cfb_data[20] = {0};
-
-    rnp_assert_int_equal(rstate, 1, pgp_crypt_any(&crypt, alg));
-
-    rnp_assert_int_equal(rstate, 1, pgp_encrypt_init(&crypt));
-
     memset(iv, 0x42, sizeof(iv));
 
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_set_key(&crypt, key));
+    rnp_assert_int_equal(rstate, 1, pgp_cipher_start(&crypt, alg, key, iv));
+
     rnp_assert_int_equal(rstate, 0, pgp_cipher_block_encrypt(&crypt, block, block));
 
     rnp_assert_int_equal(
@@ -115,15 +111,6 @@ cipher_test_success(void **state)
       test_value_equal(
         "AES ECB encrypt", "66E94BD4EF8A2C3B884CFA59CA342B2E", block, sizeof(block)));
 
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_block_decrypt(&crypt, block, block));
-
-    rnp_assert_int_equal(
-      rstate,
-      0,
-      test_value_equal(
-        "AES ECB decrypt", "00000000000000000000000000000000", block, sizeof(block)));
-
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_set_iv(&crypt, iv));
     rnp_assert_int_equal(
       rstate, 0, pgp_cipher_cfb_encrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data)));
 
@@ -133,8 +120,9 @@ cipher_test_success(void **state)
                                           "BFDAA57CB812189713A950AD9947887983021617",
                                           cfb_data,
                                           sizeof(cfb_data)));
+    rnp_assert_int_equal(rstate, 0, pgp_cipher_finish(&crypt));
 
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_set_iv(&crypt, iv));
+    rnp_assert_int_equal(rstate, 1, pgp_cipher_start(&crypt, alg, key, iv));
     rnp_assert_int_equal(
       rstate, 0, pgp_cipher_cfb_decrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data)));
     rnp_assert_int_equal(rstate,

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -97,19 +97,10 @@ cipher_test_success(void **state)
     pgp_symm_alg_t    alg = PGP_SA_AES_128;
     pgp_crypt_t       crypt;
 
-    uint8_t block[16] = {0};
     uint8_t cfb_data[20] = {0};
     memset(iv, 0x42, sizeof(iv));
 
     rnp_assert_int_equal(rstate, 1, pgp_cipher_start(&crypt, alg, key, iv));
-
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_block_encrypt(&crypt, block, block));
-
-    rnp_assert_int_equal(
-      rstate,
-      0,
-      test_value_equal(
-        "AES ECB encrypt", "66E94BD4EF8A2C3B884CFA59CA342B2E", block, sizeof(block)));
 
     rnp_assert_int_equal(
       rstate, 0, pgp_cipher_cfb_encrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data)));


### PR DESCRIPTION
The big change here is replacing the combination of `pgp_crypt_any`, `pgp_decrypt_init`, `pgp_cipher_set_iv` and `pgp_cipher_set_key` with the combination function `pgp_cipher_start` which does all of these operations on one go. Also while I could still not make the cipher structure opaque I at least change all code to not touch any fields in it except (in a couple of spots) `alg`.

Also removed several completely unused functions `pgp_decrypt_se`, `pgp_encrypt_se`, `pgp_write_symm_enc_data` and  `pgp_cipher_block_decrypt`, and removed `pgp_cipher_block_encrypt` since it was only called in one spot that was accessing internal structures of the cipher struct, so I hide the operation behind a new function `pgp_cipher_cfb_resync_v2` (which could use a better name).

More changes in this area coming soon but this seems like a big enough change to start.

Important question: I have long been confused by `iv`, `siv`, and `civ` arrays in the `pgp_crypt_t` struct. Logically, only one feedback register is required to implement CFB. What are the other two for? Now having removed several (already unused/never called) functions, it becomes clear that the only function which actually use `siv` or `civ` is `pgp_cipher_cfb_resync`. That is to say, resync moves a register around, but does not modify the register that is actually being used during encryption/decryption (which is `iv`). Which suggests to me that symmetric crypto is not matching OpenPGP format. Anyhow this PR shouldn't make the problem any worse than it already is.