### PR TITLE
G10 rework and key protect/unprotect

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -111,13 +111,13 @@ typedef struct {
     uint32_t blob_created_at;
 } kbx_pgp_blob_t;
 
-enum key_store_format_t {
+typedef enum key_store_format_t {
     UNKNOW_KEY_STORE = 0,
     GPG_KEY_STORE,
     SSH_KEY_STORE,
     KBX_KEY_STORE,
     G10_KEY_STORE,
-};
+} key_store_format_t;
 
 #define RNP_KEYSTORE_GPG "GPG" /* GPG keystore format */
 #define RNP_KEYSTORE_KBX "KBX" /* KBX keystore format */
@@ -177,10 +177,7 @@ bool rnp_key_store_get_key_by_name(pgp_io_t *,
 bool rnp_key_store_get_next_key_by_name(
   pgp_io_t *, const rnp_key_store_t *, const char *, unsigned *, const pgp_key_t **);
 
-bool rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
-bool rnp_key_store_get_key_by_grip(pgp_io_t *,
-                                   const rnp_key_store_t *,
-                                   const uint8_t *,
-                                   pgp_pubkey_t **);
+bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
+pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, rnp_key_store_t *, const uint8_t *);
 
 #endif /* KEY_STORE_H_ */

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -38,9 +38,9 @@
 #include <stdbool.h>
 
 #include "memory.h"
-#include "pgp-key.h"
 
 typedef struct rnp_t rnp_t;
+typedef struct pgp_key_t pgp_key_t;
 
 typedef enum {
     KBX_EMPTY_BLOB = 0,

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -168,14 +168,14 @@ bool rnp_key_store_add_keydata(
 bool rnp_key_store_remove_key(pgp_io_t *, rnp_key_store_t *, const pgp_key_t *);
 bool rnp_key_store_remove_key_by_id(pgp_io_t *, rnp_key_store_t *, const uint8_t *);
 
-const pgp_key_t *rnp_key_store_get_key_by_id(
+pgp_key_t *rnp_key_store_get_key_by_id(
   pgp_io_t *, const rnp_key_store_t *, const unsigned char *, unsigned *, pgp_pubkey_t **);
 bool rnp_key_store_get_key_by_name(pgp_io_t *,
                                    const rnp_key_store_t *,
                                    const char *,
-                                   const pgp_key_t **);
+                                   pgp_key_t **);
 bool rnp_key_store_get_next_key_by_name(
-  pgp_io_t *, const rnp_key_store_t *, const char *, unsigned *, const pgp_key_t **);
+  pgp_io_t *, const rnp_key_store_t *, const char *, unsigned *, pgp_key_t **);
 
 bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
 pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, rnp_key_store_t *, const uint8_t *);

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -460,11 +460,11 @@ typedef enum {
 
 typedef enum pgp_op_t {
     PGP_OP_UNKNOWN = 0,
-    PGP_OP_GENERATE_KEY = 1,
-    PGP_OP_ADD_SUBKEY = 2,
-    PGP_OP_SIGN = 3,
-    PGP_OP_DECRYPT = 4,
-    PGP_OP_UNLOCK = 5
+    PGP_OP_ADD_SUBKEY = 1, /* adding a subkey, primary key passphrase required */
+    PGP_OP_SIGN = 2,       /* signing file or data */
+    PGP_OP_DECRYPT = 3,    /* decrypting file or data */
+    PGP_OP_UNLOCK = 4,     /* unlocking a key with pgp_key_unlock */
+    PGP_OP_PROTECT = 5,    /* adding protection to a key */
 } pgp_op_t;
 
 /** Hashing Algorithm Numbers.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -295,7 +295,6 @@ typedef enum {
                                * (X9.42, as defined for
                                * IETF-S/MIME) */
     PGP_PKA_EDDSA = 22,       /* EdDSA from draft-ietf-openpgp-rfc4880bis */
-
     PGP_PKA_SM2 = 99,         /* SM2 encryption/signature schemes */
 
     PGP_PKA_PRIVATE00 = 100, /* Private/Experimental Algorithm */
@@ -462,9 +461,10 @@ typedef enum {
 typedef enum pgp_op_t {
     PGP_OP_UNKNOWN = 0,
     PGP_OP_GENERATE_KEY = 1,
-    PGP_OP_SIGN = 2,
-    PGP_OP_DECRYPT = 3,
-    PGP_OP_UNLOCK = 4
+    PGP_OP_ADD_SUBKEY = 2,
+    PGP_OP_SIGN = 3,
+    PGP_OP_DECRYPT = 4,
+    PGP_OP_UNLOCK = 5
 } pgp_op_t;
 
 /** Hashing Algorithm Numbers.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -465,6 +465,7 @@ typedef enum pgp_op_t {
     PGP_OP_DECRYPT = 3,    /* decrypting file or data */
     PGP_OP_UNLOCK = 4,     /* unlocking a key with pgp_key_unlock */
     PGP_OP_PROTECT = 5,    /* adding protection to a key */
+    PGP_OP_UNPROTECT = 6   /* removing protection from a (locked) key */
 } pgp_op_t;
 
 /** Hashing Algorithm Numbers.

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -33,6 +33,17 @@
 #include "types.h"
 #include "pass-provider.h"
 
+typedef struct rnp_action_keygen_t {
+    struct {
+        rnp_keygen_primary_desc_t   keygen;
+        rnp_key_protection_params_t protection;
+    } primary;
+    struct {
+        rnp_keygen_subkey_desc_t    keygen;
+        rnp_key_protection_params_t protection;
+    } subkey;
+} rnp_action_keygen_t;
+
 /* structure used to keep application-wide rnp configuration: keyrings, password io, whatever
  * else */
 typedef struct rnp_t {
@@ -45,7 +56,7 @@ typedef struct rnp_t {
     int       pswdtries;     /* number of password tries, -1 for unlimited */
 
     union {
-        rnp_keygen_desc_t generate_key_ctx;
+        rnp_action_keygen_t generate_key_ctx;
     } action;
 
     pgp_passphrase_provider_t passphrase_provider;

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -80,7 +80,6 @@ __RCSID("$NetBSD: crypto.c,v 1.36 2014/02/17 07:39:19 agc Exp $");
 #include "crypto/eddsa.h"
 #include "crypto/elgamal.h"
 #include "crypto/rsa.h"
-#include "crypto/s2k.h"
 #include "crypto/sm2.h"
 #include "crypto.h"
 #include "readerwriter.h"
@@ -267,8 +266,6 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
     seckey->pubkey.version = PGP_V4;
     seckey->pubkey.birthtime = time(NULL);
     seckey->pubkey.alg = crypto->key_alg;
-    seckey->hash_alg =
-      (PGP_HASH_UNKNOWN == crypto->hash_alg) ? PGP_HASH_SHA1 : crypto->hash_alg;
 
     switch (seckey->pubkey.alg) {
     case PGP_PKA_RSA:
@@ -304,12 +301,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
         goto end;
         break;
     }
-
-    seckey->s2k_usage = PGP_S2KU_ENCRYPTED_AND_HASHED;
-    seckey->s2k_specifier = PGP_S2KS_ITERATED_AND_SALTED;
-    seckey->s2k_iterations = pgp_s2k_round_iterations(65536);
-    seckey->alg = crypto->sym_alg;
-    seckey->cipher_mode = PGP_SA_DEFAULT_CIPHER_MODE;
+    seckey->s2k_usage = PGP_S2KU_NONE;
     ok = true;
 
 end:

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -301,7 +301,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
         goto end;
         break;
     }
-    seckey->s2k_usage = PGP_S2KU_NONE;
+    seckey->protection.s2k.usage = PGP_S2KU_NONE;
     ok = true;
 
 end:

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -90,7 +90,8 @@ bool pgp_generate_seckey(const rnp_keygen_crypto_params_t *params, pgp_seckey_t 
 bool pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
                               bool                       merge_defaults,
                               pgp_key_t *                primary_sec,
-                              pgp_key_t *                primary_pub);
+                              pgp_key_t *                primary_pub,
+                              key_store_format_t         secformat);
 
 /** generate a new subkey
  *
@@ -113,7 +114,8 @@ bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
                          pgp_key_t *                      primary_pub,
                          pgp_key_t *                      subkey_sec,
                          pgp_key_t *                      subkey_pub,
-                         const pgp_passphrase_provider_t *passphrase_provider);
+                         const pgp_passphrase_provider_t *passphrase_provider,
+                         key_store_format_t               secformat);
 
 /** generate a new primary key and subkey
  *
@@ -131,7 +133,8 @@ bool pgp_generate_keypair(rnp_keygen_desc_t *desc,
                           pgp_key_t *        primary_sec,
                           pgp_key_t *        primary_pub,
                           pgp_key_t *        subkey_sec,
-                          pgp_key_t *        subkey_pub);
+                          pgp_key_t *        subkey_pub,
+                          key_store_format_t secformat);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -119,7 +119,8 @@ bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
 
 /** generate a new primary key and subkey
  *
- *  @param desc keygen description
+ *  @param primary_desc primary keygen description
+ *  @param subkey_desc subkey keygen description
  *  @param merge_defaults true if you want defaults to be set for unset
  *         keygen description parameters.
  *  @param primary_sec pointer to store the generated secret key, must not be NULL
@@ -128,13 +129,14 @@ bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
  *  @param subkey_pub pointer to store the generated public key, must not be NULL
  *  @return true if successful, false otherwise.
  **/
-bool pgp_generate_keypair(rnp_keygen_desc_t *desc,
-                          bool               merge_defaults,
-                          pgp_key_t *        primary_sec,
-                          pgp_key_t *        primary_pub,
-                          pgp_key_t *        subkey_sec,
-                          pgp_key_t *        subkey_pub,
-                          key_store_format_t secformat);
+bool pgp_generate_keypair(rnp_keygen_primary_desc_t *primary_desc,
+                          rnp_keygen_subkey_desc_t * subkey_desc,
+                          bool                       merge_defaults,
+                          pgp_key_t *                primary_sec,
+                          pgp_key_t *                primary_pub,
+                          pgp_key_t *                subkey_sec,
+                          pgp_key_t *                subkey_pub,
+                          key_store_format_t         secformat);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -85,17 +85,12 @@ bool pgp_generate_seckey(const rnp_keygen_crypto_params_t *params, pgp_seckey_t 
  *         keygen description parameters.
  *  @param primary_sec pointer to store the generated secret key, must not be NULL
  *  @param primary_pub pointer to store the generated public key, must not be NULL
- *  @param decrypted_seckey optional pointer to store the decrypted secret key
- *         before encryption, may be NULL
- *  @param passphrase_provider pointer to the passphrase provider, must not be NULL
  *  @return true if successful, false otherwise.
  **/
-bool pgp_generate_primary_key(rnp_keygen_primary_desc_t *      desc,
-                              bool                             merge_defaults,
-                              pgp_key_t *                      primary_sec,
-                              pgp_key_t *                      primary_pub,
-                              pgp_seckey_t *                   decrypted_seckey,
-                              const pgp_passphrase_provider_t *passphrase_provider);
+bool pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
+                              bool                       merge_defaults,
+                              pgp_key_t *                primary_sec,
+                              pgp_key_t *                primary_pub);
 
 /** generate a new subkey
  *
@@ -106,18 +101,16 @@ bool pgp_generate_primary_key(rnp_keygen_primary_desc_t *      desc,
  *         subkey, must not be NULL
  *  @param primary_pub pointer to the primary public key that will own this
  *         subkey, must not be NULL
- *  @param primary_seckey the decrypted primary secret key that will be used to
- *         create the subkey binding signature, must not be NULL
  *  @param subkey_sec pointer to store the generated secret key, must not be NULL
  *  @param subkey_pub pointer to store the generated public key, must not be NULL
- *  @param passphrase_provider pointer to the passphrase provider, must not be NULL
+ *  @param passphrase_provider the passphrase provider that will be used to
+ *         decrypt the primary key, may be NULL if primary key is unlocked
  *  @return true if successful, false otherwise.
  **/
 bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
                          bool                             merge_defaults,
                          pgp_key_t *                      primary_sec,
                          pgp_key_t *                      primary_pub,
-                         const pgp_seckey_t *             primary_decrypted,
                          pgp_key_t *                      subkey_sec,
                          pgp_key_t *                      subkey_pub,
                          const pgp_passphrase_provider_t *passphrase_provider);
@@ -131,16 +124,14 @@ bool pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
  *  @param primary_pub pointer to store the generated public key, must not be NULL
  *  @param subkey_sec pointer to store the generated secret key, must not be NULL
  *  @param subkey_pub pointer to store the generated public key, must not be NULL
- *  @param passphrase_provider pointer to the passphrase provider, must not be NULL
  *  @return true if successful, false otherwise.
  **/
-bool pgp_generate_keypair(rnp_keygen_desc_t *              desc,
-                          bool                             merge_defaults,
-                          pgp_key_t *                      primary_sec,
-                          pgp_key_t *                      primary_pub,
-                          pgp_key_t *                      subkey_sec,
-                          pgp_key_t *                      subkey_pub,
-                          const pgp_passphrase_provider_t *passphrase_provider);
+bool pgp_generate_keypair(rnp_keygen_desc_t *desc,
+                          bool               merge_defaults,
+                          pgp_key_t *        primary_sec,
+                          pgp_key_t *        primary_pub,
+                          pgp_key_t *        subkey_sec,
+                          pgp_key_t *        subkey_pub);
 
 void pgp_reader_push_decrypt(pgp_stream_t *, pgp_crypt_t *, pgp_region_t *);
 void pgp_reader_pop_decrypt(pgp_stream_t *);

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -481,11 +481,10 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *       desc,
 
     // decrypt the primary seckey if needed (for signatures)
     if (primary_sec->key.seckey.encrypted) {
-        decrypted_primary_seckey =
-          pgp_decrypt_seckey(primary_sec,
-                             passphrase_provider,
-                             &(pgp_passphrase_ctx_t){.op = PGP_OP_ADD_SUBKEY,
-                                                     .pubkey = pgp_get_pubkey(primary_sec)});
+        decrypted_primary_seckey = pgp_decrypt_seckey(
+          primary_sec,
+          passphrase_provider,
+          &(pgp_passphrase_ctx_t){.op = PGP_OP_ADD_SUBKEY, .key = primary_sec});
         if (!decrypted_primary_seckey) {
             goto end;
         }

--- a/src/lib/memory.h
+++ b/src/lib/memory.h
@@ -56,6 +56,7 @@
 
 #include <sys/types.h>
 #include <stdbool.h>
+#include <repgp/repgp_def.h>
 
 typedef struct pgp_output_t pgp_output_t;
 

--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -117,7 +117,7 @@ start:
             goto done;
         }
         if (strcmp(passphrase, buffer) != 0) {
-            printf("Passphrases do not match!\n\n");
+            puts("\nPassphrases do not match!");
             // currently will loop forever
             goto start;
         }
@@ -125,6 +125,7 @@ start:
     ok = true;
 
 done:
+    puts("");
     pgp_forget(buffer, sizeof(buffer));
     return ok;
 }

--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -91,20 +91,16 @@ rnp_passphrase_provider_stdin(const pgp_passphrase_ctx_t *ctx,
                               size_t                      passphrase_size,
                               void *                      userdata)
 {
-    uint8_t keyid[PGP_KEY_ID_SIZE];
-    char    keyidhex[PGP_KEY_ID_SIZE * 2 + 1];
-    char    target[sizeof(keyidhex) + 16];
-    char    prompt[128];
-    char    buffer[MAX_PASSPHRASE_LENGTH];
-    bool    ok = false;
+    char keyidhex[PGP_KEY_ID_SIZE * 2 + 1];
+    char target[sizeof(keyidhex) + 16];
+    char prompt[128];
+    char buffer[MAX_PASSPHRASE_LENGTH];
+    bool ok = false;
 
     if (!ctx || !passphrase || !passphrase_size) {
         goto done;
     }
-    if (!pgp_keyid(keyid, PGP_KEY_ID_SIZE, ctx->pubkey)) {
-        goto done;
-    }
-    rnp_strhexdump(keyidhex, keyid, PGP_KEY_ID_SIZE, "");
+    rnp_strhexdump(keyidhex, ctx->key->keyid, PGP_KEY_ID_SIZE, "");
     snprintf(target, sizeof(target), "key 0x%s", keyidhex);
 start:
     snprintf(prompt, sizeof(prompt), "Enter passphrase for %s: ", target);

--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -105,18 +105,13 @@ rnp_passphrase_provider_stdin(const pgp_passphrase_ctx_t *ctx,
         goto done;
     }
     rnp_strhexdump(keyidhex, keyid, PGP_KEY_ID_SIZE, "");
-    snprintf(target,
-             sizeof(target),
-             "%s%s 0x%s",
-             ctx->op == PGP_OP_GENERATE_KEY ? "new " : "",
-             pgp_is_primary_key_tag(ctx->key_type) ? "primary key" : "subkey",
-             keyidhex);
+    snprintf(target, sizeof(target), "key 0x%s", keyidhex);
 start:
     snprintf(prompt, sizeof(prompt), "Enter passphrase for %s: ", target);
     if (!rnp_getpass(prompt, passphrase, passphrase_size)) {
         goto done;
     }
-    if (ctx->op == PGP_OP_GENERATE_KEY) {
+    if (ctx->op == PGP_OP_PROTECT) {
         snprintf(prompt, sizeof(prompt), "Repeat passphrase for %s: ", target);
         if (!rnp_getpass(prompt, buffer, sizeof(buffer))) {
             goto done;

--- a/src/lib/pass-provider.h
+++ b/src/lib/pass-provider.h
@@ -28,11 +28,11 @@
 
 #include <rnp/rnp_sdk.h>
 
-typedef struct pgp_pubkey_t pgp_pubkey_t;
+typedef struct pgp_key_t pgp_key_t;
 
 typedef struct pgp_passphrase_ctx_t {
-    uint8_t             op;
-    const pgp_pubkey_t *pubkey;
+    uint8_t          op;
+    const pgp_key_t *key;
 } pgp_passphrase_ctx_t;
 
 typedef bool pgp_passphrase_callback_t(const pgp_passphrase_ctx_t *ctx,

--- a/src/lib/pass-provider.h
+++ b/src/lib/pass-provider.h
@@ -33,7 +33,6 @@ typedef struct pgp_pubkey_t pgp_pubkey_t;
 typedef struct pgp_passphrase_ctx_t {
     uint8_t             op;
     const pgp_pubkey_t *pubkey;
-    uint8_t             key_type;
 } pgp_passphrase_ctx_t;
 
 typedef bool pgp_passphrase_callback_t(const pgp_passphrase_ctx_t *ctx,

--- a/src/lib/pem.c
+++ b/src/lib/pem.c
@@ -85,6 +85,7 @@
 #include "crypto.h"
 #include "utils.h"
 #include "crypto/bn.h"
+#include "pgp-key.h"
 
 bool
 read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -737,9 +737,7 @@ pgp_key_unlock(pgp_key_t *key, const pgp_passphrase_provider_t *provider)
     }
 
     decrypted_seckey = pgp_decrypt_seckey(
-      key,
-      provider,
-      &(pgp_passphrase_ctx_t){.op = PGP_OP_UNLOCK, .pubkey = pgp_get_pubkey(key)});
+      key, provider, &(pgp_passphrase_ctx_t){.op = PGP_OP_UNLOCK, .key = key});
 
     if (decrypted_seckey) {
         // this shouldn't really be necessary, but just in case
@@ -860,11 +858,10 @@ pgp_key_protect(pgp_key_t *                      key,
     }
 
     // ask the provider for a passphrase
-    if (!pgp_request_passphrase(
-          passphrase_provider,
-          &(pgp_passphrase_ctx_t){.op = PGP_OP_PROTECT, .pubkey = pgp_get_pubkey(key)},
-          passphrase,
-          sizeof(passphrase))) {
+    if (!pgp_request_passphrase(passphrase_provider,
+                                &(pgp_passphrase_ctx_t){.op = PGP_OP_PROTECT, .key = key},
+                                passphrase,
+                                sizeof(passphrase))) {
         goto done;
     }
 
@@ -928,10 +925,10 @@ pgp_key_unprotect(pgp_key_t *key, const pgp_passphrase_provider_t *passphrase_pr
 
     seckey = &key->key.seckey;
     if (seckey->encrypted) {
-        decrypted_seckey = pgp_decrypt_seckey(
-          key,
-          passphrase_provider,
-          &(pgp_passphrase_ctx_t){.op = PGP_OP_UNPROTECT, .pubkey = pgp_get_pubkey(key)});
+        decrypted_seckey =
+          pgp_decrypt_seckey(key,
+                             passphrase_provider,
+                             &(pgp_passphrase_ctx_t){.op = PGP_OP_UNPROTECT, .key = key});
         if (!decrypted_seckey) {
             goto done;
         }

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -79,6 +79,8 @@ struct pgp_key_t {
     uint8_t            revoked;    /* key has been revoked */
     pgp_revoke_t       revocation; /* revocation reason */
     key_store_format_t format;     /* the format of the key in packets[0] */
+
+    bool is_protected; /* whether the key in packets[0] is encrypted (for secret keys) */
 };
 
 struct pgp_key_t *pgp_key_new(void);
@@ -175,6 +177,33 @@ bool pgp_key_unlock(pgp_key_t *key, const pgp_passphrase_provider_t *provider);
  *  @param key the key
  *  @return true if the key was unlocked, false otherwise
  **/
-void pgp_key_lock(pgp_key_t *key);
+bool pgp_key_lock(pgp_key_t *key);
+
+/** add protection to a key
+ *
+ *  @param key
+ *  @param format
+ *  @param passphrase_provider
+ *  @return true if key was successfully protected, false otherwise
+ **/
+bool pgp_key_protect(pgp_key_t *                      key,
+                     key_store_format_t               format,
+                     rnp_key_protection_params_t *    protection,
+                     const pgp_passphrase_provider_t *passphrase_provider);
+
+/** remove protection from a key
+ *
+ *  @param key
+ *  @param passphrase_provider
+ *  @return true if protection was successfully removed, false otherwise
+ **/
+bool pgp_key_unprotect(pgp_key_t *key, const pgp_passphrase_provider_t *passphrase_provider);
+
+/** check if a key is currently protected
+ *
+ *  @param key
+ *  @return true if the key is protected, false otherwise
+ **/
+bool pgp_key_is_protected(const pgp_key_t *key);
 
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1205,11 +1205,10 @@ rnp_sign_file(rnp_ctx_t * ctx,
         }
         if (!use_ssh_keys(ctx->rnp)) {
             if (pgp_key_is_locked(keypair)) {
-                decrypted_seckey =
-                  pgp_decrypt_seckey(keypair,
-                                     &ctx->rnp->passphrase_provider,
-                                     &(pgp_passphrase_ctx_t){
-                                       .op = PGP_OP_SIGN, .pubkey = pgp_get_pubkey(keypair)});
+                decrypted_seckey = pgp_decrypt_seckey(
+                  keypair,
+                  &ctx->rnp->passphrase_provider,
+                  &(pgp_passphrase_ctx_t){.op = PGP_OP_SIGN, .key = keypair});
                 if (decrypted_seckey == NULL) {
                     (void) fprintf(io->errs, "Bad passphrase\n");
                 }
@@ -1338,11 +1337,10 @@ rnp_sign_memory(rnp_ctx_t * ctx,
         }
         if (!use_ssh_keys(ctx->rnp)) {
             if (pgp_key_is_locked(keypair)) {
-                decrypted_seckey =
-                  pgp_decrypt_seckey(keypair,
-                                     &ctx->rnp->passphrase_provider,
-                                     &(pgp_passphrase_ctx_t){
-                                       .op = PGP_OP_SIGN, .pubkey = pgp_get_pubkey(keypair)});
+                decrypted_seckey = pgp_decrypt_seckey(
+                  keypair,
+                  &ctx->rnp->passphrase_provider,
+                  &(pgp_passphrase_ctx_t){.op = PGP_OP_SIGN, .key = keypair});
                 if (decrypted_seckey == NULL) {
                     (void) fprintf(io->errs, "Bad passphrase\n");
                 }

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1023,13 +1023,7 @@ rnp_generate_key(rnp_t *rnp)
     if (!primary_sec || !primary_pub || !subkey_sec || !subkey_pub) {
         goto end;
     }
-    if (!pgp_generate_keypair(desc,
-                              true,
-                              primary_sec,
-                              primary_pub,
-                              subkey_sec,
-                              subkey_pub,
-                              &rnp->passphrase_provider)) {
+    if (!pgp_generate_keypair(desc, true, primary_sec, primary_pub, subkey_sec, subkey_pub)) {
         RNP_LOG("failed to generate keys");
         goto end;
     }

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -542,8 +542,6 @@ typedef struct rnp_keygen_crypto_params_t {
     pgp_pubkey_alg_t key_alg;
     // Hash to be used for key signature
     pgp_hash_alg_t hash_alg;
-    // Symmetric algorithm to be used for secret key encryption
-    pgp_symm_alg_t sym_alg;
     union {
         struct ecc_t {
             pgp_curve_t curve;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -579,11 +579,6 @@ typedef struct rnp_keygen_subkey_desc_t {
     rnp_selfsig_binding_info   binding;
 } rnp_keygen_subkey_desc_t;
 
-typedef struct rnp_keygen_desc_t {
-    rnp_keygen_primary_desc_t primary;
-    rnp_keygen_subkey_desc_t  subkey;
-} rnp_keygen_desc_t;
-
 typedef struct rnp_key_protection_params_t {
     pgp_symm_alg_t    symm_alg;
     pgp_cipher_mode_t cipher_mode;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -170,18 +170,30 @@ unsigned pgp_is_hash_alg_supported(const pgp_hash_alg_t *);
 
 typedef struct pgp_key_t pgp_key_t;
 
+typedef struct pgp_s2k {
+    pgp_s2k_usage_t usage;
+
+    /* below fields may not all be valid, depending on the usage field above */
+    pgp_s2k_specifier_t specifier;
+    pgp_hash_alg_t      hash_alg;
+    uint8_t             salt[PGP_SALT_SIZE];
+    unsigned            iterations;
+} pgp_s2k;
+
+typedef struct pgp_key_protection_t {
+    pgp_s2k           s2k;         /* string-to-key kdf params */
+    pgp_symm_alg_t    symm_alg;    /* symmetric alg */
+    pgp_cipher_mode_t cipher_mode; /* block cipher mode */
+    uint8_t           iv[PGP_MAX_BLOCK_SIZE];
+} pgp_key_protection_t;
+
 /** pgp_seckey_t
  */
 typedef struct pgp_seckey_t {
-    pgp_pubkey_t        pubkey; /* public key */
-    pgp_s2k_usage_t     s2k_usage;
-    pgp_s2k_specifier_t s2k_specifier;
-    pgp_symm_alg_t      alg;         /* symmetric alg */
-    pgp_cipher_mode_t   cipher_mode; /* block cipher mode */
-    pgp_hash_alg_t      hash_alg;    /* hash algorithm */
-    uint8_t             salt[PGP_SALT_SIZE];
-    unsigned            s2k_iterations;
-    uint8_t             iv[PGP_MAX_BLOCK_SIZE];
+    /* Note: Keep this as the first field. */
+    pgp_pubkey_t pubkey; /* public key */
+
+    pgp_key_protection_t protection;
 
     /* This indicates the current state of the key union below.
      * If false, the key union contains valid secret key material
@@ -571,5 +583,12 @@ typedef struct rnp_keygen_desc_t {
     rnp_keygen_primary_desc_t primary;
     rnp_keygen_subkey_desc_t  subkey;
 } rnp_keygen_desc_t;
+
+typedef struct rnp_key_protection_params_t {
+    pgp_symm_alg_t    symm_alg;
+    pgp_cipher_mode_t cipher_mode;
+    unsigned          iterations;
+    pgp_hash_alg_t    hash_alg;
+} rnp_key_protection_params_t;
 
 #endif /* TYPES_H_ */

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -53,8 +53,10 @@
 
 #include <stdint.h>
 #include <rnp/rnp_def.h>
+#include "memory.h"
 #include "defs.h"
 #include "errors.h"
+#include "memory.h"
 #include "crypto/rsa.h"
 #include "crypto/dsa.h"
 #include "crypto/elgamal.h"
@@ -168,11 +170,6 @@ unsigned pgp_is_hash_alg_supported(const pgp_hash_alg_t *);
 
 typedef struct pgp_key_t pgp_key_t;
 
-struct pgp_seckey_t;
-
-typedef struct pgp_seckey_t *pgp_seckey_decrypt_t(const pgp_key_t *key,
-                                                  const char *     passphrase);
-
 /** pgp_seckey_t
  */
 typedef struct pgp_seckey_t {
@@ -207,11 +204,6 @@ typedef struct pgp_seckey_t {
 
     unsigned checksum;
     uint8_t  checkhash[PGP_CHECKHASH_SIZE];
-
-    size_t                encrypted_data_len;
-    uint8_t *             encrypted_data;
-    pgp_seckey_decrypt_t *decrypt_cb;
-    const char *protected_at[PGP_PROTECTED_AT_SIZE + 1]; // keep 1 byte for \0 and padding
 } pgp_seckey_t;
 
 /** Struct to hold a signature packet.

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -38,6 +38,7 @@
 #include "symmetric.h"
 #include "readerwriter.h"
 #include "misc.h"
+#include "pgp-key.h"
 
 #define G10_CBC_IV_SIZE 16
 

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -1068,6 +1068,7 @@ rnp_key_store_g10_from_mem(pgp_io_t *       io,
     memcpy(key->packets[0].raw, memory->buf, memory->length);
     key->packetc++;
     key->format = G10_KEY_STORE;
+    key->is_protected = keydata.seckey.encrypted;
     ret = true;
 
 done:

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -35,5 +35,10 @@ bool rnp_key_store_g10_from_mem(pgp_io_t *,
                                 rnp_key_store_t *,
                                 pgp_memory_t *);
 bool rnp_key_store_g10_key_to_mem(pgp_io_t *, pgp_key_t *, const uint8_t *, pgp_memory_t *);
+bool g10_write_seckey(pgp_output_t *output, pgp_seckey_t *seckey, const char *passphrase);
+pgp_seckey_t *g10_decrypt_seckey(const uint8_t *     data,
+                                 size_t              data_len,
+                                 const pgp_pubkey_t *pubkey,
+                                 const char *        passphrase);
 
 #endif // RNP_KEY_STORE_G10_H

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -137,6 +137,9 @@ cb_keyring_read(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         key = cb->key;
         cb->subsig = NULL;
         key->format = GPG_KEY_STORE;
+        if (pgp_is_key_secret(key)) {
+            key->is_protected = key->key.seckey.encrypted;
+        }
         if (pgp_is_subkey_tag(pkt->tag) && cb->last_primary) {
             EXPAND_ARRAY(cb->last_primary, subkey);
             if (!cb->last_primary->subkeys) {

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -646,7 +646,7 @@ rnp_key_store_remove_key_by_id(pgp_io_t *io, rnp_key_store_t *keyring, const uin
    not a copy.  Do not free it after use.
 
 */
-const pgp_key_t *
+pgp_key_t *
 rnp_key_store_get_key_by_id(pgp_io_t *             io,
                             const rnp_key_store_t *keyring,
                             const uint8_t *        keyid,
@@ -735,9 +735,9 @@ get_key_by_name(pgp_io_t *             io,
                 const rnp_key_store_t *keyring,
                 const char *           name,
                 unsigned *             from,
-                const pgp_key_t **     key)
+                pgp_key_t **     key)
 {
-    const pgp_key_t *kp;
+    pgp_key_t *kp;
     uint8_t **       uidp;
     unsigned         i = 0;
     pgp_key_t *      keyp;
@@ -809,10 +809,10 @@ get_key_by_name(pgp_io_t *             io,
 
 */
 bool
-rnp_key_store_get_key_by_name(pgp_io_t *             io,
-                              const rnp_key_store_t *keyring,
-                              const char *           name,
-                              const pgp_key_t **     key)
+rnp_key_store_get_key_by_name(pgp_io_t *              io,
+                              const rnp_key_store_t * keyring,
+                              const char *            name,
+                              pgp_key_t **key)
 {
     unsigned from;
 
@@ -825,7 +825,7 @@ rnp_key_store_get_next_key_by_name(pgp_io_t *             io,
                                    const rnp_key_store_t *keyring,
                                    const char *           name,
                                    unsigned *             n,
-                                   const pgp_key_t **     key)
+                                   pgp_key_t **     key)
 {
     return get_key_by_name(io, keyring, name, n, key);
 }

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -654,7 +654,7 @@ rnp_key_store_get_key_by_id(pgp_io_t *             io,
                             pgp_pubkey_t **        pubkey)
 {
     if (rnp_get_debug(__FILE__)) {
-        fprintf(io->errs, "looking keyring %p\n", keyring);
+        fprintf(io->errs, "searching keyring %p\n", keyring);
     }
 
     for (; keyring && *from < keyring->keyc; *from += 1) {
@@ -675,30 +675,23 @@ rnp_key_store_get_key_by_id(pgp_io_t *             io,
     return NULL;
 }
 
-bool
-rnp_key_store_get_key_by_grip(pgp_io_t *             io,
-                              const rnp_key_store_t *keyring,
-                              const uint8_t *        grip,
-                              pgp_pubkey_t **        pubkey)
+pgp_key_t *
+rnp_key_store_get_key_by_grip(pgp_io_t *io, rnp_key_store_t *keyring, const uint8_t *grip)
 {
     if (rnp_get_debug(__FILE__)) {
         fprintf(io->errs, "looking keyring %p\n", keyring);
     }
 
-    *pubkey = NULL;
     for (int i = 0; keyring && i < keyring->keyc; i++) {
         if (rnp_get_debug(__FILE__)) {
             hexdump(io->errs, "looking for grip", grip, PGP_FINGERPRINT_SIZE);
             hexdump(io->errs, "keyring grip", keyring->keys[i].grip, PGP_FINGERPRINT_SIZE);
         }
         if (memcmp(keyring->keys[i].grip, grip, PGP_FINGERPRINT_SIZE) == 0) {
-            if (pubkey) {
-                *pubkey = &keyring->keys[i].key.pubkey;
-            }
-            return true;
+            return &keyring->keys[i];
         }
     }
-    return false;
+    return NULL;
 }
 
 /* convert a string keyid into a binary keyid */

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -1034,20 +1034,26 @@ print_seckey_verbose(const pgp_content_enum type, const pgp_seckey_t *seckey)
     printf("------- SECRET KEY or ENCRYPTED SECRET KEY ------\n");
     print_tagname(0, (type == PGP_PTAG_CT_SECRET_KEY) ? "SECRET_KEY" : "ENCRYPTED_SECRET_KEY");
     /* pgp_print_pubkey(key); */
-    printf("S2K Usage: %d\n", seckey->s2k_usage);
-    if (seckey->s2k_usage != PGP_S2KU_NONE) {
-        printf("S2K Specifier: %d\n", seckey->s2k_specifier);
-        printf("Symmetric algorithm: %d (%s)\n", seckey->alg, pgp_show_symm_alg(seckey->alg));
+    printf("S2K Usage: %d\n", seckey->protection.s2k.usage);
+    if (seckey->protection.s2k.usage != PGP_S2KU_NONE) {
+        printf("S2K Specifier: %d\n", seckey->protection.s2k.specifier);
+        printf("Symmetric algorithm: %d (%s)\n",
+               seckey->protection.symm_alg,
+               pgp_show_symm_alg(seckey->protection.symm_alg));
         printf("Hash algorithm: %d (%s)\n",
-               seckey->hash_alg,
-               pgp_show_hash_alg((uint8_t) seckey->hash_alg));
-        if (seckey->s2k_specifier != PGP_S2KS_SIMPLE) {
-            print_hexdump(0, "Salt", seckey->salt, (unsigned) sizeof(seckey->salt));
+               seckey->protection.s2k.hash_alg,
+               pgp_show_hash_alg((uint8_t) seckey->protection.s2k.hash_alg));
+        if (seckey->protection.s2k.specifier != PGP_S2KS_SIMPLE) {
+            print_hexdump(0,
+                          "Salt",
+                          seckey->protection.s2k.salt,
+                          (unsigned) sizeof(seckey->protection.s2k.salt));
         }
-        if (seckey->s2k_specifier == PGP_S2KS_ITERATED_AND_SALTED) {
-            printf("Octet count: %u\n", seckey->s2k_iterations);
+        if (seckey->protection.s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
+            printf("Octet count: %u\n", seckey->protection.s2k.iterations);
         }
-        print_hexdump(0, "IV", seckey->iv, pgp_block_size(seckey->alg));
+        print_hexdump(
+          0, "IV", seckey->protection.iv, pgp_block_size(seckey->protection.symm_alg));
     }
     /* no more set if encrypted */
     if (seckey->encrypted) {
@@ -1075,7 +1081,7 @@ print_seckey_verbose(const pgp_content_enum type, const pgp_seckey_t *seckey)
     default:
         (void) fprintf(stderr, "print_seckey_verbose: unusual algorithm\n");
     }
-    if (seckey->s2k_usage == PGP_S2KU_ENCRYPTED_AND_HASHED) {
+    if (seckey->protection.s2k.usage == PGP_S2KU_ENCRYPTED_AND_HASHED) {
         print_hexdump(0, "Checkhash", seckey->checkhash, PGP_CHECKHASH_SIZE);
     } else {
         printf("Checksum: %04x\n", seckey->checksum);

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -2129,11 +2129,10 @@ pgp_get_seckey_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
             repgp_print_key(
               io, cbinfo->cryptinfo.pubring, pubkey, "signature ", &pubkey->key.pubkey, 0);
             /* now decrypt key */
-            secret =
-              pgp_decrypt_seckey(keypair,
-                                 &cbinfo->cryptinfo.passphrase_provider,
-                                 &(pgp_passphrase_ctx_t){.op = PGP_OP_DECRYPT,
-                                                         .pubkey = pgp_get_pubkey(keypair)});
+            secret = pgp_decrypt_seckey(
+              keypair,
+              &cbinfo->cryptinfo.passphrase_provider,
+              &(pgp_passphrase_ctx_t){.op = PGP_OP_DECRYPT, .key = keypair});
             if (secret != NULL) {
                 break;
             }

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -2133,8 +2133,7 @@ pgp_get_seckey_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
               pgp_decrypt_seckey(keypair,
                                  &cbinfo->cryptinfo.passphrase_provider,
                                  &(pgp_passphrase_ctx_t){.op = PGP_OP_DECRYPT,
-                                                         .pubkey = pgp_get_pubkey(keypair),
-                                                         .key_type = keypair->type});
+                                                         .pubkey = pgp_get_pubkey(keypair)});
             if (secret != NULL) {
                 break;
             }

--- a/src/librepgp/repgp.c
+++ b/src/librepgp/repgp.c
@@ -47,6 +47,7 @@
 #include "crypto.h"
 #include "reader.h"
 #include "validate.h"
+#include "pgp-key.h"
 
 repgp_handle_t *
 create_filepath_handle(const char *filename)

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -186,7 +186,6 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
             strcpy((char *) key_desc->primary.cert.userid, key);
         }
         key_desc->primary.crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
-        key_desc->primary.crypto.sym_alg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
 
         if (!rnp_cfg_getbool(cfg, CFG_EXPERT)) {
             key_desc->primary.crypto.key_alg = PGP_PKA_RSA;

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -149,9 +149,13 @@ ask_bitlen(FILE *input_fp)
 pgp_errcode_t
 rnp_generate_key_expert_mode(rnp_t *rnp)
 {
-    FILE *                      input_fd = rnp->user_input_fp ? rnp->user_input_fp : stdin;
-    rnp_keygen_desc_t *         key_desc = &rnp->action.generate_key_ctx;
-    rnp_keygen_crypto_params_t *crypto = &key_desc->primary.crypto;
+    FILE *                       input_fd = rnp->user_input_fp ? rnp->user_input_fp : stdin;
+    rnp_action_keygen_t *        action = &rnp->action.generate_key_ctx;
+    rnp_keygen_primary_desc_t *  primary_desc = &action->primary.keygen;
+    rnp_key_protection_params_t *primary_protection = &action->primary.protection;
+    rnp_keygen_subkey_desc_t *   subkey_desc = &action->subkey.keygen;
+    rnp_key_protection_params_t *subkey_protection = &action->subkey.protection;
+    rnp_keygen_crypto_params_t * crypto = &primary_desc->crypto;
 
     crypto->key_alg = (pgp_pubkey_alg_t) ask_algorithm(input_fd);
     // get more details about the key
@@ -216,7 +220,9 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
         return PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG;
     }
     // TODO this is mostly to get tests passing
-    key_desc->subkey.crypto = key_desc->primary.crypto;
+    subkey_desc->crypto = primary_desc->crypto;
+    primary_protection->hash_alg = crypto->hash_alg;
+    *subkey_protection = *primary_protection;
 
     return PGP_E_OK;
 }

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -13,7 +13,8 @@ rnp_tests_SOURCES   = \
     utils-list.c \
     pgp-parse.c \
     load-pgp.c \
-    key-unlock.c
+    key-unlock.c \
+    key-protect.c
 
 # don't install any test stuff
 install-binPROGRAMS:

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -143,7 +143,6 @@ pkcs1_rsa_test_success(void **state)
 
     const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_RSA,
                                                  .hash_alg = PGP_HASH_SHA256,
-                                                 .sym_alg = PGP_SA_AES_128,
                                                  .rsa = {.modulus_bit_len = 1024}};
     sec_key = calloc(1, sizeof(*sec_key));
     assert_non_null(sec_key);
@@ -207,7 +206,7 @@ rnp_test_eddsa(void **state)
 {
     rnp_test_state_t *               rstate = *state;
     const rnp_keygen_crypto_params_t key_desc = {
-      .key_alg = PGP_PKA_EDDSA, .hash_alg = PGP_HASH_SHA256, .sym_alg = PGP_SA_AES_128};
+      .key_alg = PGP_PKA_EDDSA, .hash_alg = PGP_HASH_SHA256};
 
     pgp_seckey_t *seckey = calloc(1, sizeof(*seckey));
     assert_non_null(seckey);
@@ -350,7 +349,6 @@ ecdsa_signverify_success(void **state)
         pgp_ecc_sig_t                    sig = {NULL, NULL};
         const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_ECDSA,
                                                      .hash_alg = PGP_HASH_SHA512,
-                                                     .sym_alg = PGP_SA_AES_128,
                                                      .ecc = {.curve = curves[i].id}};
 
         pgp_seckey_t *seckey1 = calloc(1, sizeof(*seckey1));
@@ -417,7 +415,6 @@ ecdh_roundtrip(void **state)
     for (int i = 0; i < ARRAY_SIZE(curves); i++) {
         const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_ECDH,
                                                      .hash_alg = PGP_HASH_SHA512,
-                                                     .sym_alg = PGP_SA_AES_256,
                                                      .ecc = {.curve = curves[i].id}};
 
         const size_t expected_result_byte_size = curves[i].size * 2 + 1;
@@ -478,7 +475,6 @@ ecdh_decryptionNegativeCases(void **state)
 
     const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_ECDH,
                                                  .hash_alg = PGP_HASH_SHA512,
-                                                 .sym_alg = PGP_SA_AES_256,
                                                  .ecc = {.curve = PGP_CURVE_NIST_P_256}};
 
     const size_t expected_result_byte_size = 32 * 2 + 1;
@@ -618,7 +614,6 @@ sm2_roundtrip(void **state)
 
     const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_SM2,
                                                  .hash_alg = PGP_HASH_SM3,
-                                                 .sym_alg = PGP_SA_SM4,
                                                  .ecc = {.curve = PGP_CURVE_SM2_P_256}};
 
     pgp_seckey_t *sec_key = calloc(1, sizeof(*sec_key));

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -64,9 +64,9 @@ rnpkeys_generatekey_testSignature(void **state)
 
         /* Generate the RSA key and make sure it was generated */
         set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_DEFAULT_HASH_ALGORITHM);
-        strncpy((char *) rnp.action.generate_key_ctx.primary.cert.userid,
+        strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
                 userId,
-                sizeof(rnp.action.generate_key_ctx.primary.cert.userid));
+                sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
         rnp_assert_ok(rstate, rnp_generate_key(&rnp));
 
         /* Load the newly generated rnp key */
@@ -172,9 +172,9 @@ rnpkeys_generatekey_testEncryption(void **state)
     strcpy(userId, "ciphertest");
     /* Generate the RSA key and make sure it was generated */
     set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_DEFAULT_HASH_ALGORITHM);
-    strncpy((char *) rnp.action.generate_key_ctx.primary.cert.userid,
+    strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
             userId,
-            sizeof(rnp.action.generate_key_ctx.primary.cert.userid));
+            sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
     rnp_assert_ok(rstate, rnp_generate_key(&rnp));
 
     /* Load keyring */
@@ -253,8 +253,8 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
     rnp_test_state_t *rstate = *state;
     const char *hashAlg[] = {"MD5", "SHA1", "SHA256", "SHA384", "SHA512", "SHA224", "SM3"};
     const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX};
-    rnp_t rnp;
-    int   pipefd[2];
+    rnp_t       rnp;
+    int         pipefd[2];
 
     for (int i = 0; i < sizeof(hashAlg) / sizeof(hashAlg[0]); i++) {
         for (int j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
@@ -265,9 +265,12 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
             set_default_rsa_key_desc(&rnp.action.generate_key_ctx,
                                      pgp_str_to_hash_alg(hashAlg[i]));
             rnp_assert_int_not_equal(
-              rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_UNKNOWN);
-            rnp_assert_int_not_equal(
-              rstate, rnp.action.generate_key_ctx.subkey.crypto.hash_alg, PGP_HASH_UNKNOWN);
+              rstate,
+              rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg,
+              PGP_HASH_UNKNOWN);
+            rnp_assert_int_not_equal(rstate,
+                                     rnp.action.generate_key_ctx.subkey.keygen.crypto.hash_alg,
+                                     PGP_HASH_UNKNOWN);
 
             /* Generate key with specified parameters */
             rnp_assert_ok(rstate, rnp_generate_key(&rnp));
@@ -306,8 +309,8 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
                              "rnpkeys_generatekey_verifyUserIdOption_SHA224"};
 
     const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX};
-    rnp_t rnp;
-    int   pipefd[2];
+    rnp_t       rnp;
+    int         pipefd[2];
 
     for (int i = 0; i < sizeof(userIds) / sizeof(userIds[0]); i++) {
         for (int j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
@@ -318,9 +321,9 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
             rnp_assert_ok(rstate, setup_rnp_common(&rnp, keystores[j], NULL, pipefd));
 
             set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_HASH_SHA256);
-            strncpy((char *) rnp.action.generate_key_ctx.primary.cert.userid,
+            strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
                     userId,
-                    sizeof(rnp.action.generate_key_ctx.primary.cert.userid));
+                    sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
             /* Generate the key with corresponding userId */
             rnp_assert_ok(rstate, rnp_generate_key(&rnp));
 
@@ -391,9 +394,9 @@ rnpkeys_generatekey_verifykeyHomeDirOption(void **state)
 
     /* Ensure the key was generated. */
     set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_HASH_SHA256);
-    strncpy((char *) rnp.action.generate_key_ctx.primary.cert.userid,
+    strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
             "newhomekey",
-            sizeof(rnp.action.generate_key_ctx.primary.cert.userid));
+            sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
     rnp_assert_ok(rstate, rnp_generate_key(&rnp));
 
     /* Pubring and secring should now exist */
@@ -465,9 +468,9 @@ rnpkeys_generatekey_verifykeyKBXHomeDirOption(void **state)
 
     /* Ensure the key was generated. */
     set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_HASH_SHA256);
-    strncpy((char *) rnp.action.generate_key_ctx.primary.cert.userid,
+    strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
             "newhomekey",
-            sizeof(rnp.action.generate_key_ctx.primary.cert.userid));
+            sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
     rnp_assert_ok(rstate, rnp_generate_key(&rnp));
 
     /* Pubring and secring should now exist, but only for the KBX */
@@ -593,94 +596,101 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdh_256, strlen(test_ecdh_256)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_ECDH);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDH);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_NIST_P_256);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_NIST_P_256);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA256);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA256);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdh_384, strlen(test_ecdh_384)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_ECDH);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDH);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_NIST_P_384);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_NIST_P_384);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA384);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA384);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdh_521, strlen(test_ecdh_521)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_ECDH);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDH);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_NIST_P_521);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_NIST_P_521);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA512);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA512);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_256, strlen(test_ecdsa_256)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_ECDSA);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_NIST_P_256);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_NIST_P_256);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA256);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA256);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_ECDSA);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_NIST_P_384);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_NIST_P_384);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA384);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA384);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_521, strlen(test_ecdsa_521)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_ECDSA);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_NIST_P_521);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_NIST_P_521);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA512);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA512);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate, ask_expert_details(&rnp, &ops, test_eddsa, strlen(test_eddsa)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_EDDSA);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_EDDSA);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_ED25519);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve, PGP_CURVE_ED25519);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_rsa_1024, strlen(test_rsa_1024)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_RSA);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_RSA);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.rsa.modulus_bit_len, 1024);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.rsa.modulus_bit_len, 1024);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate,
                     ask_expert_details(
                       &rnp, &ops, test_rsa_ask_twice_4096, strlen(test_rsa_ask_twice_4096)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_RSA);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_RSA);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.rsa.modulus_bit_len, 4096);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.rsa.modulus_bit_len, 4096);
     rnp_end(&rnp);
 
     rnp_assert_true(rstate, ask_expert_details(&rnp, &ops, test_sm2, strlen(test_sm2)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.key_alg, PGP_PKA_SM2);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_SM2);
+    rnp_assert_int_equal(rstate,
+                         rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
+                         PGP_CURVE_SM2_P_256);
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.ecc.curve, PGP_CURVE_SM2_P_256);
-    rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SM3);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SM3);
     rnp_end(&rnp);
 
     rnp_cfg_free(&ops);
@@ -701,7 +711,7 @@ generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state)
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA384);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA384);
 
     rnp_cfg_free(&ops);
 }
@@ -721,7 +731,7 @@ generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.crypto.hash_alg, PGP_HASH_SHA512);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.hash_alg, PGP_HASH_SHA512);
 
     rnp_cfg_free(&ops);
 }

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -252,8 +252,7 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
 
     rnp_test_state_t *rstate = *state;
     const char *hashAlg[] = {"MD5", "SHA1", "SHA256", "SHA384", "SHA512", "SHA224", "SM3"};
-    const char *keystores[] = {RNP_KEYSTORE_GPG, /* RNP_KEYSTORE_GPG21, */ RNP_KEYSTORE_KBX,
-                               /* RNP_KEYSTORE_G10 */};
+    const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX};
     rnp_t rnp;
     int   pipefd[2];
 
@@ -306,8 +305,7 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
                              "rnpkeys_generatekey_verifyUserIdOption_SHA512",
                              "rnpkeys_generatekey_verifyUserIdOption_SHA224"};
 
-    const char *keystores[] = {RNP_KEYSTORE_GPG, /* RNP_KEYSTORE_GPG21,*/ RNP_KEYSTORE_KBX,
-                               /* RNP_KEYSTORE_G10 */};
+    const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX};
     rnp_t rnp;
     int   pipefd[2];
 

--- a/src/tests/key-protect.c
+++ b/src/tests/key-protect.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../librekey/key_store_pgp.h"
+#include "pgp-key.h"
+
+#include "rnp_tests.h"
+#include "support.h"
+#include "utils.h"
+#include "hash.h"
+
+/* This test loads a .gpg keyring and tests protect/unprotect functionality.
+ * There is also some lock/unlock testing in here, since the two are
+ * somewhat related.
+ */
+void
+test_key_protect_load_pgp(void **state)
+{
+    rnp_test_state_t * rstate = *state;
+    char               path[PATH_MAX];
+    pgp_io_t           io = {.errs = stderr, .res = stdout, .outs = stdout};
+    pgp_key_t *        key = NULL;
+    static const char *keyids[] = {"7bc6709b15c23a4a", // primary
+                                   "1ed63ee56fadc34d",
+                                   "1d7e8a5393c997a8",
+                                   "8a05b89fad5aded1",
+                                   "2fcadf05ffa501bb", // primary
+                                   "54505a936a4a970e",
+                                   "326ef111425d14a5"};
+
+    // load our keyring and do some quick checks
+    {
+        rnp_key_store_t *ks = calloc(1, sizeof(*ks));
+        assert_non_null(ks);
+
+        pgp_memory_t mem = {0};
+        paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/secring.gpg", NULL);
+        assert_true(pgp_mem_readfile(&mem, path));
+        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+        pgp_memory_release(&mem);
+
+        for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
+            pgp_key_t * key = NULL;
+            const char *keyid = keyids[i];
+            assert_true(rnp_key_store_get_key_by_name(&io, ks, keyid, &key));
+            assert_non_null(key);
+            // all keys in this keyring are encrypted and thus should be both protected and
+            // locked initially
+            assert_true(pgp_key_is_protected(key));
+            assert_true(pgp_key_is_locked(key));
+        }
+
+        pgp_key_t *tmp = NULL;
+        assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &tmp));
+        assert_non_null(tmp);
+
+        // steal this key from the store
+        key = calloc(1, sizeof(*key));
+        assert_non_null(key);
+        memcpy(key, tmp, sizeof(*key));
+        assert_true(rnp_key_store_remove_key(&io, ks, tmp));
+        rnp_key_store_free(ks);
+    }
+
+    // confirm that this key is indeed RSA
+    assert_int_equal(key->key.pubkey.alg, PGP_PKA_RSA);
+
+    // confirm key material is currently all NULL (in other words, the key is locked)
+    assert_null(key->key.seckey.key.rsa.d);
+    assert_null(key->key.seckey.key.rsa.p);
+    assert_null(key->key.seckey.key.rsa.q);
+    assert_null(key->key.seckey.key.rsa.u);
+
+    // try to unprotect with a failing passphrase provider
+    assert_false(
+      pgp_key_unprotect(key,
+                        &(pgp_passphrase_provider_t){.callback = failing_passphrase_callback,
+                                                     .userdata = NULL}));
+
+    // try to unprotect with an incorrect passphrase
+    assert_false(pgp_key_unprotect(
+      key,
+      &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                   .userdata = "badpass"}));
+
+    // unprotect with the correct passphrase
+    assert_true(pgp_key_unprotect(
+      key,
+      &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                   .userdata = "password"}));
+    assert_false(pgp_key_is_protected(key));
+
+    // should still be locked
+    assert_true(pgp_key_is_locked(key));
+
+    // confirm secret key material is still NULL
+    assert_null(key->key.seckey.key.rsa.d);
+    assert_null(key->key.seckey.key.rsa.p);
+    assert_null(key->key.seckey.key.rsa.q);
+    assert_null(key->key.seckey.key.rsa.u);
+
+    // unlock (no passphrase required since the key is not protected)
+    assert_true(
+      pgp_key_unlock(key,
+                     &(pgp_passphrase_provider_t){.callback = asserting_passphrase_callback,
+                                                  .userdata = NULL}));
+    assert_false(pgp_key_is_locked(key));
+
+    // secret key material should be available
+    assert_non_null(key->key.seckey.key.rsa.d);
+    assert_non_null(key->key.seckey.key.rsa.p);
+    assert_non_null(key->key.seckey.key.rsa.q);
+    assert_non_null(key->key.seckey.key.rsa.u);
+
+    // save the secret MPIs for some later comparisons
+    BIGNUM *d = BN_dup(key->key.seckey.key.rsa.d);
+    BIGNUM *p = BN_dup(key->key.seckey.key.rsa.p);
+    BIGNUM *q = BN_dup(key->key.seckey.key.rsa.q);
+    BIGNUM *u = BN_dup(key->key.seckey.key.rsa.u);
+
+    // confirm that packets[0] is no longer encrypted
+    {
+        rnp_key_store_t *ks = calloc(1, sizeof(*ks));
+        assert_non_null(ks);
+
+        pgp_memory_t mem = {0};
+        mem.buf = key->packets[0].raw;
+        mem.length = key->packets[0].length;
+        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+
+        // grab the first key
+        pgp_key_t *reloaded_key = NULL;
+        assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &reloaded_key));
+        assert_non_null(reloaded_key);
+
+        // should not be locked, nor protected
+        assert_false(pgp_key_is_locked(reloaded_key));
+        assert_false(pgp_key_is_protected(reloaded_key));
+        // secret key material should not be NULL
+        assert_non_null(reloaded_key->key.seckey.key.rsa.d);
+        assert_non_null(reloaded_key->key.seckey.key.rsa.p);
+        assert_non_null(reloaded_key->key.seckey.key.rsa.q);
+        assert_non_null(reloaded_key->key.seckey.key.rsa.u);
+
+        // compare MPIs of the reloaded key, with the unlocked key from earlier
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.d));
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.p, reloaded_key->key.seckey.key.rsa.p));
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.q, reloaded_key->key.seckey.key.rsa.q));
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.u, reloaded_key->key.seckey.key.rsa.u));
+        // negative test to try to ensure the above is a valid test
+        assert_int_not_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.p));
+
+        // lock it
+        assert_true(pgp_key_lock(reloaded_key));
+        assert_true(pgp_key_is_locked(reloaded_key));
+        // confirm that secret MPIs are NULL again
+        assert_null(reloaded_key->key.seckey.key.rsa.d);
+        assert_null(reloaded_key->key.seckey.key.rsa.p);
+        assert_null(reloaded_key->key.seckey.key.rsa.q);
+        assert_null(reloaded_key->key.seckey.key.rsa.u);
+        // unlock it (no passphrase, since it's not protected)
+        assert_true(
+          pgp_key_unlock(reloaded_key,
+                         &(pgp_passphrase_provider_t){
+                           .callback = asserting_passphrase_callback, .userdata = NULL}));
+        assert_false(pgp_key_is_locked(reloaded_key));
+        // compare MPIs of the reloaded key, with the unlocked key from earlier
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.d));
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.p, reloaded_key->key.seckey.key.rsa.p));
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.q, reloaded_key->key.seckey.key.rsa.q));
+        assert_int_equal(
+          0, BN_cmp(key->key.seckey.key.rsa.u, reloaded_key->key.seckey.key.rsa.u));
+
+        rnp_key_store_free(ks);
+    }
+
+    // lock
+    assert_true(pgp_key_lock(key));
+
+    // try to protect (will fail when key is locked)
+    assert_false(
+      pgp_key_protect(key,
+                      key->format, // same format
+                      NULL,        // default protection
+                      &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                                   .userdata = "newpass"}));
+    assert_false(pgp_key_is_protected(key));
+
+    // unlock
+    assert_true(
+      pgp_key_unlock(key,
+                     &(pgp_passphrase_provider_t){.callback = asserting_passphrase_callback,
+                                                  .userdata = NULL}));
+    assert_false(pgp_key_is_locked(key));
+
+    // try to protect with a failing passphrase provider
+    assert_false(
+      pgp_key_protect(key,
+                      key->format, // same format
+                      NULL,        // default protection
+                      &(pgp_passphrase_provider_t){.callback = failing_passphrase_callback,
+                                                   .userdata = NULL}));
+    assert_false(pgp_key_is_protected(key));
+
+    // (re)protect with a new password
+    assert_true(
+      pgp_key_protect(key,
+                      key->format, // same format
+                      NULL,        // default protection
+                      &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                                   .userdata = "newpass"}));
+    assert_true(pgp_key_is_protected(key));
+
+    // lock
+    assert_true(pgp_key_lock(key));
+    assert_true(pgp_key_is_locked(key));
+
+    // try to unlock with old password
+    assert_false(
+      pgp_key_unlock(key,
+                     &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                                  .userdata = "password"}));
+    assert_true(pgp_key_is_locked(key));
+
+    // unlock with new password
+    assert_true(
+      pgp_key_unlock(key,
+                     &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                                  .userdata = "newpass"}));
+    assert_false(pgp_key_is_locked(key));
+
+    // compare secret MPIs with those from earlier
+    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.d, d));
+    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.p, p));
+    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.q, q));
+    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.u, u));
+
+    // cleanup
+    pgp_key_free(key);
+    BN_free(d);
+    BN_free(p);
+    BN_free(q);
+    BN_free(u);
+}

--- a/src/tests/key-unlock.c
+++ b/src/tests/key-unlock.c
@@ -38,7 +38,7 @@ test_key_unlock_pgp(void **state)
     rnp_test_state_t *        rstate = *state;
     char                      path[PATH_MAX];
     rnp_t                     rnp;
-    const pgp_key_t *         key = NULL;
+    pgp_key_t *         key = NULL;
     rnp_ctx_t                 ctx;
     const char *              data = "my test data";
     char                      signature[512] = {0};
@@ -98,19 +98,19 @@ test_key_unlock_pgp(void **state)
     // try to unlock with a failing passphrase provider
     provider =
       (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
-    rnp_assert_false(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_false(rstate, pgp_key_unlock(key, &provider));
     rnp_assert_true(rstate, pgp_key_is_locked(key));
 
     // try to unlock with an incorrect passphrase
     provider = (pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
                                            .userdata = "badpass"};
-    rnp_assert_false(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_false(rstate, pgp_key_unlock(key, &provider));
     rnp_assert_true(rstate, pgp_key_is_locked(key));
 
     // unlock the signing key
     provider = (pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
                                            .userdata = "password"};
-    rnp_assert_true(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_true(rstate, pgp_key_unlock(key, &provider));
     rnp_assert_false(rstate, pgp_key_is_locked(key));
 
     // confirm the secret MPIs are NULL
@@ -146,7 +146,7 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_free(&ctx);
 
     // lock the signing key
-    pgp_key_lock((pgp_key_t *) key);
+    rnp_assert_true(rstate, pgp_key_lock(key));
     rnp_assert_true(rstate, pgp_key_is_locked(key));
     rnp.passphrase_provider =
       (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};
@@ -185,7 +185,7 @@ test_key_unlock_pgp(void **state)
     // unlock the encrypting key
     provider = (pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
                                            .userdata = "password"};
-    rnp_assert_true(rstate, pgp_key_unlock((pgp_key_t *) key, &provider));
+    rnp_assert_true(rstate, pgp_key_unlock(key, &provider));
     rnp_assert_false(rstate, pgp_key_is_locked(key));
 
     // decrypt, with no passphrase
@@ -196,7 +196,7 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_free(&ctx);
 
     // lock the encrypting key
-    pgp_key_lock((pgp_key_t *) key);
+    rnp_assert_true(rstate, pgp_key_lock(key));
     rnp_assert_true(rstate, pgp_key_is_locked(key));
     rnp.passphrase_provider =
       (pgp_passphrase_provider_t){.callback = failing_passphrase_callback, .userdata = NULL};

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -159,7 +159,8 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_load_v4_keyring_pgp),
       cmocka_unit_test(test_load_keyring_and_count_pgp),
       cmocka_unit_test(pgp_compress_roundtrip),
-      cmocka_unit_test(test_key_unlock_pgp)};
+      cmocka_unit_test(test_key_unlock_pgp),
+      cmocka_unit_test(test_key_protect_load_pgp)};
 
     /* Each test entry will invoke setup_test before running
      * and teardown_test after running. */

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -93,6 +93,8 @@ void pgp_compress_roundtrip(void **state);
 
 void test_key_unlock_pgp(void **state);
 
+void test_key_protect_load_pgp(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \

--- a/src/tests/support.c
+++ b/src/tests/support.c
@@ -419,10 +419,10 @@ setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pi
 }
 
 void
-set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc, pgp_hash_alg_t hashalg)
+set_default_rsa_key_desc(rnp_action_keygen_t *action, pgp_hash_alg_t hashalg)
 {
-    rnp_keygen_primary_desc_t *primary = &key_desc->primary;
-    rnp_keygen_subkey_desc_t * subkey = &key_desc->subkey;
+    rnp_keygen_primary_desc_t *primary = &action->primary.keygen;
+    rnp_keygen_subkey_desc_t * subkey = &action->subkey.keygen;
 
     primary->crypto.key_alg = PGP_PKA_RSA;
     primary->crypto.rsa.modulus_bit_len = 1024;

--- a/src/tests/support.c
+++ b/src/tests/support.c
@@ -425,12 +425,10 @@ set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc, pgp_hash_alg_t hashalg)
     rnp_keygen_subkey_desc_t * subkey = &key_desc->subkey;
 
     primary->crypto.key_alg = PGP_PKA_RSA;
-    primary->crypto.sym_alg = PGP_SA_DEFAULT_CIPHER;
     primary->crypto.rsa.modulus_bit_len = 1024;
     primary->crypto.hash_alg = hashalg;
 
     subkey->crypto.key_alg = PGP_PKA_RSA;
-    subkey->crypto.sym_alg = PGP_SA_DEFAULT_CIPHER;
     subkey->crypto.rsa.modulus_bit_len = 1024;
     subkey->crypto.hash_alg = hashalg;
 }

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -118,7 +118,7 @@ int setupPassphrasefd(int *pipefd);
 int setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pipefd);
 
 /* Initialize key generation params with default values and specified hash algorithm */
-void set_default_rsa_key_desc(rnp_keygen_desc_t *key_desc, pgp_hash_alg_t hashalg);
+void set_default_rsa_key_desc(rnp_action_keygen_t *action, pgp_hash_alg_t hashalg);
 
 /**
  *  Helper used to retrieve random data. Function initializes

--- a/src/tests/user-prefs.c
+++ b/src/tests/user-prefs.c
@@ -77,7 +77,7 @@ test_load_user_prefs(void **state)
         const char *userid = "key1-uid0";
 
         // find the key
-        const pgp_key_t *key = NULL;
+        pgp_key_t *key = NULL;
         rnp_assert_true(rstate,
                         rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, &key));
         assert_non_null(key);
@@ -123,7 +123,7 @@ test_load_user_prefs(void **state)
         const char *userid = "key0-uid0";
 
         // find the key
-        const pgp_key_t *key = NULL;
+        pgp_key_t *key = NULL;
         rnp_assert_true(rstate,
                         rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, &key));
         assert_non_null(key);

--- a/src/tests/user-prefs.c
+++ b/src/tests/user-prefs.c
@@ -29,6 +29,7 @@
 #include "rnp_tests.h"
 #include "support.h"
 #include "utils.h"
+#include "pgp-key.h"
 
 static const pgp_subsig_t *
 find_subsig(const pgp_key_t *key, const char *userid)


### PR DESCRIPTION
* Reworked G10 key store code a bit to align with the pgp code and function again after the subkey reworking. I did sacrifice G10 public-key support, only to save myself some time while reworking this. AFAIK this does not affect compatibility with gpg at all. So currently the valid keystore formats are GPG and GPG21 only. (cmocka tests for GPG21 have been re-enabled)
* Added key protect/unprotect.
* Fixed some bugs here and there. ~~G10 keys had keyids that varied based on the current time at which they were loaded, for example.~~ EDIT: Actually this case was handled previously, but there were some other fields that weren't right and caused keyids to be inaccurate in some cases before.

Just a quick overview of the current state (most of this is in the comments):
* A `pgp_key_t` always has the raw storage form of the key in `pgp_key_t->packets[0]`. The format of this is `pgp_key_t->format` (really it's either PGP packets or G10).
* lock/unlock - a locked key has NULL secret MPIs in the seckey structure. An unlocked key has populated secret MPIs in the seckey structure. Unlocking a key involves using the stored key in `pgp_key_t->packets[0]`. Unlocking a protected key requires a passphrase. Locking/unlocking doesn't make a lot of sense for unprotected keys since the secret MPIs would still be exposed via `pgp_key_t->packets[0]`.
* protect/unprotect - a protected key has an encrypted key stored in `pgp_key_t->packets[0]`. An unprotected key has an unencrypted key in `pgp_key_t->packets[0]`. Unprotecting a key that is protected requires a passphrase. Protecting a key requires unlocking it first (I only did this to avoid the confusion of the passphrase provider being called twice, easy to change).
* Note that keys are generated and written unencrypted after the first commit and up until the key protect/unprotect commit (at which point they are switched back to being written out encrypted).

Known issues (not introduced here AFAIK):
* The defkey setting for G10 is likely incorrect, it relies on the order of `readdir`. So signing with a GPG21 keystore format typically requires `--userid` to hint at which key you actually want.
* When we are searching for corresponding keys between pubring/secring, we really should be using the key grip and not the keyid (which is more likely to collide and slightly less reliable in general).

TODOs:
* The parameters for key protection are not currently customizable. For example, the symmetric algorithm and s2k iteration count are currently hardcoded.