### PR TITLE
Added compression parameters selection to CLI

### DIFF
--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -184,6 +184,11 @@ zlib_compressed_data_reader(pgp_stream_t *stream,
         if (len + cc > length) {
             len = length - cc;
         }
+
+        if ((len == 0) && (z->inflate_ret == Z_STREAM_END)) {
+            return cc;
+        }
+
         (void) memcpy(&cdest[cc], &z->out[z->offset], len);
         z->offset += len;
     }

--- a/src/lib/compress.c
+++ b/src/lib/compress.c
@@ -258,6 +258,11 @@ bzip2_compressed_data_reader(pgp_stream_t *stream,
             return 0;
         }
         len = (size_t)(bz->bzstream.next_out - &bz->out[bz->offset]);
+
+        if ((len == 0) && (bz->inflate_ret == BZ_STREAM_END)) {
+            return cc;
+        }
+
         if (len + cc > length) {
             len = length - cc;
         }

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -984,8 +984,12 @@ encrypt_se_ip_writer(const uint8_t *src,
     }
 
     /* create compressed packet from literal data packet */
-    if (compress && !pgp_writez(zoutput, pgp_mem_data(litmem), (unsigned) pgp_mem_len(litmem),
-                    writer->ctx->zalg, writer->ctx->zlevel)) {
+    if (compress &&
+        !pgp_writez(zoutput,
+                    pgp_mem_data(litmem),
+                    (unsigned) pgp_mem_len(litmem),
+                    writer->ctx->zalg,
+                    writer->ctx->zlevel)) {
         RNP_LOG("Compression failed");
         return false;
     }

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -581,7 +581,7 @@ process_dash_escaped(pgp_stream_t *stream,
         }
 
         if (c == '\n' && body->length) {
-            if ((body->length > 2) && 
+            if ((body->length > 2) &&
                 (memchr(body->data + 2, '\n', body->length - 2) != NULL)) {
                 (void) fprintf(stderr, "process_dash_escaped: newline found\n");
                 return -1;
@@ -990,7 +990,7 @@ armoured_data_reader(pgp_stream_t *stream,
             return n;
         } else {
             length -= n;
-            dest_ = (char*)dest_ + n;
+            dest_ = (char *) dest_ + n;
         }
     }
 

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -680,7 +680,7 @@ main(int argc, char **argv)
                 if ((strlen(optarg) != 1) || (optarg[0] < '0') || (optarg[0] > '9')) {
                     fprintf(stderr, "Bad compression level: %s. Should be 0..9\n", optarg);
                 } else {
-                    rnp_cfg_setint(&cfg, CFG_ZLEVEL, (int)(optarg[0] - '0'));
+                    rnp_cfg_setint(&cfg, CFG_ZLEVEL, (int) (optarg[0] - '0'));
                 }
                 break;
             default:

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -52,6 +52,8 @@ rnp_cfg_load_defaults(rnp_cfg_t *cfg)
     rnp_cfg_setint(cfg, CFG_OVERWRITE, 1);
     rnp_cfg_set(cfg, CFG_OUTFILE, NULL);
     rnp_cfg_set(cfg, CFG_HASH, DEFAULT_HASH_ALG);
+    rnp_cfg_setint(cfg, CFG_ZALG, PGP_C_ZIP);
+    rnp_cfg_setint(cfg, CFG_ZLEVEL, 6);
     rnp_cfg_set(cfg, CFG_CIPHER, "cast5");
     rnp_cfg_setint(cfg, CFG_MAXALLOC, 4194304);
     rnp_cfg_set(cfg, CFG_SUBDIRGPG, SUBDIRECTORY_RNP);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -63,7 +63,6 @@
 #define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
 #define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
 
-
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */
 typedef struct rnp_cfg_t {

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -60,6 +60,9 @@
 #define CFG_NUMBITS "numbits"           /* number of bits in generated key */
 #define CFG_KEYFORMAT "format"          /* key format : "human" for human-readable or ... */
 #define CFG_EXPERT "expert"             /* expert key generation mode */
+#define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
+#define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
+
 
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -65,6 +65,9 @@ def run_proc(proc, params):
     process = Popen([proc] + params, stdout=PIPE, stderr=PIPE)
     output, errout = process.communicate()
     retcode = process.poll()
+    if DEBUG:
+        print errout
+        print output
 
     return (retcode, output, errout)
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -11,6 +11,7 @@ import subprocess
 import re
 import random
 import string
+import time
 from subprocess import Popen, PIPE
 from cli_common import find_utility, run_proc, pswd_pipe, rnp_file_path, random_text, file_text
 import cli_common

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -125,12 +125,14 @@ def check_packets(fname, regexp):
         return result
 
 def clear_keyrings():
-    try:
-        shutil.rmtree(RNPDIR)
-        shutil.rmtree(GPGDIR)
-    except:
-        pass
+    shutil.rmtree(RNPDIR, ignore_errors=True)
     os.mkdir(RNPDIR, 0700)
+
+    while os.path.isdir(GPGDIR):
+        try:
+            shutil.rmtree(GPGDIR)
+        except:
+            time.sleep(0.1)
     os.mkdir(GPGDIR, 0700)
 
 def compare_files(src, dst, message):

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -105,7 +105,7 @@ def setup():
     global RMWORKDIR, WORKDIR, RNPDIR, RNP, RNPK, GPG, GPGDIR
     WORKDIR = os.getcwd()
     if not '/tmp/' in WORKDIR:
-        WORKDIR = tempfile.mkdtemp()
+        WORKDIR = tempfile.mkdtemp(prefix = 'rnpctmp')
         RMWORKDIR = True
 
     print 'Running in ' + WORKDIR

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -508,6 +508,7 @@ def rnp_encryption_gpg_to_rnp(cipher, filesize, zlevel = 6, zalgo = 1):
         # Decrypt encrypted file with RNP
         rnp_decrypt_file(dst, dec)
         compare_files(src, dec, 'rnp decrypted data differs')
+        remove_files(dst, dec)
 
 def rnp_encryption_rnp_to_gpg(filesize, zlevel = 6, zalgo = 'zip'):
     src, dst, enc = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
@@ -519,9 +520,11 @@ def rnp_encryption_rnp_to_gpg(filesize, zlevel = 6, zalgo = 'zip'):
         # Decrypt encrypted file with GPG
         gpg_decrypt_file(enc, dst, PASSWORD)
         compare_files(src, dst, 'gpg decrypted data differs')
+        remove_files(dst)
         # Decrypt encrypted file with RNP
         rnp_decrypt_file(enc, dst)
         compare_files(src, dst, 'rnp decrypted data differs')
+        remove_files(enc, dst)
 
 '''
     Things to try later:
@@ -566,7 +569,7 @@ def rnp_signing_rnp_to_gpg(filesize):
         # Verify signed message with GPG
         gpg_verify_file(sig, ver, KEY_SIGN_RNP)
         compare_files(src, ver, 'gpg verified data differs')
-        remove_files(ver)
+        remove_files(sig, ver)
 
 def rnp_detached_signing_rnp_to_gpg(filesize):
     src, sig, asc = reg_workfiles('cleartext', '.txt', '.txt.sig', '.txt.asc')
@@ -603,6 +606,7 @@ def rnp_signing_gpg_to_rnp(filesize, zlevel = 6, zalgo = 1):
         # Verify file with RNP
         rnp_verify_file(sig, ver, KEY_SIGN_GPG)
         compare_files(src, ver, 'rnp verified data differs')
+        remove_files(sig, ver)
 
 def rnp_detached_signing_gpg_to_rnp(filesize):
     src, sig, asc = reg_workfiles('cleartext', '.txt', '.txt.sig', '.txt.asc')

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python2
 
 import sys
-import distutils.spawn
 import tempfile
 import getopt
 import os
 from os import path
 import shutil
-import subprocess
 import re
 import random
 import string
 import time
-from subprocess import Popen, PIPE
 from cli_common import find_utility, run_proc, pswd_pipe, rnp_file_path, random_text, file_text
 import cli_common
 
@@ -92,6 +89,17 @@ r'using .* key .*' \
 r'signature .*' \
 r'uid\s+(.*)\s*$'
 
+class CLIError(Exception):
+    def __init__(self, message, log = None):
+        super(Exception, self).__init__(message)
+        self.log = log
+
+    def __str__(self):
+        if DEBUG and self.log:
+            return self.message + '\n' + self.log
+        else:
+            return self.message
+
 def setup():
     # Setting up directories.
     global RMWORKDIR, WORKDIR, RNPDIR, RNP, RNPK, GPG, GPGDIR
@@ -148,9 +156,10 @@ def remove_files(*args):
         pass
 
 def raise_err(msg, log = None):
-    if log and DEBUG:
-        print log
-    raise NameError(msg)
+    #if log and DEBUG:
+    #    print log
+    #raise NameError(msg)
+    raise CLIError(msg, log)
 
 def reg_workfiles(mainname, *exts):
     global TEST_WORKFILES
@@ -727,6 +736,7 @@ def run_tests():
         sys.exit(2)
 
     # Parameters are ok so we can proceed
+
     setup()
 
     if 'rnpkeys' in tests:

--- a/src/tests/perf_tests.py
+++ b/src/tests/perf_tests.py
@@ -46,7 +46,7 @@ def setup():
     GPG = find_utility('gpg')
     WORKDIR = os.getcwd()
     if not '/tmp/' in WORKDIR:
-        WORKDIR = tempfile.mkdtemp()
+        WORKDIR = tempfile.mkdtemp(prefix = 'rnpptmp')
         RMWORKDIR = True
 
     print 'Setting up test in {} ...'.format(WORKDIR)


### PR DESCRIPTION
- Added --zlib, --zip and --bzip2, -z 0..9 parameters to the rnp commandline and implemented their handling. Since compression now is used only during encryption it works only in this case.
- Fixed hanging bug in bzip2 decompression
- Updated CLI tests with more compression/decompression cases
- (hopefully) Fixed possible random CLI tests crash in Travis
- fixes #359 