### PR TITLE
Correct SM2 signature ID

### DIFF
--- a/src/lib/crypto/sm2.c
+++ b/src/lib/crypto/sm2.c
@@ -69,7 +69,7 @@ pgp_sm2_sign_hash(pgp_ecc_sig_t *         sign,
         goto end;
     }
 
-    if (botan_pk_op_sign_create(&signer, key, "Raw", 0)) {
+    if (botan_pk_op_sign_create(&signer, key, "", 0)) {
         goto end;
     }
 
@@ -144,7 +144,7 @@ pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
         goto end;
     }
 
-    if (botan_pk_op_verify_create(&verifier, pub, "Raw", 0)) {
+    if (botan_pk_op_verify_create(&verifier, pub, "", 0)) {
         goto end;
     }
 

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -444,7 +444,7 @@ pgp_check_sig(const uint8_t *     hash,
         break;
 
     case PGP_PKA_SM2:
-        ret = pgp_sm2_verify_hash(&sig->info.sig.ecdsa, hash, length, &signer->key.ecc) ==
+        ret = pgp_sm2_verify_hash(&sig->info.sig.ecc, hash, length, &signer->key.ecc) ==
               RNP_SUCCESS;
         break;
 
@@ -454,7 +454,7 @@ pgp_check_sig(const uint8_t *     hash,
         break;
 
     case PGP_PKA_ECDSA:
-        ret = (pgp_ecdsa_verify_hash(&sig->info.sig.ecdsa, hash, length, &signer->key.ecc) ==
+        ret = (pgp_ecdsa_verify_hash(&sig->info.sig.ecc, hash, length, &signer->key.ecc) ==
                RNP_SUCCESS);
         break;
 
@@ -467,23 +467,16 @@ pgp_check_sig(const uint8_t *     hash,
 }
 
 static bool
-hash_and_check_sig(pgp_hash_t *hash, const pgp_sig_t *sig, const pgp_pubkey_t *signer)
-{
-    uint8_t  hashout[PGP_MAX_HASH_SIZE];
-    unsigned n;
-
-    n = pgp_hash_finish(hash, hashout);
-    return pgp_check_sig(hashout, n, sig, signer);
-}
-
-static bool
 finalise_sig(pgp_hash_t *        hash,
              const pgp_sig_t *   sig,
              const pgp_pubkey_t *signer,
              const uint8_t *     raw_packet)
 {
     hash_add_trailer(hash, sig, raw_packet);
-    return hash_and_check_sig(hash, sig, signer);
+
+    uint8_t  hashout[PGP_MAX_HASH_SIZE];
+    size_t hash_len = pgp_hash_finish(hash, hashout);
+    return pgp_check_sig(hashout, hash_len, sig, signer);
 }
 
 /**

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -232,8 +232,7 @@ typedef struct pgp_sig_info_t {
         pgp_rsa_sig_t     rsa;     /* An RSA Signature */
         pgp_dsa_sig_t     dsa;     /* A DSA Signature */
         pgp_elgamal_sig_t elgamal; /* deprecated */
-        pgp_ecc_sig_t     ecc;     /* An ECDSA or EdDSA signature */
-        pgp_ecc_sig_t     ecdsa;   /* A ECDSA signature */
+        pgp_ecc_sig_t     ecc;     /* An ECC signature - ECDSA, SM2, or EdDSA */
         pgp_data_t        unknown; /* private or experimental */
     } sig;                         /* signature params */
     size_t   v4_hashlen;


### PR DESCRIPTION
This passed "Raw" but for SM2 the parameter is the associated userid, not the hash. Instead leave it empty.

Remove .ecdsa sig type from union and use .ecc everywhere since the same format is used for all ECC signature methods (ECDSA, SM2, EDDSA)

Inline hash_and_check_sig into its only caller, minor simplification.