### PR TITLE
Add support for writing unencrypted pgp seckeys

### DIFF
--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -74,10 +74,6 @@
 #define MAX_SYMM_KEY_SIZE 32
 #define NTAGS 0x100 /* == 256 */
 
-/* SHA1 Hash Size */
-#define PGP_SHA1_HASH_SIZE 20
-#define PGP_CHECKHASH_SIZE PGP_SHA1_HASH_SIZE
-
 void pgp_crypto_finish(void);
 
 /* raw key generation */

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -338,7 +338,7 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *      desc,
     if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
         goto end;
     }
-    if (!pgp_write_struct_seckey(PGP_PTAG_CT_SECRET_KEY, &seckey, passphrase, output) ||
+    if (!pgp_write_struct_seckey(output, PGP_PTAG_CT_SECRET_KEY, &seckey, passphrase) ||
         !pgp_write_struct_userid(output, desc->cert.userid) ||
         !pgp_write_selfsig_cert(output, &seckey, desc->crypto.hash_alg, &desc->cert)) {
         RNP_LOG("failed to write out generated key+sigs");
@@ -490,7 +490,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
     if (!pgp_setup_memory_write(NULL, &output, &mem, 4096)) {
         goto end;
     }
-    if (!pgp_write_struct_seckey(PGP_PTAG_CT_SECRET_SUBKEY, &seckey, passphrase, output) ||
+    if (!pgp_write_struct_seckey(output, PGP_PTAG_CT_SECRET_SUBKEY, &seckey, passphrase) ||
         !pgp_write_selfsig_binding(
           output, primary_decrypted, desc->crypto.hash_alg, &seckey.pubkey, &desc->binding)) {
         RNP_LOG("failed to write out generated key+sigs");

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -275,7 +275,6 @@ write_seckey_body(pgp_seckey_t *key, const char *passphrase, pgp_output_t *outpu
     /* RFC4880 Section 5.5.3 Secret-Key Packet Formats */
 
     uint8_t sesskey[PGP_MAX_KEY_SIZE];
-    uint8_t checkhash[PGP_CHECKHASH_SIZE];
     size_t  sesskey_size;
 
     sesskey_size = pgp_key_size(key->alg);
@@ -405,10 +404,10 @@ write_seckey_body(pgp_seckey_t *key, const char *passphrase, pgp_output_t *outpu
         return false;
     }
     pgp_writer_pop(output); // hash
-    if (!pgp_hash_finish(hash, checkhash)) {
+    if (!pgp_hash_finish(hash, key->checkhash)) {
         return false;
     }
-    if (!pgp_write(output, checkhash, PGP_CHECKHASH_SIZE)) {
+    if (!pgp_write(output, key->checkhash, PGP_CHECKHASH_SIZE)) {
         return false;
     }
 

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -86,7 +86,7 @@ unsigned pgp_write_ss_header(pgp_output_t *, unsigned, pgp_content_enum);
 
 bool     pgp_write_struct_pubkey(pgp_output_t *, pgp_content_enum, const pgp_pubkey_t *);
 unsigned pgp_write_struct_seckey(pgp_content_enum,
-                                 const pgp_seckey_t *,
+                                 pgp_seckey_t *,
                                  const char *,
                                  pgp_output_t *);
 unsigned pgp_write_one_pass_sig(pgp_output_t *,

--- a/src/lib/packet-create.h
+++ b/src/lib/packet-create.h
@@ -85,10 +85,10 @@ unsigned pgp_write_struct_userid(pgp_output_t *, const uint8_t *);
 unsigned pgp_write_ss_header(pgp_output_t *, unsigned, pgp_content_enum);
 
 bool     pgp_write_struct_pubkey(pgp_output_t *, pgp_content_enum, const pgp_pubkey_t *);
-unsigned pgp_write_struct_seckey(pgp_content_enum,
+unsigned pgp_write_struct_seckey(pgp_output_t *output,
+                                 pgp_content_enum,
                                  pgp_seckey_t *,
-                                 const char *,
-                                 pgp_output_t *);
+                                 const char *);
 unsigned pgp_write_one_pass_sig(pgp_output_t *,
                                 const pgp_seckey_t *,
                                 const pgp_hash_alg_t,

--- a/src/lib/readerwriter.h
+++ b/src/lib/readerwriter.h
@@ -59,7 +59,7 @@
 /* */
 unsigned pgp_write_mdc(pgp_output_t *, const uint8_t *);
 unsigned pgp_write_se_ip_pktset(pgp_output_t *, const uint8_t *, const size_t, pgp_crypt_t *);
-void     pgp_push_enc_crypt(pgp_output_t *, pgp_crypt_t *);
+bool     pgp_push_enc_crypt(pgp_output_t *, pgp_crypt_t *);
 bool     pgp_push_enc_se_ip(pgp_output_t *, const pgp_pubkey_t *, pgp_symm_alg_t, size_t);
 
 /* file writing */

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -182,6 +182,9 @@ pgp_cipher_cfb_resync_v2(pgp_crypt_t *crypt)
 int
 pgp_cipher_finish(pgp_crypt_t *crypt)
 {
+    if (!crypt) {
+        return 0;
+    }
     if (crypt->obj) {
         botan_block_cipher_destroy(crypt->obj);
         crypt->obj = NULL;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -64,6 +64,10 @@
 #define PGP_KEY_ID_SIZE 8
 #define PGP_FINGERPRINT_HEX_SIZE (PGP_FINGERPRINT_SIZE * 3) + 1
 
+/* SHA1 Hash Size */
+#define PGP_SHA1_HASH_SIZE 20
+#define PGP_CHECKHASH_SIZE PGP_SHA1_HASH_SIZE
+
 /** General-use structure for variable-length data
  */
 
@@ -202,7 +206,7 @@ typedef struct pgp_seckey_t {
     } key;
 
     unsigned checksum;
-    uint8_t *checkhash;
+    uint8_t  checkhash[PGP_CHECKHASH_SIZE];
 
     size_t                encrypted_data_len;
     uint8_t *             encrypted_data;

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -857,7 +857,7 @@ encrypt_destroyer(pgp_writer_t *writer)
 \ingroup Core_WritersNext
 \brief Push Encrypted Writer onto stack (create SE packets)
 */
-void
+bool
 pgp_push_enc_crypt(pgp_output_t *output, pgp_crypt_t *pgp_crypt)
 {
     /* Create encrypt to be used with this writer */
@@ -866,15 +866,18 @@ pgp_push_enc_crypt(pgp_output_t *output, pgp_crypt_t *pgp_crypt)
 
     if ((pgp_encrypt = calloc(1, sizeof(*pgp_encrypt))) == NULL) {
         (void) fprintf(stderr, "pgp_push_enc_crypt: bad alloc\n");
+        return false;
     } else {
         /* Setup the encrypt */
         pgp_encrypt->crypt = pgp_crypt;
         pgp_encrypt->free_crypt = 0;
         /* And push writer on stack */
         if (!pgp_writer_push(output, encrypt_writer, NULL, encrypt_destroyer, pgp_encrypt)) {
+            return false;
             free(pgp_encrypt);
         }
     }
+    return true;
 }
 
 /**************************************************************************/
@@ -1728,9 +1731,11 @@ pgp_writer_push_sum16(pgp_output_t *output)
     return pgp_writer_push(output, sum16_calculator, NULL, generic_destroyer, sum);
 }
 
-uint16_t pgp_writer_pop_sum16(pgp_output_t *output) {
-    uint16_t* sum = pgp_writer_get_arg(&output->writer);
-    uint16_t value = *sum;
+uint16_t
+pgp_writer_pop_sum16(pgp_output_t *output)
+{
+    uint16_t *sum = pgp_writer_get_arg(&output->writer);
+    uint16_t  value = *sum;
 
     pgp_writer_pop(output);
     return value;

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2468,10 +2468,6 @@ pgp_seckey_free(pgp_seckey_t *key)
     }
     pgp_seckey_free_secret_mpis(key);
     pgp_pubkey_free(&key->pubkey);
-    if (key->checkhash != NULL) {
-        free(key->checkhash);
-    }
-    key->checkhash = NULL;
 }
 
 static int
@@ -2683,19 +2679,11 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
         fprintf(stderr, "parse_seckey: end of crypted passphrase\n");
     }
     if (pkt.u.seckey.s2k_usage == PGP_S2KU_ENCRYPTED_AND_HASHED) {
-        /* XXX - Hard-coded SHA1 here ?? Check */
-        pkt.u.seckey.checkhash = calloc(1, PGP_SHA1_HASH_SIZE);
-        if (pkt.u.seckey.checkhash == NULL) {
-            (void) fprintf(stderr, "parse_seckey: bad alloc\n");
-            return false;
-        }
         if (!pgp_hash_create(&checkhash, PGP_HASH_SHA1)) {
-            free(pkt.u.seckey.checkhash);
             (void) fprintf(stderr, "parse_seckey: bad alloc\n");
             return false;
         }
         if (!pgp_reader_push_hash(stream, &checkhash)) {
-            free(pkt.u.seckey.checkhash);
             (void) fprintf(stderr, "parse_seckey: bad alloc\n");
             return false;
         }


### PR DESCRIPTION
This is based on the branch in https://github.com/riboseinc/rnp/pull/431 so that should be merged first. The last 4 commits are the ones relevant here.

Note: This adds the functionality for writing unencrypted keys but it does *not* use it yet.

This also cleans up a lot of the error handling in some of these functions.

My plan here is to:
* Add support for writing unencrypted pgp seckeys.
* Use unencrypted keys during key generation. (See below point)
* Add the concept of protect/unprotect. Will take care of things like those mentioned [here](https://github.com/riboseinc/rnp/issues/231#issuecomment-310108861).
* Do a few other things to get G10 support working again.