### PR TITLE
Copy primary crypto params to subkey crypto params in non-expert mode.

### DIFF
--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -191,6 +191,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         if (!rnp_cfg_getbool(cfg, CFG_EXPERT)) {
             key_desc->primary.crypto.key_alg = PGP_PKA_RSA;
             key_desc->primary.crypto.rsa.modulus_bit_len = rnp_cfg_getint(cfg, CFG_NUMBITS);
+            key_desc->subkey.crypto = key_desc->primary.crypto;
         } else if (rnp_generate_key_expert_mode(rnp) != PGP_E_OK) {
             RNP_LOG("Critical error: Key generation failed");
             return false;


### PR DESCRIPTION
Otherwise you may do something like:
```
rnpkeys --gen-key --numbits 1024
```
And you'll get a primary key 1024-bit RSA key but a 2048-bit (the default) subkey.