### PR TITLE
Review pgp_forget usage in #463, some s2k refactoring

### DIFF
--- a/src/lib/crypto/s2k.c
+++ b/src/lib/crypto/s2k.c
@@ -33,6 +33,34 @@
 
 #include "crypto/s2k.h"
 
+bool
+pgp_s2k_derive_key(pgp_s2k *s2k, const char *passphrase, uint8_t *key, int keysize)
+{
+    uint8_t *saltptr = NULL;
+    unsigned iterations = 1;
+
+    switch (s2k->specifier) {
+    case PGP_S2KS_SIMPLE:
+        break;
+    case PGP_S2KS_SALTED:
+        saltptr = s2k->salt;
+        break;
+    case PGP_S2KS_ITERATED_AND_SALTED:
+        saltptr = s2k->salt;
+        iterations = pgp_s2k_decode_iterations(s2k->iterations);
+        break;
+    default:
+        return false;
+    }
+
+    if (pgp_s2k_iterated(s2k->hash_alg, key, keysize, passphrase, saltptr, iterations)) {
+        (void) fprintf(stderr, "s2k_derive_key: s2k failed\n");
+        return false;
+    }
+
+    return true;
+}
+
 int
 pgp_s2k_simple(pgp_hash_alg_t alg, uint8_t *out, size_t output_len, const char *passphrase)
 {

--- a/src/lib/crypto/s2k.c
+++ b/src/lib/crypto/s2k.c
@@ -47,7 +47,11 @@ pgp_s2k_derive_key(pgp_s2k_t *s2k, const char *passphrase, uint8_t *key, int key
         break;
     case PGP_S2KS_ITERATED_AND_SALTED:
         saltptr = s2k->salt;
-        iterations = pgp_s2k_decode_iterations(s2k->iterations);
+        if (s2k->iterations < 256) {
+            iterations = pgp_s2k_decode_iterations(s2k->iterations);
+        } else {
+            iterations = s2k->iterations;
+        }
         break;
     default:
         return false;

--- a/src/lib/crypto/s2k.c
+++ b/src/lib/crypto/s2k.c
@@ -34,7 +34,7 @@
 #include "crypto/s2k.h"
 
 bool
-pgp_s2k_derive_key(pgp_s2k *s2k, const char *passphrase, uint8_t *key, int keysize)
+pgp_s2k_derive_key(pgp_s2k_t *s2k, const char *passphrase, uint8_t *key, int keysize)
 {
     uint8_t *saltptr = NULL;
     unsigned iterations = 1;

--- a/src/lib/crypto/s2k.h
+++ b/src/lib/crypto/s2k.h
@@ -60,4 +60,14 @@ uint8_t pgp_s2k_encode_iterations(size_t iterations);
 // Round iterations to nearest representable value
 size_t pgp_s2k_round_iterations(size_t iterations);
 
+/** @brief Derive key from passphrase using the information stored in s2k structure
+ *  @param s2k pointer to s2k structure, filled according to RFC 4880. Iterations field should
+ * contain encoded value.
+ *  @param passphrase NULL-terminated passphrase
+ *  @param key buffer to store the derived key, must have at least keysize bytes
+ *  @param keysize number of bytes in the key.
+ *  @return true on success or false otherwise
+*/
+bool pgp_s2k_derive_key(pgp_s2k *s2k, const char *passphrase, uint8_t *key, int keysize);
+
 #endif

--- a/src/lib/crypto/s2k.h
+++ b/src/lib/crypto/s2k.h
@@ -61,7 +61,7 @@ uint8_t pgp_s2k_encode_iterations(size_t iterations);
 size_t pgp_s2k_round_iterations(size_t iterations);
 
 /** @brief Derive key from passphrase using the information stored in s2k structure
- *  @param s2k pointer to s2k structure, filled according to RFC 4880. 
+ *  @param s2k pointer to s2k structure, filled according to RFC 4880.
  *  Iterations field may contain encoded ( < 256) or decoded ( > 256) value.
  *  @param passphrase NULL-terminated passphrase
  *  @param key buffer to store the derived key, must have at least keysize bytes

--- a/src/lib/crypto/s2k.h
+++ b/src/lib/crypto/s2k.h
@@ -68,6 +68,6 @@ size_t pgp_s2k_round_iterations(size_t iterations);
  *  @param keysize number of bytes in the key.
  *  @return true on success or false otherwise
 */
-bool pgp_s2k_derive_key(pgp_s2k *s2k, const char *passphrase, uint8_t *key, int keysize);
+bool pgp_s2k_derive_key(pgp_s2k_t *s2k, const char *passphrase, uint8_t *key, int keysize);
 
 #endif

--- a/src/lib/crypto/s2k.h
+++ b/src/lib/crypto/s2k.h
@@ -61,8 +61,8 @@ uint8_t pgp_s2k_encode_iterations(size_t iterations);
 size_t pgp_s2k_round_iterations(size_t iterations);
 
 /** @brief Derive key from passphrase using the information stored in s2k structure
- *  @param s2k pointer to s2k structure, filled according to RFC 4880. Iterations field should
- * contain encoded value.
+ *  @param s2k pointer to s2k structure, filled according to RFC 4880. 
+ *  Iterations field may contain encoded ( < 256) or decoded ( > 256) value.
  *  @param passphrase NULL-terminated passphrase
  *  @param key buffer to store the derived key, must have at least keysize bytes
  *  @param keysize number of bytes in the key.

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -301,19 +301,8 @@ write_protected_seckey_body(pgp_output_t *output, pgp_seckey_t *seckey, const ch
         goto done;
     }
 
-    // s2k
-    switch (seckey->protection.s2k.specifier) {
-    case PGP_S2KS_SIMPLE:
-        // derive key
-        if (pgp_s2k_simple(
-              seckey->protection.s2k.hash_alg, sesskey, sesskey_size, passphrase) < 0) {
-            RNP_LOG("pgp_s2k_simple failed");
-            goto done;
-        }
-        break;
-
-    case PGP_S2KS_SALTED:
-        // randomize and write salt
+    // salt
+    if (seckey->protection.s2k.specifier != PGP_S2KS_SIMPLE) {
         if (pgp_random(seckey->protection.s2k.salt, PGP_SALT_SIZE)) {
             RNP_LOG("pgp_random failed");
             goto done;
@@ -321,47 +310,21 @@ write_protected_seckey_body(pgp_output_t *output, pgp_seckey_t *seckey, const ch
         if (!pgp_write(output, seckey->protection.s2k.salt, PGP_SALT_SIZE)) {
             goto done;
         }
+    }
 
-        // derive key
-        if (pgp_s2k_salted(seckey->protection.s2k.hash_alg,
-                           sesskey,
-                           sesskey_size,
-                           passphrase,
-                           seckey->protection.s2k.salt)) {
-            RNP_LOG("pgp_s2k_salted failed");
-            goto done;
-        }
-        break;
-
-    case PGP_S2KS_ITERATED_AND_SALTED:
-        // randomize and write salt
-        if (pgp_random(seckey->protection.s2k.salt, PGP_SALT_SIZE)) {
-            RNP_LOG("pgp_random failed");
-            goto done;
-        }
-        if (!pgp_write(output, seckey->protection.s2k.salt, PGP_SALT_SIZE)) {
-            goto done;
-        }
-
-        // derive key
-        if (pgp_s2k_iterated(seckey->protection.s2k.hash_alg,
-                             sesskey,
-                             sesskey_size,
-                             passphrase,
-                             seckey->protection.s2k.salt,
-                             seckey->protection.s2k.iterations)) {
-            RNP_LOG("pgp_s2k_iterated failed");
-            goto done;
-        }
-
-        // encode and write iteration count
-        uint8_t encoded_iterations =
-          pgp_s2k_encode_iterations(seckey->protection.s2k.iterations);
-        if (!pgp_write_scalar(output, encoded_iterations, 1)) {
+    // iterations
+    if (seckey->protection.s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
+        uint8_t enc_it = pgp_s2k_encode_iterations(seckey->protection.s2k.iterations);
+        if (!pgp_write_scalar(output, enc_it, 1)) {
             RNP_LOG("write failed");
             goto done;
         }
-        break;
+    }
+
+    // derive key
+    if (!pgp_s2k_derive_key(&seckey->protection.s2k, passphrase, sesskey, sesskey_size)) {
+        RNP_LOG("failed to derive key");
+        goto done;
     }
 
     // randomize and write IV

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -901,14 +901,13 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher)
             goto done;
         }
 
-        const rnp_result_t err =
-          pgp_ecdh_encrypt_pkcs5(encoded_key,
-                                 sz_encoded_key,
-                                 encmpibuf,
-                                 &out_len,
-                                 sesskey->params.ecdh.ephemeral_point,
-                                 &pubkey->key.ecdh,
-                                 &fingerprint);
+        const rnp_result_t err = pgp_ecdh_encrypt_pkcs5(encoded_key,
+                                                        sz_encoded_key,
+                                                        encmpibuf,
+                                                        &out_len,
+                                                        sesskey->params.ecdh.ephemeral_point,
+                                                        &pubkey->key.ecdh,
+                                                        &fingerprint);
         if (RNP_SUCCESS != err) {
             RNP_LOG("Encryption failed %d\n", err);
             goto error;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -168,7 +168,7 @@ unsigned pgp_is_hash_alg_supported(const pgp_hash_alg_t *);
 
 typedef struct pgp_key_t pgp_key_t;
 
-typedef struct pgp_s2k {
+typedef struct pgp_s2k_t {
     pgp_s2k_usage_t usage;
 
     /* below fields may not all be valid, depending on the usage field above */
@@ -176,10 +176,10 @@ typedef struct pgp_s2k {
     pgp_hash_alg_t      hash_alg;
     uint8_t             salt[PGP_SALT_SIZE];
     unsigned            iterations;
-} pgp_s2k;
+} pgp_s2k_t;
 
 typedef struct pgp_key_protection_t {
-    pgp_s2k           s2k;         /* string-to-key kdf params */
+    pgp_s2k_t         s2k;         /* string-to-key kdf params */
     pgp_symm_alg_t    symm_alg;    /* symmetric alg */
     pgp_cipher_mode_t cipher_mode; /* block cipher mode */
     uint8_t           iv[PGP_MAX_BLOCK_SIZE];
@@ -432,7 +432,7 @@ typedef struct {
 typedef struct {
     unsigned       version;
     pgp_symm_alg_t alg;
-    pgp_s2k        s2k;
+    pgp_s2k_t      s2k;
     uint8_t        enckey[PGP_MAX_KEY_SIZE + 1];
     unsigned       enckeylen;
 } pgp_sk_sesskey_t;

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2619,7 +2619,8 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
             return false;
         }
 
-        if (!pgp_s2k_derive_key(&pkt.u.seckey.protection.s2k, passphrase, derived_key, keysize)) {
+        if (!pgp_s2k_derive_key(
+              &pkt.u.seckey.protection.s2k, passphrase, derived_key, keysize)) {
             (void) fprintf(stderr, "pgp_s2k_derive_key failed\n");
             pgp_forget(passphrase, strlen(passphrase));
             return false;

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2619,31 +2619,10 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
             return false;
         }
 
-        if (pkt.u.seckey.protection.s2k.specifier == PGP_S2KS_SIMPLE) {
-            if (pgp_s2k_simple(
-                  pkt.u.seckey.protection.s2k.hash_alg, derived_key, keysize, passphrase)) {
-                (void) fprintf(stderr, "pgp_s2k_simple failed\n");
-                return false;
-            }
-        } else if (pkt.u.seckey.protection.s2k.specifier == PGP_S2KS_SALTED) {
-            if (pgp_s2k_salted(pkt.u.seckey.protection.s2k.hash_alg,
-                               derived_key,
-                               keysize,
-                               passphrase,
-                               pkt.u.seckey.protection.s2k.salt)) {
-                (void) fprintf(stderr, "pgp_s2k_salted failed\n");
-                return false;
-            }
-        } else if (pkt.u.seckey.protection.s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
-            if (pgp_s2k_iterated(pkt.u.seckey.protection.s2k.hash_alg,
-                                 derived_key,
-                                 keysize,
-                                 passphrase,
-                                 pkt.u.seckey.protection.s2k.salt,
-                                 pkt.u.seckey.protection.s2k.iterations)) {
-                (void) fprintf(stderr, "pgp_s2k_iterated failed\n");
-                return false;
-            }
+        if (!pgp_s2k_derive_key(&pkt.u.seckey.protection.s2k, passphrase, derived_key, keysize)) {
+            (void) fprintf(stderr, "pgp_s2k_derive_key failed\n");
+            pgp_forget(passphrase, strlen(passphrase));
+            return false;
         }
 
         pgp_forget(passphrase, strlen(passphrase));

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -488,12 +488,7 @@ init_encrypted_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *wr
         goto finish;
     }
 
-    if (pgp_s2k_iterated(skey.s2k.hash_alg,
-                         s2key,
-                         keylen,
-                         passphrase,
-                         skey.s2k.salt,
-                         pgp_s2k_decode_iterations(skey.s2k.iterations))) {
+    if (!pgp_s2k_derive_key(&skey.s2k, passphrase, s2key, keylen)) {
         (void) fprintf(stderr, "init_encrypted_dst: s2k failed\n");
         ret = RNP_ERROR_GENERIC;
         goto finish;


### PR DESCRIPTION
This PR:
- adds `pgp_forget` in some places, fixing #473 
- renames pgp_s2k to pgp_s2k_t
- removes some s2k-related code duplication by using new function pgp_s2k_derive_key