### PR TITLE
Improve key lock test

### DIFF
--- a/src/tests/key-unlock.c
+++ b/src/tests/key-unlock.c
@@ -32,40 +32,6 @@
 #include "utils.h"
 #include "hash.h"
 
-// this is a passphrase callback that will always fail
-static bool
-failing_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
-                            char *                      passphrase,
-                            size_t                      passphrase_size,
-                            void *                      userdata)
-{
-    return false;
-}
-
-// this is a passphrase callback that should never be called
-static bool
-asserting_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
-                              char *                      passphrase,
-                              size_t                      passphrase_size,
-                              void *                      userdata)
-{
-    assert_false(true);
-    return false;
-}
-
-// this is a passphrase callback that just copies the string in userdata to
-// the passphrase buffer
-static bool
-string_copy_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
-                                char *                      passphrase,
-                                size_t                      passphrase_size,
-                                void *                      userdata)
-{
-    const char *str = (const char *) userdata;
-    strncpy(passphrase, str, passphrase_size - 1);
-    return true;
-}
-
 void
 test_key_unlock_pgp(void **state)
 {

--- a/src/tests/support.c
+++ b/src/tests/support.c
@@ -462,3 +462,37 @@ destroy_global_rng()
     (void) botan_rng_destroy(global_rng);
     global_rng = NULL;
 }
+
+// this is a passphrase callback that will always fail
+bool
+failing_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                            char *                      passphrase,
+                            size_t                      passphrase_size,
+                            void *                      userdata)
+{
+    return false;
+}
+
+// this is a passphrase callback that should never be called
+bool
+asserting_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                              char *                      passphrase,
+                              size_t                      passphrase_size,
+                              void *                      userdata)
+{
+    assert_false(true);
+    return false;
+}
+
+// this is a passphrase callback that just copies the string in userdata to
+// the passphrase buffer
+bool
+string_copy_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                                char *                      passphrase,
+                                size_t                      passphrase_size,
+                                void *                      userdata)
+{
+    const char *str = (const char *) userdata;
+    strncpy(passphrase, str, passphrase_size - 1);
+    return true;
+}

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -134,3 +134,22 @@ bool get_random(uint8_t *data, size_t len);
 
 /** Ensures global handler for DRBG used in tests is destroyed. */
 void destroy_global_rng();
+
+// this is a passphrase callback that will always fail
+bool failing_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                                 char *                      passphrase,
+                                 size_t                      passphrase_size,
+                                 void *                      userdata);
+
+// this is a passphrase callback that should never be called
+bool asserting_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                                   char *                      passphrase,
+                                   size_t                      passphrase_size,
+                                   void *                      userdata);
+
+// this is a passphrase callback that just copies the string in userdata to
+// the passphrase buffer
+bool string_copy_passphrase_callback(const pgp_passphrase_ctx_t *ctx,
+                                     char *                      passphrase,
+                                     size_t                      passphrase_size,
+                                     void *                      userdata);


### PR DESCRIPTION
This just makes this test a little more thorough.
I also moved the passphrase callbacks to support because I used them in some other tests (future PR).