### PR TITLE
G10 keystore doesn't keep a key metadata likes `key_flags`.

### DIFF
--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1141,6 +1141,7 @@ rnp_sign_file(rnp_ctx_t * ctx,
     int                 attempts;
     int                 ret;
     int                 i;
+    unsigned            from;
 
     io = ctx->rnp->io;
     if (f == NULL) {
@@ -1154,6 +1155,12 @@ rnp_sign_file(rnp_ctx_t * ctx,
     if (!pgp_key_can_sign(keypair) &&
         !(keypair = find_suitable_subkey(keypair, PGP_KF_SIGN))) {
         RNP_LOG("this key can not sign");
+        return RNP_FAIL;
+    }
+    // key exist and might be used to sign, trying get it from secring
+    from = 0;
+    if ((keypair = rnp_key_store_get_key_by_id(
+           io, ctx->rnp->secring, keypair->keyid, &from, NULL)) == NULL) {
         return RNP_FAIL;
     }
     ret = RNP_OK;
@@ -1270,6 +1277,7 @@ rnp_sign_memory(rnp_ctx_t * ctx,
     int                 attempts;
     int                 ret;
     int                 i;
+    unsigned            from;
 
     io = ctx->rnp->io;
     if (mem == NULL) {
@@ -1282,6 +1290,12 @@ rnp_sign_memory(rnp_ctx_t * ctx,
     if (!pgp_key_can_sign(keypair) &&
         !(keypair = find_suitable_subkey(keypair, PGP_KF_SIGN))) {
         RNP_LOG("this key can not sign");
+        return RNP_FAIL;
+    }
+    // key exist and might be used to sign, trying get it from secring
+    from = 0;
+    if ((keypair = rnp_key_store_get_key_by_id(
+           io, ctx->rnp->secring, keypair->keyid, &from, NULL)) == NULL) {
         return RNP_FAIL;
     }
     ret = RNP_OK;

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1148,7 +1148,7 @@ rnp_sign_file(rnp_ctx_t * ctx,
         return RNP_FAIL;
     }
     /* get key with which to sign */
-    if ((keypair = resolve_userid(ctx->rnp, ctx->rnp->secring, userid)) == NULL) {
+    if ((keypair = resolve_userid(ctx->rnp, ctx->rnp->pubring, userid)) == NULL) {
         return RNP_FAIL;
     }
     if (!pgp_key_can_sign(keypair) &&
@@ -1276,7 +1276,7 @@ rnp_sign_memory(rnp_ctx_t * ctx,
         (void) fprintf(io->errs, "rnp_sign_memory: no memory to sign\n");
         return RNP_FAIL;
     }
-    if ((keypair = resolve_userid(ctx->rnp, ctx->rnp->secring, userid)) == NULL) {
+    if ((keypair = resolve_userid(ctx->rnp, ctx->rnp->pubring, userid)) == NULL) {
         return RNP_FAIL;
     }
     if (!pgp_key_can_sign(keypair) &&


### PR DESCRIPTION
So we can't be sure does this key can be used to signing.

This commit just switched to using pubring that is GPG or KBX and keeps metadata.