### PR TITLE
Add support for adding additional userids to keys, fix key importing

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -189,7 +189,6 @@ typedef enum {
     PGP_PARSER_PACKET_END = 0x103,
 
     /* signature subpackets (0x200-2ff) (type+0x200) */
-    /* only those we can parse are listed here */
     PGP_PTAG_SIG_SUBPKT_BASE = 0x200,        /* Base for signature
                                               * subpacket types - All
                                               * signature type values

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -207,4 +207,9 @@ bool pgp_key_unprotect(pgp_key_t *key, const pgp_passphrase_provider_t *passphra
  **/
 bool pgp_key_is_protected(const pgp_key_t *key);
 
+bool pgp_key_add_userid(pgp_key_t *            key,
+                        const pgp_seckey_t *   seckey,
+                        pgp_hash_alg_t         hash_alg,
+                        rnp_selfsig_cert_info *cert);
+
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -75,10 +75,11 @@ struct pgp_key_t {
     uint8_t            keyid[PGP_KEY_ID_SIZE];
     pgp_fingerprint_t  fingerprint;
     uint8_t            grip[PGP_FINGERPRINT_SIZE];
-    uint32_t           uid0;       /* primary uid index in uids array */
-    uint8_t            revoked;    /* key has been revoked */
-    pgp_revoke_t       revocation; /* revocation reason */
-    key_store_format_t format;     /* the format of the key in packets[0] */
+    uint32_t           uid0;         /* primary uid index in uids array */
+    unsigned           uid0_set : 1; /* flag for the above */
+    uint8_t            revoked;      /* key has been revoked */
+    pgp_revoke_t       revocation;   /* revocation reason */
+    key_store_format_t format;       /* the format of the key in packets[0] */
 
     bool is_protected; /* whether the key in packets[0] is encrypted (for secret keys) */
 };

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -180,6 +180,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
         break;
     case PGP_PTAG_SS_PRIMARY_USER_ID:
         key->uid0 = key->uidc - 1;
+        key->uid0_set = 1;
         break;
     case PGP_PTAG_SS_REVOCATION_REASON: {
         SUBSIG_REQUIRED_BEFORE("ss revocation reason");

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -68,4 +68,6 @@ bool rnp_key_store_pgp_read_from_mem(pgp_io_t *,
 int rnp_key_store_pgp_write_to_mem(
   pgp_io_t *, rnp_key_store_t *, const uint8_t *, const unsigned, pgp_memory_t *);
 
+bool pgp_parse_key_attrs(pgp_key_t *key, const uint8_t *data, size_t data_len);
+
 #endif /* KEY_STORE_PGP_H_ */

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -14,7 +14,8 @@ rnp_tests_SOURCES   = \
     pgp-parse.c \
     load-pgp.c \
     key-unlock.c \
-    key-protect.c
+    key-protect.c \
+    key-add-userid.c
 
 # don't install any test stuff
 install-binPROGRAMS:

--- a/src/tests/key-add-userid.c
+++ b/src/tests/key-add-userid.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../librekey/key_store_pgp.h"
+#include "pgp-key.h"
+
+#include "rnp_tests.h"
+#include "support.h"
+#include "utils.h"
+#include "hash.h"
+
+/* This test loads a pgp keyring and adds a few userids to the key.
+ */
+void
+test_key_add_userid(void **state)
+{
+    rnp_test_state_t * rstate = *state;
+    char               path[PATH_MAX];
+    pgp_io_t           io = {.errs = stderr, .res = stdout, .outs = stdout};
+    pgp_key_t *        key = NULL;
+    static const char *keyids[] = {"7bc6709b15c23a4a", // primary
+                                   "1ed63ee56fadc34d",
+                                   "1d7e8a5393c997a8",
+                                   "8a05b89fad5aded1",
+                                   "2fcadf05ffa501bb", // primary
+                                   "54505a936a4a970e",
+                                   "326ef111425d14a5"};
+
+    rnp_key_store_t *ks = calloc(1, sizeof(*ks));
+    assert_non_null(ks);
+
+    pgp_memory_t mem = {0};
+    paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/secring.gpg", NULL);
+    assert_true(pgp_mem_readfile(&mem, path));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+    pgp_memory_release(&mem);
+
+    // locate our key
+    assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &key));
+    assert_non_null(key);
+
+    // unlock the key
+    assert_true(
+      pgp_key_unlock(key,
+                     &(pgp_passphrase_provider_t){.callback = string_copy_passphrase_callback,
+                                                  .userdata = "password"}));
+
+    // save the counts for a few items
+    unsigned uidc = key->uidc;
+    unsigned subsigc = key->subsigc;
+
+    // add a userid
+    assert_true(pgp_key_add_userid(
+      key,
+      pgp_get_seckey(key),
+      PGP_HASH_SHA1,
+      &(rnp_selfsig_cert_info){
+        .userid = "added1", .key_flags = 0xAB, .key_expiration = 123456789, .primary = 1}));
+
+    // make sure this userid has been marked as primary
+    assert_int_equal(key->uidc - 1, key->uid0);
+
+    // try to add the same userid (should fail)
+    assert_false(pgp_key_add_userid(
+      key, pgp_get_seckey(key), PGP_HASH_SHA1, &(rnp_selfsig_cert_info){.userid = "added1"}));
+
+    // try to add another primary userid (should fail)
+    assert_false(
+      pgp_key_add_userid(key,
+                         pgp_get_seckey(key),
+                         PGP_HASH_SHA1,
+                         &(rnp_selfsig_cert_info){.userid = "added2", .primary = 1}));
+
+    // actually add another userid
+    assert_true(
+      pgp_key_add_userid(key,
+                         pgp_get_seckey(key),
+                         PGP_HASH_SHA1,
+                         &(rnp_selfsig_cert_info){.userid = "added2", .key_flags = 0xCD}));
+
+    // confirm that the counts have increased as expected
+    assert_int_equal(key->uidc, uidc + 2);
+    assert_int_equal(key->subsigc, subsigc + 2);
+
+    // check the userids array
+    // added1
+    assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 2], "added1"));
+    assert_int_equal(key->uidc - 2, key->subsigs[key->subsigc - 2].uid);
+    assert_int_equal(0xAB, key->subsigs[key->subsigc - 2].key_flags);
+    assert_int_equal(123456789, key->key.pubkey.duration);
+    // added2
+    assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 1], "added2"));
+    assert_int_equal(key->uidc - 1, key->subsigs[key->subsigc - 1].uid);
+    assert_int_equal(0xCD, key->subsigs[key->subsigc - 1].key_flags);
+
+    // save the raw packets for the key (to reload later)
+    mem = (pgp_memory_t){0};
+    for (unsigned i = 0; i < key->packetc; i++) {
+        pgp_memory_add(&mem, key->packets[i].raw, key->packets[i].length);
+    }
+    // cleanup
+    rnp_key_store_free(ks);
+    key = NULL;
+
+    // start over
+    ks = calloc(1, sizeof(*ks));
+    assert_non_null(ks);
+    // read from the saved packets
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+    assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &key));
+    assert_non_null(key);
+
+    // confirm that the counts have increased as expected
+    assert_int_equal(key->uidc, uidc + 2);
+    assert_int_equal(key->subsigc, subsigc + 2);
+
+    // check the userids array
+    // added1
+    assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 2], "added1"));
+    assert_int_equal(key->uidc - 2, key->subsigs[key->subsigc - 2].uid);
+    assert_int_equal(0xAB, key->subsigs[key->subsigc - 2].key_flags);
+    assert_int_equal(123456789, key->key.pubkey.duration);
+    // added2
+    assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 1], "added2"));
+    assert_int_equal(key->uidc - 1, key->subsigs[key->subsigc - 1].uid);
+    assert_int_equal(0xCD, key->subsigs[key->subsigc - 1].key_flags);
+
+    // cleanup
+    rnp_key_store_free(ks);
+}

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -160,7 +160,9 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_load_keyring_and_count_pgp),
       cmocka_unit_test(pgp_compress_roundtrip),
       cmocka_unit_test(test_key_unlock_pgp),
-      cmocka_unit_test(test_key_protect_load_pgp)};
+      cmocka_unit_test(test_key_protect_load_pgp),
+      cmocka_unit_test(test_key_add_userid),
+    };
 
     /* Each test entry will invoke setup_test before running
      * and teardown_test after running. */

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -95,6 +95,8 @@ void test_key_unlock_pgp(void **state);
 
 void test_key_protect_load_pgp(void **state);
 
+void test_key_add_userid(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \


### PR DESCRIPTION
Ok I had to expand this PR and fix an unrelated issue or CI would be broken.

So this:
* Fixes key importing (https://github.com/riboseinc/rnp/issues/21). I've only tested .gpg format. It would likely (should) fail for imports that require conversions (like importing a G10 key into a GPG key store).
    * Support secret keys.
    * Actually save to disk.
* Adds some support+tests for adding additional userids to keys.