### PR TITLE
Returns raw key if it unencrypted

### DIFF
--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -457,7 +457,16 @@ pgp_seckey_t *
 pgp_decrypt_seckey(const pgp_key_t *key, FILE *passfp)
 {
     if (key->key.seckey.decrypt_cb == NULL) {
-        return NULL;
+        pgp_seckey_t *seckey = calloc(1, sizeof(*seckey));
+        if (seckey == NULL) {
+            (void) fprintf(stderr, "can't allocate memory\n");
+            return NULL;
+        }
+
+        // copy secret key for don't crash at free when the key doesn't need anymore
+        memcpy(seckey, &key->key.seckey, sizeof(*seckey));
+
+        return seckey;
     }
 
     return key->key.seckey.decrypt_cb(key, passfp);

--- a/src/tests/exportkey.c
+++ b/src/tests/exportkey.c
@@ -40,7 +40,9 @@ rnpkeys_exportkey_verifyUserId(void **state)
     char *            exportedkey = NULL;
 
     /* Initialize the rnp structure. */
-    rnp_assert_ok(rstate, setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
+    rnp_assert_ok(
+      rstate,
+      setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd, "passwordforkeygeneration\n"));
 
     /* Generate the key */
     set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_HASH_SHA256);

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -109,13 +109,14 @@ int test_value_equal(const char *  what,
  */
 char *uint_to_string(char *buff, const int buffsize, unsigned int num, int base);
 
-bool write_pass_to_pipe(int fd, size_t count);
+bool write_pass_to_pipe(int fd, const char *password, size_t count);
 /* Setup readable pipe with default passphrase inside */
-int setupPassphrasefd(int *pipefd);
+int setupPassphrasefd(int *pipefd, const char *password);
 
 /* Common initialization of rnp structure : home path, keystore format and pointer to store
  * passphrase fd */
-int setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pipefd);
+int setup_rnp_common(
+  rnp_t *rnp, const char *ks_format, const char *homedir, int *pipefd, const char *password);
 
 /* Initialize key generation params with default values and specified hash algorithm */
 void set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc, pgp_hash_alg_t hashalg);

--- a/src/tests/user-prefs.c
+++ b/src/tests/user-prefs.c
@@ -67,7 +67,9 @@ test_load_user_prefs(void **state)
 
     paths_concat(homedir, sizeof(homedir), rstate->data_dir, "keyrings/1", NULL);
 
-    rnp_assert_ok(rstate, setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, homedir, pipefd));
+    rnp_assert_ok(
+      rstate,
+      setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, homedir, pipefd, "passwordforkeygeneration\n"));
     rnp_assert_ok(rstate, rnp_key_store_load_keys(&rnp, false));
     rnp_assert_true(rstate, rnp_secret_count(&rnp) == 0 && rnp_public_count(&rnp) == 7);
 


### PR DESCRIPTION
Without this small fix, unencrypted G10 key creates an loop:
```
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
signature  2048/RSA (Encrypt or Sign) d8dd13e2700f8be2 2017-08-18 [E] [EXPIRES 2019-08-18]
                 6ed7 1b4e 68e8 7525 57d2 49cb d8dd 13e2 700f 8be2 
Bad passphrase
^C
```