### PR TITLE
Re-add SM2 to allowed algs for pgp_create_pk_sesskey.

### DIFF
--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -821,6 +821,7 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
     case PGP_PKA_DSA:
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ECDH:
+    case PGP_PKA_SM2:
         break;
     default:
         RNP_LOG("Bad public key encryption algorithm");


### PR DESCRIPTION
It looks like this was accidentally dropped in https://github.com/riboseinc/rnp/pull/422, SM2 encryption fails without it.
We have tests for the lower-level SM2 enc/dec, but not for this particular piece so it wasn't caught.