### PR TITLE
Remove empty passphrase decryption attempt.

### DIFF
--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -434,12 +434,6 @@ pgp_decrypt_seckey(const pgp_key_t *                key,
         goto done;
     }
 
-    // try an empty passphrase first
-    decrypted_seckey = decryptor(key, "");
-    if (decrypted_seckey) {
-        goto done;
-    }
-
     // ask the provider for a passphrase
     if (!pgp_request_passphrase(provider, ctx, passphrase, sizeof(passphrase))) {
         goto done;


### PR DESCRIPTION
We added this originally in [PR 181](https://github.com/riboseinc/rnp/pull/181/files) because netpgp CVS added it, but they
probably added it because they don't actually support unencrypted
(password-less) keys, which we now do.

It's really inefficient to try decryption twice for each decryption
attempt, so it seems best to remove this now.