### PR TITLE
Add passphrase provider framework and key locking/unlocking

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -125,7 +125,7 @@ enum key_store_format_t {
 // combinated keystores
 #define RNP_KEYSTORE_GPG21 "GPG21" /* KBX + G10 keystore format */
 
-typedef struct {
+typedef struct rnp_key_store_t {
     const char *            path;
     const char *            format_label;
     enum key_store_format_t format;

--- a/include/repgp/repgp.h
+++ b/include/repgp/repgp.h
@@ -60,10 +60,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <rekey/rnp_key_store.h>
-
+#include <json.h>
 #include "repgp_def.h"
 #include "packet.h"
+
+struct rnp_key_store_t;
 
 /** pgp_region_t */
 typedef struct pgp_region_t {
@@ -172,18 +173,39 @@ pgp_reader_func_t pgp_stacked_read;
 
 /* ----------------------------- printing -----------------------------*/
 void repgp_print_key(pgp_io_t *,
-                     const rnp_key_store_t *,
+                     const struct rnp_key_store_t *,
                      const pgp_key_t *,
                      const char *,
                      const pgp_pubkey_t *,
                      const int);
 
 int repgp_sprint_json(pgp_io_t *,
-                      const rnp_key_store_t *,
+                      const struct rnp_key_store_t *,
                       const pgp_key_t *,
                       json_object *,
                       const char *,
                       const pgp_pubkey_t *,
                       const int);
+
+typedef struct pgp_passphrase_ctx_t {
+    uint8_t             op;
+    const pgp_pubkey_t *pubkey;
+    uint8_t             key_type;
+} pgp_passphrase_ctx_t;
+
+typedef bool pgp_passphrase_callback_t(const pgp_passphrase_ctx_t *ctx,
+                                       char *                      passphrase,
+                                       size_t                      passphrase_size,
+                                       void *                      userdata);
+
+typedef struct pgp_passphrase_provider_t {
+    pgp_passphrase_callback_t *callback;
+    void *                     userdata;
+} pgp_passphrase_provider_t;
+
+bool pgp_request_passphrase(const pgp_passphrase_provider_t *provider,
+                            const pgp_passphrase_ctx_t *     ctx,
+                            char *                           passphrase,
+                            size_t                           passphrase_size);
 
 #endif /* REPGP_H_ */

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -222,11 +222,6 @@ typedef enum {
     PGP_PTAG_CT_SIGNED_CLEARTEXT_BODY = 0x300 + 7,
     PGP_PTAG_CT_SIGNED_CLEARTEXT_TRAILER = 0x300 + 8,
     PGP_PTAG_CT_UNARMOURED_TEXT = 0x300 + 9,
-    PGP_PTAG_CT_ENCRYPTED_SECRET_KEY = 0x300 + 10, /* In this case the
-                                                    * algorithm specific
-                                                    * fields will not be
-                                                    * initialised */
-    PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY = 0x300 + 11,
     PGP_PTAG_CT_SE_DATA_HEADER = 0x300 + 12,
     PGP_PTAG_CT_SE_DATA_BODY = 0x300 + 13,
     PGP_PTAG_CT_SE_IP_DATA_HEADER = 0x300 + 14,
@@ -431,5 +426,13 @@ typedef enum {
     PGP_V3 = 3, /* Version 3 */
     PGP_V4 = 4  /* Version 4 */
 } pgp_version_t;
+
+typedef enum pgp_op_t {
+    PGP_OP_UNKNOWN = 0,
+    PGP_OP_GENERATE_KEY = 1,
+    PGP_OP_SIGN = 2,
+    PGP_OP_DECRYPT = 3,
+    PGP_OP_UNLOCK = 4
+} pgp_op_t;
 
 #endif

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -91,9 +91,9 @@ int rnp_sign_file(rnp_ctx_t *, const char *, const char *, const char *, bool, b
 int rnp_verify_file(rnp_ctx_t *, const char *, const char *, int);
 
 /* memory signing and encryption */
-int rnp_sign_memory(rnp_ctx_t *, const char *, char *, size_t, char *, size_t, bool);
+int rnp_sign_memory(rnp_ctx_t *, const char *, const char *, size_t, char *, size_t, bool);
 int rnp_verify_memory(rnp_ctx_t *, const void *, const size_t, void *, size_t, const int);
-int rnp_encrypt_memory(rnp_ctx_t *, const char *, void *, const size_t, char *, size_t);
+int rnp_encrypt_memory(rnp_ctx_t *, const char *, const void *, const size_t, char *, size_t);
 int rnp_decrypt_memory(rnp_ctx_t *, const void *, const size_t, char *, size_t);
 
 /* match and hkp-related functions */

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include "packet.h"
+#include <repgp/repgp.h>
 
 /* rnp_result is the type used for return codes from the APIs. */
 typedef uint32_t rnp_result;
@@ -39,13 +40,16 @@ typedef struct rnp_t {
     void *    pubring;       /* public key ring */
     void *    secring;       /* s3kr1t key ring */
     pgp_io_t *io;            /* the io struct for results/errs */
-    void *    user_input_fp; /* file pointer for password input */
+    void *    user_input_fp; /* file pointer for user input */
+    void *    passfp;        /* file pointer for password input */
     char *    defkey;        /* default key id */
     int       pswdtries;     /* number of password tries, -1 for unlimited */
 
     union {
         rnp_keygen_desc_t generate_key_ctx;
     } action;
+
+    pgp_passphrase_provider_t passphrase_provider;
 } rnp_t;
 
 /* rnp initialization parameters : keyring pathes, flags, whatever else */
@@ -54,16 +58,19 @@ typedef struct rnp_params_t {
                                   default to not leak confidential information */
 
     int         passfd; /* password file descriptor */
-    const char *outs;   /* output stream : may be <stderr> , most likel these are subject for
-                           refactoring  */
-    const char *errs;   /* error stream : may be <stdout> */
-    const char *ress;   /* results stream : maye be <stdout>, <stderr> or file name/path */
+    int         userinputfd;
+    const char *outs; /* output stream : may be <stderr> , most likel these are subject for
+                         refactoring  */
+    const char *errs; /* error stream : may be <stdout> */
+    const char *ress; /* results stream : maye be <stdout>, <stderr> or file name/path */
 
     const char *ks_pub_format; /* format of the public key store */
     const char *ks_sec_format; /* format of the secret key store */
     char *      pubpath;       /* public keystore path */
     char *      secpath;       /* secret keystore path */
     char *      defkey;        /* default/preferred key id */
+
+    pgp_passphrase_provider_t passphrase_provider;
 } rnp_params_t;
 
 /* rnp operation context : contains additional data about the currently ongoing operation */

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -24,6 +24,7 @@ librnp_la_SOURCES	= \
 	list.c \
 	misc.c \
 	packet-create.c \
+	pass-provider.c \
 	pem.c \
 	pgp-key.c \
 	rnp.c \

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -199,11 +199,6 @@ validate_keygen_primary(const rnp_keygen_primary_desc_t *desc)
         RNP_LOG("userid is required for primary key");
         return false;
     }
-
-    if (desc->crypto.passphrase[0] == '\0') {
-        // allow it, but warn
-        RNP_LOG("warning: blank passphrase");
-    }
     return true;
 }
 
@@ -285,16 +280,18 @@ keygen_primary_merge_defaults(rnp_keygen_primary_desc_t *desc)
 }
 
 bool
-pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
-                         bool                       merge_defaults,
-                         pgp_key_t *                primary_sec,
-                         pgp_key_t *                primary_pub,
-                         pgp_seckey_t *             decrypted_seckey)
+pgp_generate_primary_key(rnp_keygen_primary_desc_t *      desc,
+                         bool                             merge_defaults,
+                         pgp_key_t *                      primary_sec,
+                         pgp_key_t *                      primary_pub,
+                         pgp_seckey_t *                   decrypted_seckey,
+                         const pgp_passphrase_provider_t *passphrase_provider)
 {
     bool          ok = false;
     pgp_output_t *output = NULL;
     pgp_memory_t *mem = NULL;
     pgp_seckey_t  seckey;
+    char          passphrase[MAX_PASSPHRASE_LENGTH] = {0};
 
     memset(&seckey, 0, sizeof(seckey));
 
@@ -322,12 +319,26 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
         goto end;
     }
 
+    // get a passphrase for the new key
+    if (!pgp_request_passphrase(passphrase_provider,
+                                &(pgp_passphrase_ctx_t){.op = PGP_OP_GENERATE_KEY,
+                                                        .pubkey = &seckey.pubkey,
+                                                        .key_type = PGP_PTAG_CT_SECRET_KEY},
+                                passphrase,
+                                sizeof(passphrase))) {
+        RNP_LOG("no passphrase provided for new key");
+        goto end;
+    }
+    if (passphrase[0] == '\0') {
+        // allow it, but warn
+        RNP_LOG("warning: blank passphrase for key generation");
+    }
+
     // write the secret key, userid, and self-signature
     if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
         goto end;
     }
-    if (!pgp_write_struct_seckey(
-          PGP_PTAG_CT_SECRET_KEY, &seckey, desc->crypto.passphrase, output) ||
+    if (!pgp_write_struct_seckey(PGP_PTAG_CT_SECRET_KEY, &seckey, passphrase, output) ||
         !pgp_write_struct_userid(output, desc->cert.userid) ||
         !pgp_write_selfsig_cert(output, &seckey, desc->crypto.hash_alg, &desc->cert)) {
         RNP_LOG("failed to write out generated key+sigs");
@@ -355,12 +366,17 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
 
     ok = true;
 end:
+    // always scrub passphrase
+    pgp_forget(passphrase, sizeof(passphrase));
+    // free any user preferences
+    pgp_free_user_prefs(&desc->cert.prefs);
+
     if (output && mem) {
         pgp_teardown_memory_write(output, mem);
         output = NULL;
         mem = NULL;
     }
-    if (decrypted_seckey) {
+    if (ok && decrypted_seckey) {
         // caller wants a copy of the decrypted seckey
         memcpy(decrypted_seckey, &seckey, sizeof(*decrypted_seckey));
     } else {
@@ -387,11 +403,6 @@ validate_keygen_subkey(rnp_keygen_subkey_desc_t *desc)
         // TODO: (allowing for now)
         // return false;
     }
-
-    if (desc->crypto.passphrase[0] == '\0') {
-        // allow it, but warn
-        RNP_LOG("warning: blank passphrase");
-    }
     return true;
 }
 
@@ -406,17 +417,19 @@ keygen_subkey_merge_defaults(rnp_keygen_subkey_desc_t *desc)
 }
 
 bool
-pgp_generate_subkey(rnp_keygen_subkey_desc_t *desc,
-                    bool                      merge_defaults,
-                    pgp_key_t *               primary_sec,
-                    pgp_key_t *               primary_pub,
-                    const pgp_seckey_t *      primary_decrypted,
-                    pgp_key_t *               subkey_sec,
-                    pgp_key_t *               subkey_pub)
+pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
+                    bool                             merge_defaults,
+                    pgp_key_t *                      primary_sec,
+                    pgp_key_t *                      primary_pub,
+                    const pgp_seckey_t *             primary_decrypted,
+                    pgp_key_t *                      subkey_sec,
+                    pgp_key_t *                      subkey_pub,
+                    const pgp_passphrase_provider_t *passphrase_provider)
 {
     bool          ok = false;
     pgp_output_t *output = NULL;
     pgp_memory_t *mem = NULL;
+    char          passphrase[MAX_PASSPHRASE_LENGTH] = {0};
 
     // validate args
     if (!desc || !primary_sec || !primary_pub || !primary_decrypted || !subkey_sec ||
@@ -458,12 +471,26 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *desc,
         goto end;
     }
 
+    // get a passphrase for the new key
+    if (!pgp_request_passphrase(passphrase_provider,
+                                &(pgp_passphrase_ctx_t){.op = PGP_OP_GENERATE_KEY,
+                                                        .pubkey = &seckey.pubkey,
+                                                        .key_type = PGP_PTAG_CT_SECRET_SUBKEY},
+                                passphrase,
+                                sizeof(passphrase))) {
+        RNP_LOG("no passphrase provided for new key");
+        goto end;
+    }
+    if (passphrase[0] == '\0') {
+        // allow it, but warn
+        RNP_LOG("warning: blank passphrase for key generation");
+    }
+
     // write the secret subkey, userid, and binding self-signature
     if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
         goto end;
     }
-    if (!pgp_write_struct_seckey(
-          PGP_PTAG_CT_SECRET_SUBKEY, &seckey, desc->crypto.passphrase, output) ||
+    if (!pgp_write_struct_seckey(PGP_PTAG_CT_SECRET_SUBKEY, &seckey, passphrase, output) ||
         !pgp_write_selfsig_binding(
           output, primary_decrypted, desc->crypto.hash_alg, &seckey.pubkey, &desc->binding)) {
         RNP_LOG("failed to write out generated key+sigs");
@@ -493,6 +520,8 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *desc,
 
     ok = true;
 end:
+    // always scrub passphrase
+    pgp_forget(passphrase, sizeof(passphrase));
     pgp_seckey_free(&seckey);
     if (!ok) {
         pgp_key_free_data(subkey_pub);
@@ -544,12 +573,13 @@ print_keygen_subkey(const rnp_keygen_subkey_desc_t *desc)
 }
 
 bool
-pgp_generate_keypair(rnp_keygen_desc_t *desc,
-                     bool               merge_defaults,
-                     pgp_key_t *        primary_sec,
-                     pgp_key_t *        primary_pub,
-                     pgp_key_t *        subkey_sec,
-                     pgp_key_t *        subkey_pub)
+pgp_generate_keypair(rnp_keygen_desc_t *              desc,
+                     bool                             merge_defaults,
+                     pgp_key_t *                      primary_sec,
+                     pgp_key_t *                      primary_pub,
+                     pgp_key_t *                      subkey_sec,
+                     pgp_key_t *                      subkey_pub,
+                     const pgp_passphrase_provider_t *passphrase_provider)
 {
     bool         ok = false;
     pgp_seckey_t decrypted_primary;
@@ -573,8 +603,12 @@ pgp_generate_keypair(rnp_keygen_desc_t *desc,
     }
 
     // generate the primary key
-    if (!pgp_generate_primary_key(
-          &desc->primary, merge_defaults, primary_sec, primary_pub, &decrypted_primary)) {
+    if (!pgp_generate_primary_key(&desc->primary,
+                                  merge_defaults,
+                                  primary_sec,
+                                  primary_pub,
+                                  &decrypted_primary,
+                                  passphrase_provider)) {
         RNP_LOG("failed to generate primary key");
         goto end;
     }
@@ -586,7 +620,8 @@ pgp_generate_keypair(rnp_keygen_desc_t *desc,
                              primary_pub,
                              &decrypted_primary,
                              subkey_sec,
-                             subkey_pub)) {
+                             subkey_pub,
+                             passphrase_provider)) {
         RNP_LOG("failed to generate subkey");
         goto end;
     }

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -91,6 +91,7 @@ __RCSID("$NetBSD: misc.c,v 1.41 2012/03/05 02:20:18 christos Exp $");
 #include "utils.h"
 #include "memory.h"
 #include "readerwriter.h"
+#include "pgp-key.h"
 
 #ifdef WIN32
 #define vsnprintf _vsnprintf

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -338,7 +338,7 @@ hash_key_material(const pgp_seckey_t *key, uint8_t *result)
  * verification.
  */
 static bool
-write_seckey_body(const pgp_seckey_t *key, const uint8_t *passphrase, pgp_output_t *output)
+write_seckey_body(const pgp_seckey_t *key, const char *passphrase, pgp_output_t *output)
 {
     /* RFC4880 Section 5.5.3 Secret-Key Packet Formats */
 
@@ -597,7 +597,6 @@ pgp_write_xfer_pubkey(pgp_output_t *         output,
 bool
 pgp_write_xfer_seckey(pgp_output_t *         output,
                       const pgp_key_t *      key,
-                      const uint8_t *        passphrase,
                       const rnp_key_store_t *subkeys,
                       unsigned               armoured)
 {
@@ -605,6 +604,11 @@ pgp_write_xfer_seckey(pgp_output_t *         output,
                                                       PGP_PTAG_CT_SECRET_SUBKEY,
                                                       PGP_PTAG_CT_USER_ID,
                                                       PGP_PTAG_CT_SIGNATURE};
+
+    if (!key->packetc || !key->packets) {
+        return false;
+    }
+
     if (armoured) {
         pgp_writer_push_armoured(output, PGP_PGP_PRIVATE_KEY_BLOCK);
     }
@@ -615,54 +619,6 @@ pgp_write_xfer_seckey(pgp_output_t *         output,
         pgp_writer_info_finalise(&output->errors, &output->writer);
         pgp_writer_pop(output);
     }
-    return true;
-}
-
-bool
-pgp_write_xfer_anykey(pgp_output_t *         output,
-                      const pgp_key_t *      key,
-                      const uint8_t *        passphrase,
-                      const rnp_key_store_t *subkeys,
-                      unsigned               armoured)
-{
-    int i;
-
-    switch (key->type) {
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
-        if (!pgp_write_xfer_pubkey(output, key, NULL, armoured)) {
-            fprintf(stderr, "Can't write public key\n");
-            return false;
-        }
-        break;
-
-    case PGP_PTAG_CT_SECRET_KEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
-        if (!pgp_write_xfer_seckey(output, key, passphrase, NULL, armoured)) {
-            RNP_LOG("Can't write private key");
-            return false;
-        }
-        break;
-
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY:
-        if (key->packetc == 0) {
-            fprintf(stderr, "Can't write encrypted private key without RAW packed.\n");
-            return false;
-        }
-        for (i = 0; i < key->packetc; i++) {
-            if (!pgp_write(output, key->packets[i].raw, key->packets[i].length)) {
-                fprintf(stderr, "Can't write part of encrypted private key\n");
-                return false;
-            }
-        }
-        break;
-
-    default:
-        fprintf(stderr, "Can't write key type: %d\n", key->type);
-        return false;
-    }
-
     return true;
 }
 
@@ -704,7 +660,7 @@ pgp_build_pubkey(pgp_memory_t *out, const pgp_pubkey_t *key, unsigned make_packe
 unsigned
 pgp_write_struct_seckey(pgp_content_enum    tag,
                         const pgp_seckey_t *key,
-                        const uint8_t *     passphrase,
+                        const char *        passphrase,
                         pgp_output_t *      output)
 {
     int length = 0;

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -87,7 +87,7 @@ unsigned pgp_write_ss_header(pgp_output_t *, unsigned, pgp_content_enum);
 bool     pgp_write_struct_pubkey(pgp_output_t *, pgp_content_enum, const pgp_pubkey_t *);
 unsigned pgp_write_struct_seckey(pgp_content_enum,
                                  const pgp_seckey_t *,
-                                 const uint8_t *,
+                                 const char *,
                                  pgp_output_t *);
 unsigned pgp_write_one_pass_sig(pgp_output_t *,
                                 const pgp_seckey_t *,
@@ -100,10 +100,10 @@ unsigned          pgp_write_xfer_pubkey(pgp_output_t *,
                                const pgp_key_t *,
                                const rnp_key_store_t *,
                                const unsigned);
-bool pgp_write_xfer_seckey(
-  pgp_output_t *, const pgp_key_t *, const uint8_t *, const rnp_key_store_t *, const unsigned);
-bool pgp_write_xfer_anykey(
-  pgp_output_t *, const pgp_key_t *, const uint8_t *, const rnp_key_store_t *, const unsigned);
+bool pgp_write_xfer_seckey(pgp_output_t *,
+                           const pgp_key_t *,
+                           const rnp_key_store_t *,
+                           const unsigned);
 
 unsigned pgp_write_userid(const uint8_t *, pgp_output_t *);
 unsigned pgp_fileread_litdata(const char *, const pgp_litdata_enum, pgp_output_t *);

--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "pass-provider.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <termios.h>
+
+#include <packet.h>
+#include <pgp-key.h>
+#include <rnp/rnp_sdk.h>
+
+bool
+rnp_getpass(const char *prompt, char *buffer, size_t size)
+{
+    struct termios saved_flags, noecho_flags;
+    bool           restore_ttyflags = false;
+    bool           ok = false;
+    FILE *         in, *out;
+
+    // validate args
+    if (!buffer) {
+        goto end;
+    }
+    // doesn't hurt
+    *buffer = '\0';
+
+    in = fopen("/dev/tty", "w+ce");
+    if (!in) {
+        in = stdin;
+        out = stderr;
+    } else {
+        out = in;
+    }
+
+    // save the original termios
+    if (tcgetattr(fileno(in), &saved_flags) == 0) {
+        noecho_flags = saved_flags;
+        // disable echo in the local modes
+        noecho_flags.c_lflag = (noecho_flags.c_lflag & ~ECHO) | ECHONL | ISIG;
+        restore_ttyflags = (tcsetattr(fileno(in), TCSANOW, &noecho_flags) == 0);
+    }
+    if (prompt) {
+        fputs(prompt, out);
+    }
+    if (fgets(buffer, size, in) == NULL) {
+        goto end;
+    }
+
+    // strip trailing newline if needed
+    size_t length = strlen(buffer);
+    if (length >= 1 && buffer[length - 1] == '\n') {
+        buffer[length - 1] = '\0';
+    }
+
+    ok = true;
+end:
+    if (restore_ttyflags) {
+        tcsetattr(fileno(in), TCSAFLUSH, &saved_flags);
+    }
+    return ok;
+}
+
+bool
+rnp_passphrase_provider_stdin(const pgp_passphrase_ctx_t *ctx,
+                              char *                      passphrase,
+                              size_t                      passphrase_size,
+                              void *                      userdata)
+{
+    uint8_t keyid[PGP_KEY_ID_SIZE];
+    char    keyidhex[PGP_KEY_ID_SIZE * 2 + 1];
+    char    target[sizeof(keyidhex) + 16];
+    char    prompt[128];
+    char    buffer[MAX_PASSPHRASE_LENGTH];
+    bool    ok = false;
+
+    if (!ctx || !passphrase || !passphrase_size) {
+        goto done;
+    }
+    if (!pgp_keyid(keyid, PGP_KEY_ID_SIZE, ctx->pubkey)) {
+        goto done;
+    }
+    rnp_strhexdump(keyidhex, keyid, PGP_KEY_ID_SIZE, "");
+    snprintf(target,
+             sizeof(target),
+             "%s%s 0x%s",
+             ctx->op == PGP_OP_GENERATE_KEY ? "new " : "",
+             pgp_is_primary_key_tag(ctx->key_type) ? "primary key" : "subkey",
+             keyidhex);
+start:
+    snprintf(prompt, sizeof(prompt), "Enter passphrase for %s: ", target);
+    if (!rnp_getpass(prompt, passphrase, passphrase_size)) {
+        goto done;
+    }
+    if (ctx->op == PGP_OP_GENERATE_KEY) {
+        snprintf(prompt, sizeof(prompt), "Repeat passphrase for %s: ", target);
+        if (!rnp_getpass(prompt, buffer, sizeof(buffer))) {
+            goto done;
+        }
+        if (strcmp(passphrase, buffer) != 0) {
+            printf("Passphrases do not match!\n\n");
+            // currently will loop forever
+            goto start;
+        }
+    }
+    ok = true;
+
+done:
+    pgp_forget(buffer, sizeof(buffer));
+    return ok;
+}
+
+bool
+rnp_passphrase_provider_file(const pgp_passphrase_ctx_t *ctx,
+                             char *                      passphrase,
+                             size_t                      passphrase_size,
+                             void *                      userdata)
+{
+    FILE *fp = (FILE *) userdata;
+
+    if (!ctx || !passphrase || !passphrase_size || !userdata) {
+        return false;
+    }
+    if (!fgets(passphrase, passphrase_size, fp)) {
+        return false;
+    }
+    size_t length = strlen(passphrase);
+    if (passphrase[length - 1] == '\n') {
+        passphrase[length - 1] = '\0';
+    }
+    return true;
+}

--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -33,7 +33,7 @@
 #include <pgp-key.h>
 #include <rnp/rnp_sdk.h>
 
-bool
+static bool
 rnp_getpass(const char *prompt, char *buffer, size_t size)
 {
     struct termios saved_flags, noecho_flags;

--- a/src/lib/pass-provider.h
+++ b/src/lib/pass-provider.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef RNP_PASS_PROVIDER_H
+#define RNP_PASS_PROVIDER_H
+
+#include <repgp/repgp.h>
+
+bool rnp_passphrase_provider_stdin(const pgp_passphrase_ctx_t *ctx,
+                                   char *                      passphrase,
+                                   size_t                      passphrase_size,
+                                   void *                      userdata);
+bool rnp_passphrase_provider_file(const pgp_passphrase_ctx_t *ctx,
+                                  char *                      passphrase,
+                                  size_t                      passphrase_size,
+                                  void *                      userdata);
+#endif

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -54,6 +54,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <repgp/repgp.h>
 #include "packet.h"
 
 struct pgp_key_t *pgp_key_new(void);
@@ -96,9 +97,11 @@ const struct pgp_seckey_t *pgp_get_seckey(const pgp_key_t *);
 
 pgp_seckey_t *pgp_get_writable_seckey(pgp_key_t *);
 
-pgp_seckey_t *pgp_decrypt_seckey_parser(const pgp_key_t *, FILE *);
+pgp_seckey_t *pgp_decrypt_seckey_parser(const pgp_key_t *, const char *);
 
-pgp_seckey_t *pgp_decrypt_seckey(const pgp_key_t *, FILE *);
+pgp_seckey_t *pgp_decrypt_seckey(const pgp_key_t *,
+                                 const pgp_passphrase_provider_t *,
+                                 const pgp_passphrase_ctx_t *);
 
 void pgp_set_seckey(pgp_contents_t *, const pgp_key_t *);
 
@@ -118,6 +121,10 @@ void pgp_key_init(pgp_key_t *, const pgp_content_enum);
 
 pgp_key_flags_t pgp_pk_alg_capabilities(pgp_pubkey_alg_t alg);
 
-char *pgp_export_key(pgp_io_t *, const pgp_key_t *, uint8_t *);
+char *pgp_export_key(pgp_io_t *, const pgp_key_t *, const pgp_passphrase_provider_t *);
+
+bool pgp_key_is_locked(const pgp_key_t *key);
+bool pgp_key_unlock(pgp_key_t *key, const pgp_passphrase_provider_t *provider);
+void pgp_key_lock(pgp_key_t *key);
 
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/readerwriter.h
+++ b/src/lib/readerwriter.h
@@ -82,6 +82,4 @@ pgp_cb_ret_t pgp_litdata_cb(const pgp_packet_t *, pgp_cbdata_t *);
 pgp_cb_ret_t pgp_pk_sesskey_cb(const pgp_packet_t *, pgp_cbdata_t *);
 pgp_cb_ret_t pgp_get_seckey_cb(const pgp_packet_t *, pgp_cbdata_t *);
 
-bool pgp_getpassphrase(void *, char *, size_t);
-
 #endif /* READERWRITER_H_ */

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -1270,7 +1270,7 @@ done:
 /* sign a file, and put the signature in a separate file */
 int
 pgp_sign_detached(
-  rnp_ctx_t *ctx, pgp_io_t *io, const char *f, const char *sigfile, pgp_seckey_t *seckey)
+  rnp_ctx_t *ctx, pgp_io_t *io, const char *f, const char *sigfile, const pgp_seckey_t *seckey)
 {
     pgp_create_sig_t *sig = NULL;
     pgp_hash_alg_t    hash_alg;

--- a/src/lib/signature.h
+++ b/src/lib/signature.h
@@ -132,7 +132,8 @@ unsigned pgp_sig_add_preferred_key_server(pgp_create_sig_t *sig, const uint8_t *
 bool pgp_sign_file(
   rnp_ctx_t *, pgp_io_t *, const char *, const char *, const pgp_seckey_t *, bool cleartext);
 
-int pgp_sign_detached(rnp_ctx_t *, pgp_io_t *, const char *, const char *, pgp_seckey_t *);
+int pgp_sign_detached(
+  rnp_ctx_t *, pgp_io_t *, const char *, const char *, const pgp_seckey_t *);
 
 bool pgp_check_sig(const uint8_t *, unsigned, const pgp_sig_t *, const pgp_pubkey_t *);
 

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -123,8 +123,6 @@ cb_keyring_read(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
     switch (pkt->tag) {
     case PGP_PTAG_CT_SECRET_KEY:
     case PGP_PTAG_CT_SECRET_SUBKEY:
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY:
     case PGP_PTAG_CT_PUBLIC_KEY:
     case PGP_PTAG_CT_PUBLIC_SUBKEY:
         if (pgp_is_secret_key_tag(pkt->tag)) {

--- a/src/librepgp/Makefile.am
+++ b/src/librepgp/Makefile.am
@@ -7,4 +7,5 @@ librepgp_la_SOURCES     =  \
     packet-parse.c \
     packet-print.c \
     packet-show.c \
+    pass-provider.c \
     reader.c

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -1138,8 +1138,6 @@ pgp_parser_content_free(pgp_packet_t *c)
 
     case PGP_PTAG_CT_SECRET_KEY:
     case PGP_PTAG_CT_SECRET_SUBKEY:
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY:
         pgp_seckey_free(&c->u.seckey);
         break;
 
@@ -2420,6 +2418,44 @@ parse_litdata(pgp_region_t *region, pgp_stream_t *stream)
     return true;
 }
 
+void
+pgp_seckey_free_secret_mpis(pgp_seckey_t *seckey)
+{
+    switch (seckey->pubkey.alg) {
+    case PGP_PKA_RSA:
+    case PGP_PKA_RSA_ENCRYPT_ONLY:
+    case PGP_PKA_RSA_SIGN_ONLY:
+        free_BN(&seckey->key.rsa.d);
+        free_BN(&seckey->key.rsa.p);
+        free_BN(&seckey->key.rsa.q);
+        free_BN(&seckey->key.rsa.u);
+        break;
+
+    case PGP_PKA_DSA:
+        free_BN(&seckey->key.dsa.x);
+        break;
+
+    case PGP_PKA_EDDSA:
+    case PGP_PKA_ECDH:
+    case PGP_PKA_ECDSA:
+    case PGP_PKA_SM2:
+    case PGP_PKA_SM2_ENCRYPT:
+        free_BN(&seckey->key.ecc.x);
+        break;
+
+    case PGP_PKA_ELGAMAL:
+    case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
+        free_BN(&seckey->key.elgamal.x);
+        break;
+
+    default:
+        (void) fprintf(stderr,
+                       "pgp_seckey_free: Unknown algorithm: %d (%s)\n",
+                       seckey->pubkey.alg,
+                       pgp_show_pka(seckey->pubkey.alg));
+    }
+}
+
 /**
  * \ingroup Core_Create
  *
@@ -2435,40 +2471,8 @@ pgp_seckey_free(pgp_seckey_t *key)
     if (!key || !key->pubkey.alg) {
         return;
     }
+    pgp_seckey_free_secret_mpis(key);
     pgp_pubkey_free(&key->pubkey);
-    switch (key->pubkey.alg) {
-    case PGP_PKA_RSA:
-    case PGP_PKA_RSA_ENCRYPT_ONLY:
-    case PGP_PKA_RSA_SIGN_ONLY:
-        free_BN(&key->key.rsa.d);
-        free_BN(&key->key.rsa.p);
-        free_BN(&key->key.rsa.q);
-        free_BN(&key->key.rsa.u);
-        break;
-
-    case PGP_PKA_DSA:
-        free_BN(&key->key.dsa.x);
-        break;
-
-    case PGP_PKA_EDDSA:
-    case PGP_PKA_ECDH:
-    case PGP_PKA_ECDSA:
-    case PGP_PKA_SM2:
-    case PGP_PKA_SM2_ENCRYPT:
-        free_BN(&key->key.ecc.x);
-        break;
-
-    case PGP_PKA_ELGAMAL:
-    case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN:
-        free_BN(&key->key.elgamal.x);
-        break;
-
-    default:
-        (void) fprintf(stderr,
-                       "pgp_seckey_free: Unknown algorithm: %d (%s)\n",
-                       key->pubkey.alg,
-                       pgp_show_pka(key->pubkey.alg));
-    }
     if (key->checkhash != NULL) {
         free(key->checkhash);
     }
@@ -2514,7 +2518,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
     pgp_crypt_t   decrypt;
     pgp_hash_t    checkhash;
     unsigned      blocksize;
-    unsigned      crypted;
+    bool          crypted;
     uint8_t       c = 0x0;
     int           ret = 1;
 
@@ -2583,6 +2587,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
     }
     crypted = pkt.u.seckey.s2k_usage == PGP_S2KU_ENCRYPTED ||
               pkt.u.seckey.s2k_usage == PGP_S2KU_ENCRYPTED_AND_HASHED;
+    pkt.u.seckey.encrypted = crypted;
 
     if (crypted) {
         pgp_packet_t seckey;
@@ -2615,12 +2620,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
             if (!consume_packet(region, stream, 0)) {
                 return false;
             }
-            if (tag == PGP_PTAG_CT_SECRET_KEY) {
-                CALLBACK(PGP_PTAG_CT_ENCRYPTED_SECRET_KEY, &stream->cbinfo, &pkt);
-
-            } else {
-                CALLBACK(PGP_PTAG_CT_ENCRYPTED_SECRET_SUBKEY, &stream->cbinfo, &pkt);
-            }
+            CALLBACK(tag, &stream->cbinfo, &pkt);
             return true;
         }
         keysize = pgp_key_size(pkt.u.seckey.alg);
@@ -2669,6 +2669,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
         /* now read encrypted data */
 
         pgp_reader_push_decrypt(stream, &decrypt, region);
+        pkt.u.seckey.encrypted = false;
 
         /*
          * Since all known encryption for PGP doesn't compress, we

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -704,13 +704,13 @@ pgp_sprint_key(pgp_io_t *             io,
 
 /* return the key info as a JSON encoded string */
 int
-repgp_sprint_json(pgp_io_t *             io,
-                  const rnp_key_store_t *keyring,
-                  const pgp_key_t *      key,
-                  json_object *          keyjson,
-                  const char *           header,
-                  const pgp_pubkey_t *   pubkey,
-                  const int              psigs)
+repgp_sprint_json(pgp_io_t *                    io,
+                  const struct rnp_key_store_t *keyring,
+                  const pgp_key_t *             key,
+                  json_object *                 keyjson,
+                  const char *                  header,
+                  const pgp_pubkey_t *          pubkey,
+                  const int                     psigs)
 {
     char     keyid[PGP_KEY_ID_SIZE * 3];
     char     fp[PGP_FINGERPRINT_HEX_SIZE];
@@ -801,12 +801,12 @@ repgp_sprint_json(pgp_io_t *             io,
 }
 
 int
-pgp_hkp_sprint_key(pgp_io_t *             io,
-                   const rnp_key_store_t *keyring,
-                   const pgp_key_t *      key,
-                   char **                buf,
-                   const pgp_pubkey_t *   pubkey,
-                   const int              psigs)
+pgp_hkp_sprint_key(pgp_io_t *                    io,
+                   const struct rnp_key_store_t *keyring,
+                   const pgp_key_t *             key,
+                   char **                       buf,
+                   const pgp_pubkey_t *          pubkey,
+                   const int                     psigs)
 {
     const pgp_key_t *trustkey;
     unsigned         from;
@@ -1044,7 +1044,7 @@ print_seckey_verbose(const pgp_content_enum type, const pgp_seckey_t *seckey)
         print_hexdump(0, "IV", seckey->iv, pgp_block_size(seckey->alg));
     }
     /* no more set if encrypted */
-    if (type == PGP_PTAG_CT_ENCRYPTED_SECRET_KEY) {
+    if (seckey->encrypted) {
         return;
     }
     switch (seckey->pubkey.alg) {
@@ -1653,11 +1653,6 @@ pgp_print_packet(pgp_printstate_t *print, const pgp_packet_t *pkt)
         print_seckey_verbose(pkt->tag, &content->seckey);
         break;
 
-    case PGP_PTAG_CT_ENCRYPTED_SECRET_KEY:
-        print_tagname(print->indent, "PGP_PTAG_CT_ENCRYPTED_SECRET_KEY");
-        print_seckey_verbose(pkt->tag, &content->seckey);
-        break;
-
     case PGP_PTAG_CT_ARMOUR_HEADER:
         print_tagname(print->indent, "ARMOUR HEADER");
         print_string(print->indent, "type", content->armour_header.type);
@@ -1729,13 +1724,12 @@ cb_list_packets(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
 \param cb_get_passphrase
 */
 int
-pgp_list_packets(pgp_io_t *       io,
-                 char *           filename,
-                 unsigned         armour,
-                 rnp_key_store_t *secring,
-                 rnp_key_store_t *pubring,
-                 void *           passfp,
-                 pgp_cbfunc_t *   cb_get_passphrase)
+pgp_list_packets(pgp_io_t *                       io,
+                 char *                           filename,
+                 unsigned                         armour,
+                 rnp_key_store_t *                secring,
+                 rnp_key_store_t *                pubring,
+                 const pgp_passphrase_provider_t *passphrase_provider)
 {
     pgp_stream_t * stream = NULL;
     const unsigned accumulate = 1;
@@ -1746,8 +1740,7 @@ pgp_list_packets(pgp_io_t *       io,
     pgp_parse_options(stream, PGP_PTAG_SS_ALL, PGP_PARSE_PARSED);
     stream->cryptinfo.secring = secring;
     stream->cryptinfo.pubring = pubring;
-    stream->cbinfo.passfp = passfp;
-    stream->cryptinfo.getpassphrase = cb_get_passphrase;
+    stream->cryptinfo.passphrase_provider = *passphrase_provider;
     if (armour) {
         pgp_reader_push_dearmour(stream);
     }

--- a/src/librepgp/packet-print.h
+++ b/src/librepgp/packet-print.h
@@ -84,7 +84,11 @@ void pgp_print_key(pgp_io_t *,
 void pgp_print_pubkey(const pgp_pubkey_t *);
 int  pgp_sprint_pubkey(const pgp_key_t *, char *, size_t);
 
-int pgp_list_packets(
-  pgp_io_t *, char *, unsigned, rnp_key_store_t *, rnp_key_store_t *, void *, pgp_cbfunc_t *);
+int pgp_list_packets(pgp_io_t *,
+                     char *,
+                     unsigned,
+                     rnp_key_store_t *,
+                     rnp_key_store_t *,
+                     const pgp_passphrase_provider_t *);
 
 #endif /* PACKET_PRINT_H_ */

--- a/src/librepgp/packet-show.c
+++ b/src/librepgp/packet-show.c
@@ -134,7 +134,6 @@ static pgp_map_t packet_tag_map[] = {
   {PGP_PTAG_CT_SIGNED_CLEARTEXT_BODY, "CT: Signed Cleartext Body"},
   {PGP_PTAG_CT_SIGNED_CLEARTEXT_TRAILER, "CT: Signed Cleartext Trailer"},
   {PGP_PTAG_CT_UNARMOURED_TEXT, "CT: Unarmoured Text"},
-  {PGP_PTAG_CT_ENCRYPTED_SECRET_KEY, "CT: Encrypted Secret Key"},
   {PGP_PTAG_CT_SE_DATA_HEADER, "CT: Sym Encrypted Data Header"},
   {PGP_PTAG_CT_SE_DATA_BODY, "CT: Sym Encrypted Data Body"},
   {PGP_PTAG_CT_SE_IP_DATA_HEADER, "CT: Sym Encrypted IP Data Header"},

--- a/src/librepgp/pass-provider.c
+++ b/src/librepgp/pass-provider.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <repgp/repgp.h>
+#include "packet.h"
+
+bool
+pgp_request_passphrase(const pgp_passphrase_provider_t *provider,
+                       const pgp_passphrase_ctx_t *     ctx,
+                       char *                           passphrase,
+                       size_t                           passphrase_size)
+{
+    if (!provider || !provider->callback || !ctx || !passphrase || !passphrase_size) {
+        return false;
+    }
+    return provider->callback(ctx, passphrase, passphrase_size, provider->userdata);
+}

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -68,7 +68,7 @@ rnp_cfg_load_defaults(rnp_cfg_t *cfg)
 bool
 rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params)
 {
-    int         passfd;
+    int         fd;
     const char *stream;
 
     /* enabling core dumps if user wants this */
@@ -77,8 +77,13 @@ rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params)
     }
 
     /* checking if password input was specified */
-    if ((passfd = rnp_cfg_getint(cfg, CFG_PASSFD))) {
-        params->passfd = passfd;
+    if ((fd = rnp_cfg_getint(cfg, CFG_PASSFD))) {
+        params->passfd = fd;
+    }
+
+    /* checking if user input was specified */
+    if ((fd = rnp_cfg_getint(cfg, CFG_USERINPUTFD))) {
+        params->userinputfd = fd;
     }
 
     /* stdout/stderr and results redirection */

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -43,22 +43,23 @@
 #define CFG_COREDUMPS "coredumps"     /* enable/disable core dumps. 1 or 0. */
 #define CFG_NEEDSUSERID "needsuserid" /* needs user id for the ongoing operation */
 #define CFG_NEEDSSECKEY "needsseckey" /* needs secret key for the ongoing operation */
-#define CFG_KEYRING "keyring"     /* path to the keyring ?? seems not to be used anywhere */
-#define CFG_USERID "userid"       /* userid for the ongoing operation */
-#define CFG_VERBOSE "verbose"     /* verbose logging */
-#define CFG_HOMEDIR "homedir"     /* home directory - folder with keyrings and so on */
-#define CFG_PASSFD "pass-fd"      /* password file descriptor */
-#define CFG_NUMTRIES "numtries"   /* number of password request tries, or 'unlimited' */
-#define CFG_DURATION "duration"   /* signature validity duration */
-#define CFG_BIRTHTIME "birthtime" /* signature validity start */
-#define CFG_CIPHER "cipher"       /* symmetric encryption algorithm as string */
-#define CFG_HASH "hash"           /* hash algorithm used, string like 'SHA1'*/
-#define CFG_IO_OUTS "outs"        /* output stream */
-#define CFG_IO_ERRS "errs"        /* error stream */
-#define CFG_IO_RESS "ress"        /* results stream */
-#define CFG_NUMBITS "numbits"     /* number of bits in generated key */
-#define CFG_KEYFORMAT "format"    /* key format : "human" for human-readable or ... */
-#define CFG_EXPERT "expert"       /* expert key generation mode */
+#define CFG_KEYRING "keyring" /* path to the keyring ?? seems not to be used anywhere */
+#define CFG_USERID "userid"   /* userid for the ongoing operation */
+#define CFG_VERBOSE "verbose" /* verbose logging */
+#define CFG_HOMEDIR "homedir" /* home directory - folder with keyrings and so on */
+#define CFG_PASSFD "pass-fd"  /* password file descriptor */
+#define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
+#define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
+#define CFG_DURATION "duration"         /* signature validity duration */
+#define CFG_BIRTHTIME "birthtime"       /* signature validity start */
+#define CFG_CIPHER "cipher"             /* symmetric encryption algorithm as string */
+#define CFG_HASH "hash"                 /* hash algorithm used, string like 'SHA1'*/
+#define CFG_IO_OUTS "outs"              /* output stream */
+#define CFG_IO_ERRS "errs"              /* error stream */
+#define CFG_IO_RESS "ress"              /* results stream */
+#define CFG_NUMBITS "numbits"           /* number of bits in generated key */
+#define CFG_KEYFORMAT "format"          /* key format : "human" for human-readable or ... */
+#define CFG_EXPERT "expert"             /* expert key generation mode */
 
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -12,7 +12,8 @@ rnp_tests_SOURCES   = \
     user-prefs.c \
     utils-list.c \
     pgp-parse.c \
-    load-pgp.c
+    load-pgp.c \
+    key-unlock.c
 
 # don't install any test stuff
 install-binPROGRAMS:

--- a/src/tests/key-unlock.c
+++ b/src/tests/key-unlock.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../librekey/key_store_pgp.h"
+#include "pgp-key.h"
+
+#include "rnp_tests.h"
+#include "support.h"
+
+// this is a passphrase callback that will always fail
+static bool
+failing_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                            char *                      passphrase,
+                            size_t                      passphrase_size,
+                            void *                      userdata)
+{
+    return false;
+}
+
+// this is a passphrase callback that should never be called
+static bool
+asserting_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                              char *                      passphrase,
+                              size_t                      passphrase_size,
+                              void *                      userdata)
+{
+    assert_false(true);
+    return false;
+}
+
+// this is a passphrase callback that just copies the string in userdata to
+// the passphrase buffer
+static bool
+string_copy_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                                char *                      passphrase,
+                                size_t                      passphrase_size,
+                                void *                      userdata)
+{
+    const char *str = (const char *) userdata;
+    strncpy(passphrase, str, passphrase_size - 1);
+    return true;
+}
+
+void
+test_key_unlock_pgp(void **state)
+{
+    rnp_test_state_t *        rstate = *state;
+    char                      path[PATH_MAX];
+    rnp_t                     rnp;
+    const pgp_key_t *         key = NULL;
+    rnp_ctx_t                 ctx;
+    const char *              data = "my test data";
+    char                      signature[512] = {0};
+    int                       siglen = 0;
+    char                      encrypted[512] = {0};
+    int                       enclen = 0;
+    char                      decrypted[512] = {0};
+    int                       declen = 0;
+    pgp_passphrase_provider_t provider = {0};
+    static const char *       keyids[] = {"7bc6709b15c23a4a", // primary
+                                   "1ed63ee56fadc34d",
+                                   "1d7e8a5393c997a8",
+                                   "8a05b89fad5aded1",
+                                   "2fcadf05ffa501bb", // primary
+                                   "54505a936a4a970e",
+                                   "326ef111425d14a5"};
+
+    paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/", NULL);
+    rnp_assert_ok(rstate, setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, path, NULL));
+    rnp_assert_ok(rstate, rnp_key_store_load_keys(&rnp, true));
+
+    for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
+        const char *keyid = keyids[i];
+        key = NULL;
+        rnp_assert_true(rstate,
+                        rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyid, &key));
+        assert_non_null(key);
+        // all keys in this keyring are encrypted and thus should be locked initially
+        rnp_assert_true(rstate, pgp_key_is_locked(key));
+    }
+
+    // try signing with a failing passphrase provider (should fail)
+    rnp.passphrase_provider =
+      (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
+    rnp_ctx_init(&ctx, &rnp);
+    ctx.halg = pgp_str_to_hash_alg("SHA1");
+    memset(signature, 0, sizeof(signature));
+    siglen = rnp_sign_memory(
+      &ctx, keyids[0], data, strlen(data), signature, sizeof(signature), false);
+    rnp_assert_int_equal(rstate, 0, siglen);
+    rnp_ctx_free(&ctx);
+
+    // grab the signing key to unlock
+    rnp_assert_true(rstate,
+                    rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], &key));
+
+    // try to unlock with a failing passphrase provider
+    provider =
+      (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
+    rnp_assert_false(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_true(rstate, pgp_key_is_locked(key));
+
+    // try to unlock with an incorrect passphrase
+    provider = (pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                           .userdata = "badpass"};
+    rnp_assert_false(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_true(rstate, pgp_key_is_locked(key));
+
+    // unlock with the signing key
+    provider = (pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                           .userdata = "password"};
+    rnp_assert_true(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_false(rstate, pgp_key_is_locked(key));
+
+    // now the signing key is unlocked, confirm that no passphrase is required for signing
+    rnp.passphrase_provider =
+      (pgp_passphrase_provider_t){.callback = asserting_passphrase_callback, .userdata = NULL};
+
+    // sign, with no passphrase
+    rnp_ctx_init(&ctx, &rnp);
+    ctx.halg = pgp_str_to_hash_alg("SHA1");
+    memset(signature, 0, sizeof(signature));
+    siglen = rnp_sign_memory(
+      &ctx, keyids[0], data, strlen(data), signature, sizeof(signature), false);
+    rnp_assert_int_not_equal(rstate, 0, siglen);
+    rnp_ctx_free(&ctx);
+
+    // verify
+    rnp_ctx_init(&ctx, &rnp);
+    rnp_assert_int_equal(
+      rstate, 1, rnp_verify_memory(&ctx, signature, siglen, NULL, 0, false));
+    rnp_ctx_free(&ctx);
+
+    // verify (negative)
+    rnp_ctx_init(&ctx, &rnp);
+    signature[siglen / 2] ^= 0xff;
+    rnp_assert_int_equal(
+      rstate, 0, rnp_verify_memory(&ctx, signature, siglen, NULL, 0, false));
+    rnp_ctx_free(&ctx);
+
+    // lock the signing key
+    pgp_key_lock((pgp_key_t *) key);
+    rnp_assert_true(rstate, pgp_key_is_locked(key));
+    rnp.passphrase_provider =
+      (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
+
+    // sign, with no passphrase (should now fail)
+    rnp_ctx_init(&ctx, &rnp);
+    ctx.halg = pgp_str_to_hash_alg("SHA1");
+    memset(signature, 0, sizeof(signature));
+    siglen = rnp_sign_memory(
+      &ctx, keyids[0], data, strlen(data), signature, sizeof(signature), false);
+    rnp_assert_int_equal(rstate, 0, siglen);
+    rnp_ctx_free(&ctx);
+
+    // encrypt
+    rnp_ctx_init(&ctx, &rnp);
+    ctx.ealg = PGP_SA_AES_256;
+    // Note: keyids[1] is an encrypting subkey
+    enclen =
+      rnp_encrypt_memory(&ctx, keyids[1], data, strlen(data), encrypted, sizeof(encrypted));
+    rnp_assert_true(rstate, enclen > 0);
+    rnp_ctx_free(&ctx);
+
+    // try decrypting with a failing passphrase provider (should fail)
+    rnp.passphrase_provider =
+      (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
+    rnp_ctx_init(&ctx, &rnp);
+    declen = rnp_decrypt_memory(&ctx, encrypted, enclen, decrypted, sizeof(decrypted));
+    rnp_assert_true(rstate, declen <= 0);
+    rnp_ctx_free(&ctx);
+
+    // grab the encrypting key to unlock
+    key = NULL;
+    rnp_assert_true(rstate,
+                    rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[1], &key));
+
+    // unlock the encrypting key
+    provider = (pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                           .userdata = "password"};
+    rnp_assert_true(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_false(rstate, pgp_key_is_locked(key));
+
+    // decrypt, with no passphrase
+    rnp_ctx_init(&ctx, &rnp);
+    declen = rnp_decrypt_memory(&ctx, encrypted, enclen, decrypted, sizeof(decrypted));
+    rnp_assert_int_equal(rstate, declen, strlen(data));
+    assert_string_equal(data, decrypted);
+    rnp_ctx_free(&ctx);
+
+    // lock the encrypting key
+    pgp_key_lock((pgp_key_t *) key);
+    rnp_assert_true(rstate, pgp_key_is_locked(key));
+    rnp.passphrase_provider =
+      (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
+
+    // decrypt, with no passphrase (should now fail)
+    rnp_ctx_init(&ctx, &rnp);
+    declen = rnp_decrypt_memory(&ctx, encrypted, enclen, decrypted, sizeof(decrypted));
+    rnp_assert_true(rstate, declen <= 0);
+    rnp_ctx_free(&ctx);
+
+    // cleanup
+    rnp_end(&rnp);
+}

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -158,7 +158,8 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_load_v3_keyring_pgp),
       cmocka_unit_test(test_load_v4_keyring_pgp),
       cmocka_unit_test(test_load_keyring_and_count_pgp),
-      cmocka_unit_test(pgp_compress_roundtrip)};
+      cmocka_unit_test(pgp_compress_roundtrip),
+      cmocka_unit_test(test_key_unlock_pgp)};
 
     /* Each test entry will invoke setup_test before running
      * and teardown_test after running. */

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -91,6 +91,8 @@ void test_load_keyring_and_count_pgp(void **state);
 
 void pgp_compress_roundtrip(void **state);
 
+void test_key_unlock_pgp(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \


### PR DESCRIPTION
Refs: https://github.com/riboseinc/rnp/issues/39 https://github.com/riboseinc/rnp/issues/396

I apologize in advance for the large PR with a single commit.
The main thing here is the addition of a passphrase provider concept, and also key unlocking/locking.
The interfaces were added to librepgp and two providers were added to librnp.

Some random notes:
* A passphrase provider is just a callback and a userdata void pointer.
* There is also a passphrase context, which gives some information on why a passphrase is required. (Like we're generating a key, signing, ...).
* I was able to keep all the tests virtually the same. The `rnp_passphrase_provider_file` provider is used which reads from a pipe as before. No modifications required for `cli_tests.py all`.
* For CLI, the passphrase provider is by default `rnp_passphrase_provider_stdin`. I also added a replacement for `getpass`. Please test (esp. macOS).
* I split `user_input_fp` apart from passphrase handling. So `user_input_fp` is only used for rnpkeys expert mode. There is a separate `passfp` for passphrases specifically.
* I also added the key unlocking/locking functionality as discussed. There is a large test for it too. It's a bit too long, but can be split apart later.
* I removed the CT_ENCRYPTED_*KEY psuedo types and replaced them with a boolean, mostly to simplify some things. (Also renamed the G10 encrypted fields to encrypted_data to accommodate this).

Note: I shuffled things around at the last minute and somewhat hackishly resolved a circular dependency. Can be improved later.

