### PR TITLE
Fix decryption of V3 keys

### DIFF
--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -56,13 +56,11 @@
 struct pgp_crypt_t {
     pgp_symm_alg_t                    alg;
     size_t                            blocksize;
-    size_t                            offset; // offset for CFB
+    size_t                            remaining;
     struct botan_block_cipher_struct *obj;
 
     uint8_t iv[PGP_MAX_BLOCK_SIZE];
-    uint8_t civ[PGP_MAX_BLOCK_SIZE];
-    uint8_t siv[PGP_MAX_BLOCK_SIZE];
-    /* siv is needed for weird v3 resync */
+    uint8_t prev_iv[PGP_MAX_BLOCK_SIZE];
 };
 
 pgp_symm_alg_t pgp_str_to_cipher(const char *name);

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -1321,9 +1321,9 @@ encrypted_data_reader(pgp_stream_t *stream,
             (void) fprintf(stderr, "encrypted_data_reader: bad v3 secret\n");
             return -1;
         }
-        pgp_cipher_cfb_resync(encrypted->decrypt);
         encrypted->prevplain = 0;
     } else if (readinfo->parent->reading_v3_secret && readinfo->parent->reading_mpi_len) {
+        pgp_cipher_cfb_resync(encrypted->decrypt);
         encrypted->prevplain = 1;
     }
     while (length > 0) {
@@ -1383,11 +1383,11 @@ encrypted_data_reader(pgp_stream_t *stream,
                 encrypted->c = n;
 
                 if (rnp_get_debug(__FILE__)) {
-                    hexdump(stderr, "encrypted", buffer, 16);
-                    hexdump(stderr, "decrypted", encrypted->decrypted, 16);
+                    hexdump(stderr, "encrypted", buffer, n);
+                    hexdump(stderr, "decrypted", encrypted->decrypted, n);
                 }
             } else {
-                (void) memcpy(&encrypted->decrypted[encrypted->off], buffer, n);
+                (void) memcpy(&encrypted->decrypted[0], buffer, n);
                 encrypted->c = n;
             }
 


### PR DESCRIPTION
This took way longer than I expected because I figured it was just an issue of implementing CFB resync correctly. It turned out there were also two bugs in `reader.c` that meant reading a V3 encrypted key almost certainly never worked (including in NetPGP, based on the history).

First, the resync call happened in the wrong time, which screwed up the IVs. Additionally, when copying the unencrypted v3 MPI lengths, it copied them into an offset. So what ended up happening is RNP would interpret the first 2 bytes of the decrypted modulus (still around in the buffer at offset 0) as the length of the following MPI. This would fail due to either being a seemingly invalid length or else cause corruptions. So it seems like there is no way this could have worked.

Anyway I confirmed that with this change we can correctly decrypt the key in #403 and sign a message that gpg will verify.

CFB resync for tag=9 messages may still be broken, it doesn't seem like `rnp` supports symmetrically encrypted messages?

See #403 and #401
