### PR TITLE
repgp: Use NULL instead of REPGP_HANDLE_NULL

### DIFF
--- a/include/repgp/repgp.h
+++ b/include/repgp/repgp.h
@@ -42,8 +42,6 @@
 #include <rnp/rnp_def.h>
 #include "repgp_def.h"
 
-#define REPGP_HANDLE_NULL NULL
-
 typedef struct pgp_packet_t   pgp_packet_t;
 typedef struct pgp_stream_t   pgp_stream_t;
 typedef struct repgp_handle_t repgp_handle_t;
@@ -62,7 +60,7 @@ typedef enum {
  *
  * @param   filename NULL-terminated string with full path to the file
  *
- * @return  Initialized handle on success or REPGP_HANDLE_NULL
+ * @return  Initialized handle on success or NULL
  *          if input parameters are invalid.
  */
 repgp_handle_t *create_filepath_handle(const char *filename);
@@ -73,7 +71,7 @@ repgp_handle_t *create_filepath_handle(const char *filename);
  *          all the data from standard input and coppies
  *          it to internal buffer.
  *
- * @return  Initialized handle on success or REPGP_HANDLE_NULL
+ * @return  Initialized handle on success or NULL
  *          if input parameters are invalid.
  */
 repgp_handle_t *create_stdin_handle(void);
@@ -84,7 +82,7 @@ repgp_handle_t *create_stdin_handle(void);
  *
  * @param   buffer_size size of the buffer to allocate
  *
- * @return  Initialized handle on success or REPGP_HANDLE_NULL
+ * @return  Initialized handle on success or NULL
  *          if input parameters are invalid.
  */
 repgp_handle_t *create_buffer_handle(const size_t buffer_size);
@@ -98,7 +96,7 @@ repgp_handle_t *create_buffer_handle(const size_t buffer_size);
  * @param   data data provided by the caller
  * @param   data_len length of the data
  *
- * @return  Initialized handle on success or REPGP_HANDLE_NULL
+ * @return  Initialized handle on success or NULL
  *          if input parameters are invalid.
  */
 repgp_handle_t *create_data_handle(const uint8_t *data, size_t data_len);
@@ -132,7 +130,7 @@ rnp_result repgp_copy_buffer_from_handle(uint8_t *             out,
 /*
  * @brief   Creates opaque repgp_io_t object
  *
- * @returns Initialized repgp_io_t object or REPGP_HANDLE_NULL on
+ * @returns Initialized repgp_io_t object or NULL on
  *          error.
  */
 repgp_io_t *repgp_create_io(void);
@@ -141,7 +139,7 @@ repgp_io_t *repgp_create_io(void);
  * @brief   Sets input handler. If another handler was already
  *          set, it gets destroyed in order to make sure no
  *          memory leak is introduced.
- *          Function can be called with handle set to REPGP_HANDLE_NULL
+ *          Function can be called with handle set to NULL
  *
  * @param   io input/output object on which input handler will be set
  * @param   handle handle object to be set
@@ -152,7 +150,7 @@ void repgp_set_input(repgp_io_t *io, repgp_handle_t *handle);
  * @brief   Sets output handler. If another handler was already
  *          set, it gets destroyed in order to make sure no
  *          memory leak is introduced.
- *          Function can be called with handle set to REPGP_HANDLE_NULL
+ *          Function can be called with handle set to NULL
  *
  * @param   io input/output object on which input handler will be set
  * @param   handle handle object to be set

--- a/src/lib/crypto/ecdh.h
+++ b/src/lib/crypto/ecdh.h
@@ -75,13 +75,13 @@ bool set_ecdh_params(pgp_seckey_t *seckey, pgp_curve_t curve_id);
  *        Current implementation always produces 48 bytes as key
  *        is padded with PKCS-5/7
  * @param ephemeral_key [out] public ephemeral ECDH key used for key
- *        agreement (private part).
+ *        agreement (private part). Must be initialized
  * @param pubkey public key to be used for encryption
  * @param fingerprint fingerprint of the pubkey
  *
  * @return RNP_SUCCESS on success and output parameters are populated
  * @return RNP_ERROR_NOT_SUPPORTED unknown curve
- * @return RNP_ERROR_BAD_PARAMETERS unexpected value of input one or many arguments
+ * @return RNP_ERROR_BAD_PARAMETERS unexpected input provided
  * @return RNP_ERROR_SHORT_BUFFER `wrapped_key_len' to small to store result
  * @return RNP_ERROR_OUT_OF_MEMORY failed to allocated memory
  * @return RNP_ERROR_GENERIC implementation error
@@ -104,13 +104,13 @@ rnp_result pgp_ecdh_encrypt_pkcs5(const uint8_t *const     session_key,
  *        in RFC 3394
  * @param wrapped_key_len length of the `wrapped_key' buffer
  * @param ephemeral_key public ephemeral ECDH key comming from
- *        encrypted packet
+ *        encrypted packet.
  * @param seckey secret key to be used for decryption
  * @param fingerprint fingerprint of the key
  *
  * @return RNP_SUCCESS on success and output parameters are populated
  * @return RNP_ERROR_NOT_SUPPORTED unknown curve
- * @return RNP_ERROR_BAD_PARAMETERS unexpected value of input one or many arguments
+ * @return RNP_ERROR_BAD_PARAMETERS unexpected input provided
  * @return RNP_ERROR_SHORT_BUFFER `session_key_len' to small to store result
  * @return RNP_ERROR_GENERIC decryption failed or implementation error
  */

--- a/src/librepgp/repgp.c
+++ b/src/librepgp/repgp.c
@@ -53,12 +53,12 @@ repgp_handle_t *
 create_filepath_handle(const char *filename)
 {
     if (!filename) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     repgp_handle_t *s = calloc(sizeof(*s), 1);
     if (!s) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     s->filepath = strndup(filename, strlen(filename));
@@ -71,12 +71,12 @@ create_buffer_handle(const size_t buffer_size)
 {
     repgp_handle_t *s = calloc(sizeof(*s), 1);
     if (!s) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     s->buffer.data = (unsigned char *) malloc(buffer_size);
     if (!s->buffer.data) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     s->buffer.size = buffer_size;
@@ -89,12 +89,12 @@ create_data_handle(const uint8_t *data, size_t data_len)
 {
     repgp_handle_t *s = calloc(sizeof(*s), 1);
     if (!s) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     s->buffer.data = (unsigned char *) malloc(data_len);
     if (!s->buffer.data) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
     memcpy(s->buffer.data, data, data_len);
 
@@ -114,7 +114,7 @@ create_stdin_handle(void)
 
     repgp_handle_t *s = calloc(sizeof(*s), 1);
     if (!s) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     /* Read in everything and keeps it in memory.
@@ -130,7 +130,7 @@ create_stdin_handle(void)
         if (loc == NULL) {
             RNP_LOG("Short read");
             free(data);
-            return REPGP_HANDLE_NULL;
+            return NULL;
         }
         data = loc;
         memcpy(data + size, buf, n);
@@ -140,7 +140,7 @@ create_stdin_handle(void)
     if (n < 0) {
         RNP_LOG("Error while reading from stdin [%s]", strerror(errno));
         free(data);
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
     s->type = REPGP_HANDLE_BUFFER;
@@ -152,7 +152,7 @@ create_stdin_handle(void)
 rnp_result
 repgp_copy_buffer_from_handle(uint8_t *out, size_t *out_size, const repgp_handle_t *handle)
 {
-    if (!out || !out_size || (*out_size == 0) || (handle == REPGP_HANDLE_NULL)) {
+    if (!out || !out_size || (*out_size == 0) || (handle == NULL)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -272,11 +272,11 @@ repgp_create_io(void)
 {
     repgp_io_t *io = malloc(sizeof(*io));
     if (!io) {
-        return REPGP_HANDLE_NULL;
+        return NULL;
     }
 
-    io->in = REPGP_HANDLE_NULL;
-    io->out = REPGP_HANDLE_NULL;
+    io->in = NULL;
+    io->out = NULL;
 
     return (repgp_io_t *) io;
 }
@@ -302,12 +302,12 @@ rnp_result
 repgp_list_packets(const void *ctx, const repgp_handle_t *input)
 {
     const rnp_ctx_t *rctx = (rnp_ctx_t *) ctx;
-    if (!rctx || !rctx->rnp || (input == REPGP_HANDLE_NULL)) {
+    if (!rctx || !rctx->rnp || (input == NULL)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
     const repgp_handle_t *i = (repgp_handle_t *) input;
-    if ((i == REPGP_HANDLE_NULL) || (i->type != REPGP_HANDLE_FILE)) {
+    if ((i == NULL) || (i->type != REPGP_HANDLE_FILE)) {
         RNP_LOG("Incorrectly initialized input handle");
         return RNP_ERROR_BAD_PARAMETERS;
     }

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -311,7 +311,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
     static const char stdout_marker[2] = "-";
     repgp_io_t *      io = repgp_create_io();
 
-    if (io == REPGP_HANDLE_NULL) {
+    if (io == NULL) {
         RNP_LOG("Allocation failed");
         return false;
     }
@@ -400,7 +400,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         break;
     }
     case CMD_VERIFY_CAT: {
-        repgp_handle_t *os = REPGP_HANDLE_NULL;
+        repgp_handle_t *os = NULL;
         if (f == NULL) {
             os = create_buffer_handle((size_t) rnp_cfg_getint(cfg, CFG_MAXALLOC));
         } else {
@@ -418,7 +418,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
     }
     case CMD_LIST_PACKETS: {
         repgp_handle_t *input = create_filepath_handle(f);
-        if (input == REPGP_HANDLE_NULL) {
+        if (input == NULL) {
             RNP_LOG("%s: No filename provided", __progname);
             ret = false;
             break;


### PR DESCRIPTION
REPGP_HANDLE_NULL was useful when functions were returning or accepting
pointers to void. Later this has been simplified. Currently API
functions accept or return pointers to types which are forward-declared.
At the moment REPGP_HANDLE_NULL can be simply replaced with NULL.

Also improves some comments in ECDH