### PR TITLE
One OpenPGP block can't be bigger than 0xffffffff, so, switched to streaming if it required

### DIFF
--- a/src/lib/readerwriter.h
+++ b/src/lib/readerwriter.h
@@ -58,12 +58,9 @@
 
 /* */
 unsigned pgp_write_mdc(pgp_output_t *, const uint8_t *);
-unsigned pgp_write_se_ip_pktset(pgp_output_t *,
-                                const uint8_t *,
-                                const unsigned,
-                                pgp_crypt_t *);
-void pgp_push_enc_crypt(pgp_output_t *, pgp_crypt_t *);
-bool pgp_push_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t);
+unsigned pgp_write_se_ip_pktset(pgp_output_t *, const uint8_t *, const size_t, pgp_crypt_t *);
+void     pgp_push_enc_crypt(pgp_output_t *, pgp_crypt_t *);
+bool     pgp_push_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t, size_t);
 
 /* Secret Key checksum */
 void     pgp_push_checksum_writer(pgp_output_t *, pgp_seckey_t *);

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -124,8 +124,10 @@ pgp_cipher_start(pgp_crypt_t *crypt, pgp_symm_alg_t alg, const uint8_t *key, con
     memset(crypt, 0x0, sizeof(*crypt));
 
     const char *cipher_name = pgp_sa_to_botan_string(alg);
-    if (cipher_name == NULL)
+    if (cipher_name == NULL) {
+        fprintf(stderr, "Unsupported algorithm: %d\n", alg);
         return false;
+    }
 
     crypt->alg = alg;
     crypt->blocksize = pgp_block_size(alg);
@@ -240,7 +242,7 @@ pgp_cipher_alg_id(pgp_crypt_t *cipher)
     return cipher->alg;
 }
 
-int
+size_t
 pgp_cipher_block_size(pgp_crypt_t *cipher)
 {
     return cipher->blocksize;

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -86,7 +86,7 @@ bool pgp_cipher_start(pgp_crypt_t *  cipher,
 // Deallocate all storage
 int pgp_cipher_finish(pgp_crypt_t *cipher);
 
-int pgp_cipher_block_size(pgp_crypt_t *cipher);
+size_t pgp_cipher_block_size(pgp_crypt_t *cipher);
 pgp_symm_alg_t pgp_cipher_alg_id(pgp_crypt_t *cipher);
 
 // CFB encryption/decryption

--- a/src/lib/writer.h
+++ b/src/lib/writer.h
@@ -65,7 +65,7 @@
  */
 
 typedef struct pgp_writer_t pgp_writer_t;
-typedef bool pgp_writer_func_t(const uint8_t *, unsigned, pgp_error_t **, pgp_writer_t *);
+typedef bool pgp_writer_func_t(const uint8_t *, size_t, pgp_error_t **, pgp_writer_t *);
 typedef bool pgp_writer_finaliser_t(pgp_error_t **, pgp_writer_t *);
 typedef void pgp_writer_destroyer_t(pgp_writer_t *);
 
@@ -98,7 +98,7 @@ unsigned pgp_writer_passthrough(const uint8_t *, unsigned, pgp_error_t **, pgp_w
 void     pgp_writer_set_fd(pgp_output_t *, int);
 unsigned pgp_writer_close(pgp_output_t *);
 
-bool pgp_write(pgp_output_t *, const void *, unsigned);
+bool pgp_write(pgp_output_t *, const void *, size_t);
 bool pgp_write_length(pgp_output_t *, unsigned);
 bool pgp_write_ptag(pgp_output_t *, pgp_content_enum);
 bool pgp_write_scalar(pgp_output_t *, unsigned, unsigned);
@@ -107,7 +107,7 @@ bool pgp_write_mpi(pgp_output_t *, const BIGNUM *);
 void     pgp_writer_info_delete(pgp_writer_t *);
 unsigned pgp_writer_info_finalise(pgp_error_t **, pgp_writer_t *);
 
-void pgp_push_stream_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t);
+bool pgp_push_stream_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t);
 
 /* memory writing */
 bool pgp_setup_memory_write(rnp_ctx_t *, pgp_output_t **, pgp_memory_t **, size_t);


### PR DESCRIPTION
First step of #412.

Each OpenPGP block can be up to 4Gb size and in case if someone try to encrypt file >= 4Gb we should use the parital encoding.

Good new: we have this code and looks like it works.

Bad news:
 - we haven't got decryption code :(
 - sometime GnuPG can't decode the file that rnp provides.

But I'm using 'crypto-container' (gpg encrypted archives, from few gigabytes up to handreds gigabytes) and I can say that GnuPG not at all time can decrypt bigger file that it created :)