### PR TITLE
Add GPG 2.1 to CI and run cli_tests.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - BOTAN_INSTALL="$HOME/builds/botan-install"
     - CMOCKA_INSTALL="$HOME/builds/cmocka-install"
     - JSONC_INSTALL="$HOME/builds/jsonc-install"
+    - GPG21_INSTALL="$HOME/builds/gpg21-install"
     - LOGNAME="Travis"
     - CLANG_FORMAT_DIFF="clang-format-diff-4.0"
 
@@ -46,6 +47,7 @@ cache:
     - "$BOTAN_INSTALL"
     - "$CMOCKA_INSTALL"
     - "$JSONC_INSTALL"
+    - "$GPG21_INSTALL"
 
 install:
   - ./ci/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ branches:
 
 env:
   global:
-    - BOTAN_INSTALL="$HOME/builds/botan-install"
-    - CMOCKA_INSTALL="$HOME/builds/cmocka-install"
-    - JSONC_INSTALL="$HOME/builds/jsonc-install"
-    - GPG21_INSTALL="$HOME/builds/gpg21-install"
+    - LOCAL_BUILDS="$HOME/local-builds"
+    - BOTAN_INSTALL="${LOCAL_BUILDS}/botan-install"
+    - CMOCKA_INSTALL="${LOCAL_BUILDS}/cmocka-install"
+    - JSONC_INSTALL="${LOCAL_BUILDS}/jsonc-install"
+    - GPG21_INSTALL="${LOCAL_BUILDS}/gpg21-install"
     - LOGNAME="Travis"
     - CLANG_FORMAT_DIFF="clang-format-diff-4.0"
 

--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -97,9 +97,11 @@ git clone https://github.com/riboseinc/rnp
 # or if testing local copy
 # git clone /usr/local/rnp
 cd rnp
-export BOTAN_INSTALL="$HOME/builds/botan-install"
-export CMOCKA_INSTALL="$HOME/builds/cmocka-install"
-export JSONC_INSTALL="$HOME/builds/json-c-install"
+export LOCAL_BUILDS="$HOME/local-builds"
+export BOTAN_INSTALL="${LOCAL_BUILDS}/botan-install"
+export CMOCKA_INSTALL="${LOCAL_BUILDS}/cmocka-install"
+export JSONC_INSTALL="${LOCAL_BUILDS}/jsonc-install"
+export GPG21_INSTALL="${LOCAL_BUILDS}/gpg21-install"
 export BUILD_MODE=normal
 ci/install.sh
 env CC=clang ci/main.sh

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -42,3 +42,83 @@ if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ] && [ ! -e "${JSONC_INSTALL}/lib/
   make -j${CORES} install
 fi
 
+# gpg21
+if [ ! -e "${GPG21_INSTALL}/bin/gpg2" ]; then
+  mkdir ~/builds/gpg21
+  cd ~/builds/gpg21
+
+  gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 249B39D24F25E3B6 04376F3EE0856959 2071B08A33BD3F06 8A861B1C7EFD60D9
+
+  wget -c https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.gz
+  wget -c https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.27.tar.gz.sig
+  gpg --verify libgpg-error-1.27.tar.gz.sig
+  tar -xzf libgpg-error-1.27.tar.gz
+  cd libgpg-error-1.27/
+  ./configure --prefix="${GPG21_INSTALL}"
+  make -j${CORES} install
+  cd ..
+
+  wget -c https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.0.tar.gz
+  wget -c https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.0.tar.gz.sig
+  gpg --verify libgcrypt-1.8.0.tar.gz.sig
+  tar -xzf libgcrypt-1.8.0.tar.gz
+  cd libgcrypt-1.8.0
+  ./configure --prefix="${GPG21_INSTALL}" --with-libgpg-error-prefix="${GPG21_INSTALL}"
+  make -j${CORES} install
+  cd ..
+
+  wget -c https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.3.tar.bz2
+  wget -c https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.4.3.tar.bz2.sig
+  gpg --verify libassuan-2.4.3.tar.bz2.sig
+  tar -xjf libassuan-2.4.3.tar.bz2
+  cd libassuan-2.4.3
+  ./configure --prefix="${GPG21_INSTALL}" --with-libgpg-error-prefix="${GPG21_INSTALL}"
+  make -j${CORES} install
+  cd ..
+
+  wget -c  https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2
+  wget -c https://www.gnupg.org/ftp/gcrypt/libksba/libksba-1.3.5.tar.bz2.sig
+  gpg --verify libksba-1.3.5.tar.bz2.sig
+  tar -xjf libksba-1.3.5.tar.bz2
+  cd libksba-1.3.5
+  ./configure --prefix="${GPG21_INSTALL}" --with-libgpg-error-prefix="${GPG21_INSTALL}"
+  make -j${CORES} install
+  cd ..
+
+  wget -c https://www.gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2
+  wget -c https://www.gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2.sig
+  gpg --verify npth-1.5.tar.bz2.sig
+  tar -xjf npth-1.5.tar.bz2
+  cd npth-1.5
+  ./configure --prefix="${GPG21_INSTALL}"
+  make -j${CORES} install
+  cd ..
+
+  wget -c https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.0.0.tar.bz2
+  wget -c https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.0.0.tar.bz2.sig
+  gpg --verify pinentry-1.0.0.tar.bz2.sig
+  tar -xjf pinentry-1.0.0.tar.bz2
+  cd pinentry-1.0.0
+  ./configure --prefix="${GPG21_INSTALL}" \
+    --with-libgpg-error-prefix="${GPG21_INSTALL}" \
+    --with-libassuan-prefix="${GPG21_INSTALL}" \
+    --enable-pinentry-curses \
+    --disable-pinentry-qt4
+  make -j${CORES} install
+  cd ..
+
+  wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.22.tar.bz2
+  wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.22.tar.bz2.sig
+  gpg --verify gnupg-2.1.22.tar.bz2.sig
+  tar -xjf gnupg-2.1.22.tar.bz2
+  cd gnupg-2.1.22
+  ./configure --prefix="${GPG21_INSTALL}" \
+    --with-libgpg-error-prefix="${GPG21_INSTALL}" \
+    --with-libgcrypt-prefix="${GPG21_INSTALL}" \
+    --with-libassuan-prefix="${GPG21_INSTALL}" \
+    --with-ksba-prefix="${GPG21_INSTALL}" \
+    --with-npth-prefix="${GPG21_INSTALL}"
+  make -j${CORES} install
+
+fi
+

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -32,7 +32,7 @@ fi
 
 # json-c
 if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ] && [ ! -e "${JSONC_INSTALL}/lib/libjson-c.dylib" ]; then
-  mkdir "${LOCAL_BUILDS}/json-c"
+  mkdir -p "${LOCAL_BUILDS}/json-c"
   cd "${LOCAL_BUILDS}/json-c"
   wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz -O json-c.tar.gz
   tar xzf json-c.tar.gz --strip 1
@@ -44,7 +44,7 @@ fi
 
 # gpg21
 if [ ! -e "${GPG21_INSTALL}/bin/gpg2" ]; then
-  mkdir "${LOCAL_BUILDS}/gpg21"
+  mkdir -p "${LOCAL_BUILDS}/gpg21"
   cd "${LOCAL_BUILDS}/gpg21"
 
   gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 249B39D24F25E3B6 04376F3EE0856959 2071B08A33BD3F06 8A861B1C7EFD60D9

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -43,7 +43,7 @@ if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ] && [ ! -e "${JSONC_INSTALL}/lib/
 fi
 
 # gpg21
-if [ ! -e "${GPG21_INSTALL}/bin/gpg2" ]; then
+if [ ! -e "${GPG21_INSTALL}/bin/gpg" ]; then
   mkdir -p "${LOCAL_BUILDS}/gpg21"
   cd "${LOCAL_BUILDS}/gpg21"
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -107,11 +107,11 @@ if [ ! -e "${GPG21_INSTALL}/bin/gpg2" ]; then
   make -j${CORES} install
   cd ..
 
-  wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.22.tar.bz2
-  wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.22.tar.bz2.sig
-  gpg --verify gnupg-2.1.22.tar.bz2.sig
-  tar -xjf gnupg-2.1.22.tar.bz2
-  cd gnupg-2.1.22
+  wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.23.tar.bz2
+  wget -c https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-2.1.23.tar.bz2.sig
+  gpg --verify gnupg-2.1.23.tar.bz2.sig
+  tar -xjf gnupg-2.1.23.tar.bz2
+  cd gnupg-2.1.23
   ./configure --prefix="${GPG21_INSTALL}" \
     --with-libgpg-error-prefix="${GPG21_INSTALL}" \
     --with-libgcrypt-prefix="${GPG21_INSTALL}" \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,33 +7,33 @@ set -exu
 
 # botan
 if [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.so" ] && [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.dylib" ]; then
-  git clone https://github.com/randombit/botan ~/builds/botan
-  cd ~/builds/botan
+  git clone https://github.com/randombit/botan "${LOCAL_BUILDS}/botan"
+  cd "${LOCAL_BUILDS}/botan"
   ./configure.py --prefix="${BOTAN_INSTALL}"
   make -j${CORES} install
 fi
 
 # cmocka
 if [ ! -e "${CMOCKA_INSTALL}/lib/libcmocka.so" ] && [ ! -e "${CMOCKA_INSTALL}/lib/libcmocka.dylib" ]; then
-  git clone git://git.cryptomilk.org/projects/cmocka.git ~/builds/cmocka
-  cd ~/builds/cmocka
+  git clone git://git.cryptomilk.org/projects/cmocka.git "${LOCAL_BUILDS}/cmocka"
+  cd "${LOCAL_BUILDS}/cmocka"
   git checkout tags/cmocka-1.1.1
 
-  cd ~/builds/
+  cd "${LOCAL_BUILDS}"
   mkdir -p cmocka-build
   cd cmocka-build
   cmake \
     -DCMAKE_INSTALL_DIR="${CMOCKA_INSTALL}" \
     -DLIB_INSTALL_DIR="${CMOCKA_INSTALL}/lib" \
     -DINCLUDE_INSTALL_DIR="${CMOCKA_INSTALL}/include" \
-    ~/builds/cmocka
+    "${LOCAL_BUILDS}/cmocka"
   make -j${CORES} all install
 fi
 
 # json-c
 if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ] && [ ! -e "${JSONC_INSTALL}/lib/libjson-c.dylib" ]; then
-  mkdir ~/builds/json-c
-  cd ~/builds/json-c
+  mkdir "${LOCAL_BUILDS}/json-c"
+  cd "${LOCAL_BUILDS}/json-c"
   wget https://s3.amazonaws.com/json-c_releases/releases/json-c-0.12.1.tar.gz -O json-c.tar.gz
   tar xzf json-c.tar.gz --strip 1
 
@@ -44,8 +44,8 @@ fi
 
 # gpg21
 if [ ! -e "${GPG21_INSTALL}/bin/gpg2" ]; then
-  mkdir ~/builds/gpg21
-  cd ~/builds/gpg21
+  mkdir "${LOCAL_BUILDS}/gpg21"
+  cd "${LOCAL_BUILDS}/gpg21"
 
   gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 249B39D24F25E3B6 04376F3EE0856959 2071B08A33BD3F06 8A861B1C7EFD60D9
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -3,13 +3,13 @@ set -exu
 
 [ "$BUILD_MODE" = "style-check" ] && exit 0
 
-CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
+: "${CORES:=2}"
 
 # botan
 if [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.so" ] && [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.dylib" ]; then
   git clone https://github.com/randombit/botan ~/builds/botan
   cd ~/builds/botan
-  ./configure.py --cc=clang --prefix="${BOTAN_INSTALL}"
+  ./configure.py --prefix="${BOTAN_INSTALL}"
   make -j${CORES} install
 fi
 

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -35,3 +35,7 @@ make -j${CORES}
 cd src/tests
 ./rnp_tests
 
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${GPG21_INSTALL}/lib"
+export LD_LIBRARY_PATH
+env PATH="${GPG21_INSTALL}/bin:$PATH" python2 cli_tests.py all --debug
+

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -3,7 +3,7 @@ set -eux
 
 [ "$BUILD_MODE" = "style-check" ] && exec ci/style-check.sh
 
-CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
+: "${CORES:=2}"
 
 LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib"
 CFLAGS=""

--- a/packaging/redhat/extra/prepare_build.sh
+++ b/packaging/redhat/extra/prepare_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CORES="2" && [ -r /proc/cpuinfo ] && CORES=$(grep -c '^$' /proc/cpuinfo)
+: "${CORES:=2}"
 
 [ "x${RNP_BUILD_DIR}" = "x" ] && \
   export RNP_BUILD_DIR=$(mktemp -d)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -102,7 +102,10 @@ def setup():
     os.mkdir(RNPDIR, 0700)
 
     GPGDIR = path.join(WORKDIR, '.gpg')
-    GPG = find_utility('gpg')
+    GPG = find_utility('gpg2', False)
+    if not GPG:
+        GPG = find_utility('gpg')
+
     os.mkdir(GPGDIR, 0700)
 
     return

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -102,9 +102,7 @@ def setup():
     os.mkdir(RNPDIR, 0700)
 
     GPGDIR = path.join(WORKDIR, '.gpg')
-    GPG = find_utility('gpg2', False)
-    if not GPG:
-        GPG = find_utility('gpg')
+    GPG = find_utility('gpg')
 
     os.mkdir(GPGDIR, 0700)
 


### PR DESCRIPTION
Fixes https://github.com/riboseinc/rnp/issues/394#issuecomment-323879018

I also realized my mistake of setting CORES based on /proc/cpuinfo in Travis CI. The container's /proc/cpuinfo matches the host, of course, so sometimes we were trying to build botan and other things with 32 cores in a travis-ci container (which resulted in processes being killed). Now defaults to 2 cores and can be overridden.