### PR TITLE
Clean up inclusion of botan/ffi.h

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -195,7 +195,7 @@ pgp_decrypt_decode_mpi(uint8_t *           buf,
                                                         &out_len,
                                                         encmpibuf,
                                                         encmpi_len,
-                                                        g_to_k->mp,
+                                                        g_to_k,
                                                         &seckey->key.ecc,
                                                         &seckey->pubkey.key.ecdh,
                                                         &fingerprint);

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -56,7 +56,6 @@
 #define CRYPTO_H_
 
 #include <limits.h>
-#include <botan/ffi.h>
 
 #include <librepgp/packet-parse.h>
 #include <librepgp/packet-print.h>

--- a/src/lib/crypto/bn.c
+++ b/src/lib/crypto/bn.c
@@ -27,6 +27,7 @@
 
 #include "crypto.h"
 #include "crypto/bn.h"
+#include <botan/ffi.h>
 
 #ifndef USE_ARG
 #define USE_ARG(x) /*LINTED*/ (void) &x
@@ -572,24 +573,6 @@ int
 PGPV_BN_gcd(PGPV_BIGNUM *r, PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 {
     return botan_mp_gcd(r->mp, a->mp, b->mp);
-}
-
-BIGNUM *
-new_BN_take_mp(botan_mp_t mp)
-{
-    PGPV_BIGNUM *a;
-    a = calloc(1, sizeof(*a));
-    if (a) {
-        a->mp = mp;
-    }
-    return a;
-}
-
-void
-destroy_BN_mp(BIGNUM **a)
-{
-    free(*a);
-    *a = NULL;
 }
 
 DSA_SIG *

--- a/src/lib/crypto/bn.h
+++ b/src/lib/crypto/bn.h
@@ -29,20 +29,6 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-#include <botan/ffi.h>
-
-#ifndef BEGIN_DECLS__
-#if defined(__cplusplus)
-#define BEGIN_DECLS__ extern "C" {
-#define END_DECLS__ }
-#else
-#define BEGIN_DECLS__
-#define END_DECLS__
-#endif
-#endif
-
-BEGIN_DECLS__
-
 #define USE_BN_INTERFACE
 
 #ifdef USE_BN_INTERFACE
@@ -73,7 +59,6 @@ BEGIN_DECLS__
 #define BN_mul PGPV_BN_mul
 #define BN_div PGPV_BN_div
 #define BN_swap PGPV_BN_swap
-#define BN_bitop PGPV_BN_bitop
 #define BN_lshift PGPV_BN_lshift
 #define BN_lshift1 PGPV_BN_lshift1
 #define BN_rshift PGPV_BN_rshift
@@ -96,6 +81,8 @@ BEGIN_DECLS__
 #define BN_gcd PGPV_BN_gcd
 #define BN_words_used PGPV_BN_words_used
 #endif /* USE_BN_INTERFACE */
+
+typedef struct botan_mp_struct* botan_mp_t;
 
 /*
  * PGPV_BIGNUM struct
@@ -152,10 +139,6 @@ int PGPV_BN_div(PGPV_BIGNUM * /*q*/,
                 const PGPV_BIGNUM * /*a*/,
                 const PGPV_BIGNUM * /*b*/);
 void PGPV_BN_swap(PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
-int  PGPV_BN_bitop(PGPV_BIGNUM * /*r*/,
-                  const PGPV_BIGNUM * /*a*/,
-                  char /*op*/,
-                  const PGPV_BIGNUM * /*b*/);
 int PGPV_BN_lshift(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, int /*n*/);
 int PGPV_BN_lshift1(PGPV_BIGNUM * /*r*/, PGPV_BIGNUM * /*a*/);
 int PGPV_BN_rshift(PGPV_BIGNUM * /*r*/, const PGPV_BIGNUM * /*a*/, int /*n*/);
@@ -197,12 +180,6 @@ int                PGPV_BN_is_bit_set(const PGPV_BIGNUM * /*a*/, int /*n*/);
 
 int PGPV_BN_gcd(PGPV_BIGNUM * /*r*/, PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
 
-/**
- * \brief Allocates BIGNUM and mp value assigned
- */
-BIGNUM *new_BN_take_mp(botan_mp_t mp);
-void destroy_BN_mp(BIGNUM **a);
-
 /*
 * This type is used to represent any signature where
 * a pair of MPIs is used (DSA, ECDSA, EdDSA, ...)
@@ -214,7 +191,5 @@ typedef struct DSA_SIG_st {
 
 DSA_SIG *DSA_SIG_new();
 void DSA_SIG_free(DSA_SIG *sig);
-
-END_DECLS__
 
 #endif

--- a/src/lib/crypto/dsa.c
+++ b/src/lib/crypto/dsa.c
@@ -78,6 +78,7 @@
 #include <stdlib.h>
 #include "crypto/dsa.h"
 #include "crypto/bn.h"
+#include <botan/ffi.h>
 
 unsigned
 pgp_dsa_verify(const uint8_t *         hash,

--- a/src/lib/crypto/ecdh.c
+++ b/src/lib/crypto/ecdh.c
@@ -202,7 +202,7 @@ pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
                        size_t                   session_key_len,
                        uint8_t *                wrapped_key,
                        size_t *                 wrapped_key_len,
-                       botan_mp_t               ephemeral_key,
+                       BIGNUM *                 ephemeral_key,
                        const pgp_ecdh_pubkey_t *pubkey,
                        const pgp_fingerprint_t *fingerprint)
 {
@@ -215,8 +215,8 @@ pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
     uint8_t *       tmp_buf = NULL;
     uint8_t         kek[32] = {0}; // Size of SHA-256 or smaller
 
-    if ((session_key_len > OBFUSCATED_KEY_SIZE) || !ephemeral_key || !pubkey || !wrapped_key ||
-        !wrapped_key_len || !fingerprint || !pubkey->ec.point) {
+    if ((session_key_len > OBFUSCATED_KEY_SIZE) || !ephemeral_key || !ephemeral_key->mp ||
+        !pubkey || !wrapped_key || !wrapped_key_len || !fingerprint || !pubkey->ec.point) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -293,7 +293,7 @@ pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
         goto end;
     }
 
-    if (botan_mp_from_bin(ephemeral_key, tmp_buf, tmp_len)) {
+    if (botan_mp_from_bin(ephemeral_key->mp, tmp_buf, tmp_len)) {
         goto end;
     }
 
@@ -312,7 +312,7 @@ pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
                        size_t *                 session_key_len,
                        uint8_t *                wrapped_key,
                        size_t                   wrapped_key_len,
-                       const botan_mp_t         ephemeral_key,
+                       const BIGNUM *           ephemeral_key,
                        const pgp_ecc_seckey_t * seckey,
                        const pgp_ecdh_pubkey_t *pubkey,
                        const pgp_fingerprint_t *fingerprint)
@@ -326,7 +326,7 @@ pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
     size_t          key_len = sizeof(key);
 
     if (!session_key_len || !session_key_len || !wrapped_key || !seckey || !seckey->x ||
-        !seckey->x->mp || !pubkey) {
+        !seckey->x->mp || !pubkey || !ephemeral_key || !ephemeral_key->mp) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -367,7 +367,7 @@ pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
                      other_info,
                      other_info_size,
                      curve_desc,
-                     ephemeral_key,
+                     ephemeral_key->mp,
                      prv_key,
                      kdf_hash)) {
         goto end;

--- a/src/lib/crypto/ecdh.h
+++ b/src/lib/crypto/ecdh.h
@@ -90,7 +90,7 @@ rnp_result_t pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
                                     size_t                   session_key_len,
                                     uint8_t *                wrapped_key,
                                     size_t *                 wrapped_key_len,
-                                    botan_mp_t               ephemeral_key,
+                                    BIGNUM *                 ephemeral_key,
                                     const pgp_ecdh_pubkey_t *pubkey,
                                     const pgp_fingerprint_t *fingerprint);
 
@@ -118,7 +118,7 @@ rnp_result_t pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
                                     size_t *                 session_key_len,
                                     uint8_t *                wrapped_key,
                                     size_t                   wrapped_key_len,
-                                    const botan_mp_t         ephemeral_key,
+                                    const BIGNUM *           ephemeral_key,
                                     const pgp_ecc_seckey_t * seckey,
                                     const pgp_ecdh_pubkey_t *pubkey,
                                     const pgp_fingerprint_t *fingerprint);

--- a/src/lib/crypto/elgamal.c
+++ b/src/lib/crypto/elgamal.c
@@ -80,6 +80,7 @@
 #include <string.h>
 #include "crypto/elgamal.h"
 #include "crypto/bn.h"
+#include <botan/ffi.h>
 
 #define FAIL(str)                                                                      \
     do {                                                                               \

--- a/src/lib/crypto/rsa.c
+++ b/src/lib/crypto/rsa.c
@@ -84,6 +84,7 @@
 #include "utils.h"
 #include "crypto/rsa.h"
 #include "crypto/bn.h"
+#include <botan/ffi.h>
 
 #include "hash.h"
 

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -943,7 +943,7 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
                                  sz_encoded_key,
                                  encmpibuf,
                                  &out_len,
-                                 sesskey->params.ecdh.ephemeral_point->mp,
+                                 sesskey->params.ecdh.ephemeral_point,
                                  &pubkey->key.ecdh,
                                  &fingerprint);
         if (RNP_SUCCESS != err) {

--- a/src/lib/pem.c
+++ b/src/lib/pem.c
@@ -86,6 +86,7 @@
 #include "utils.h"
 #include "crypto/bn.h"
 #include "pgp-key.h"
+#include <botan/ffi.h>
 
 bool
 read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)
@@ -134,18 +135,15 @@ read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)
         }
 
         {
-            botan_mp_t x;
-            botan_mp_init(&x);
-            botan_privkey_get_field(x, priv_key, "d");
-            key->key.seckey.key.rsa.d = new_BN_take_mp(x);
+            pgp_rsa_seckey_t* rsa = &(key->key.seckey.key.rsa);
+            botan_mp_init(&rsa->d->mp);
+            botan_privkey_get_field(rsa->d->mp, priv_key, "d");
 
-            botan_mp_init(&x);
-            botan_privkey_get_field(x, priv_key, "p");
-            key->key.seckey.key.rsa.p = new_BN_take_mp(x);
+            botan_mp_init(&rsa->p->mp);
+            botan_privkey_get_field(rsa->p->mp, priv_key, "p");
 
-            botan_mp_init(&x);
-            botan_privkey_get_field(x, priv_key, "q");
-            key->key.seckey.key.rsa.q = new_BN_take_mp(x);
+            botan_mp_init(&rsa->q->mp);
+            botan_privkey_get_field(rsa->q->mp, priv_key, "q");
             botan_privkey_destroy(priv_key);
             ok = true;
         }
@@ -153,10 +151,8 @@ read_pem_seckey(const char *f, pgp_key_t *key, const char *type, int verbose)
         if (botan_privkey_load(&priv_key, rng, keybuf, read, NULL) != 0) {
             ok = false;
         } else {
-            botan_mp_t x;
-            botan_mp_init(&x);
-            botan_privkey_get_field(x, priv_key, "x");
-            key->key.seckey.key.dsa.x = new_BN_take_mp(x);
+            botan_mp_init(&key->key.seckey.key.dsa.x->mp);
+            botan_privkey_get_field(key->key.seckey.key.dsa.x->mp, priv_key, "x");
             botan_privkey_destroy(priv_key);
             ok = true;
         }

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -39,6 +39,7 @@
 #include "readerwriter.h"
 #include "misc.h"
 #include "pgp-key.h"
+#include <botan/ffi.h>
 
 #define G10_CBC_IV_SIZE 16
 

--- a/src/tests/support.c
+++ b/src/tests/support.c
@@ -43,10 +43,10 @@
 
 #include <crypto.h>
 #include <pgp-key.h>
-#include <crypto/bn.h>
 
 #include <rnp/rnp.h>
 #include <sys/stat.h>
+#include <botan/ffi.h>
 
 /*
  * Handler used to access DRBG.

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -34,7 +34,6 @@
 #include <unistd.h>
 #include <limits.h>
 #include <ftw.h>
-#include <botan/ffi.h>
 #include <sys/stat.h>
 #include <cmocka.h>
 #include <rnp/rnp.h>


### PR DESCRIPTION
All super piddly stuff actually but I noticed it while looking at something else and it bugged me.

Basically don't include `<botan/ffi.h>` in any headers, just in the files that directly use it. Changes ECDH interface slightly (taking BIGNUM instead of botan_mp_t)

Removes `new_BN_take_mp` because it was only used in one place and the code is simpler without it.

The BN layer is due for a pruning, a lot of functionality in there was just to implement ElGamal etc and is no longer necessary. But not really a problem so ignoring that here.