### PR TITLE
tests: Provide explicit path for gpg to cli_tests.py.

### DIFF
--- a/ci/main.sh
+++ b/ci/main.sh
@@ -37,5 +37,5 @@ cd src/tests
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${GPG21_INSTALL}/lib"
 export LD_LIBRARY_PATH
-env PATH="${GPG21_INSTALL}/bin:$PATH" python2 cli_tests.py all --debug
+env RNPC_GPG_PATH="${GPG21_INSTALL}/bin/gpg" python2 cli_tests.py all --debug
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -116,7 +116,7 @@ def setup():
     os.mkdir(RNPDIR, 0700)
 
     GPGDIR = path.join(WORKDIR, '.gpg')
-    GPG = find_utility('gpg')
+    GPG = os.getenv('RNPC_GPG_PATH') or find_utility('gpg')
 
     os.mkdir(GPGDIR, 0700)
 


### PR DESCRIPTION
It looks like CI isn't always finding the correct gpg, for whatever reason, so it's likely safest to just provide an explicit path.
I just used the environment here, but an arg would certainly work as well. It still falls back to the normal search.