### PR TITLE
Remove passphrase parameters from key store interfaces.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -39,7 +39,7 @@
 
 #include "memory.h"
 
-typedef struct rnp_t rnp_t;
+typedef struct rnp_t     rnp_t;
 typedef struct pgp_key_t pgp_key_t;
 
 typedef enum {
@@ -146,12 +146,8 @@ bool rnp_key_store_load_from_mem(rnp_t *rnp,
                                  const unsigned,
                                  pgp_memory_t *);
 
-bool rnp_key_store_write_to_file(rnp_t *rnp,
-                                 rnp_key_store_t *,
-                                 const uint8_t *,
-                                 const unsigned);
-bool rnp_key_store_write_to_mem(
-  rnp_t *rnp, rnp_key_store_t *, const uint8_t *, const unsigned, pgp_memory_t *);
+bool rnp_key_store_write_to_file(rnp_t *rnp, rnp_key_store_t *, const unsigned);
+bool rnp_key_store_write_to_mem(rnp_t *rnp, rnp_key_store_t *, const unsigned, pgp_memory_t *);
 
 void rnp_key_store_clear(rnp_key_store_t *);
 void rnp_key_store_free(rnp_key_store_t *);

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1048,8 +1048,8 @@ rnp_import_key(rnp_t *rnp, char *f)
     }
 
     // update the keyrings on disk
-    if (!rnp_key_store_write_to_file(rnp, rnp->secring, NULL, 0) ||
-        !rnp_key_store_write_to_file(rnp, rnp->pubring, NULL, 0)) {
+    if (!rnp_key_store_write_to_file(rnp, rnp->secring, 0) ||
+        !rnp_key_store_write_to_file(rnp, rnp->pubring, 0)) {
         RNP_LOG("failed to write keyring");
         goto done;
     }
@@ -1148,8 +1148,8 @@ rnp_generate_key(rnp_t *rnp)
     }
 
     // update the keyring on disk
-    if (!rnp_key_store_write_to_file(rnp, rnp->secring, NULL, 0) ||
-        !rnp_key_store_write_to_file(rnp, rnp->pubring, NULL, 0)) {
+    if (!rnp_key_store_write_to_file(rnp, rnp->secring, 0) ||
+        !rnp_key_store_write_to_file(rnp, rnp->pubring, 0)) {
         RNP_LOG("failed to write keyring");
         goto end;
     }

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -1582,10 +1582,7 @@ error:
 }
 
 bool
-rnp_key_store_g10_key_to_mem(pgp_io_t *     io,
-                             pgp_key_t *    key,
-                             const uint8_t *passphrase,
-                             pgp_memory_t * memory)
+rnp_key_store_g10_key_to_mem(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *memory)
 {
     if (DYNARRAY_IS_EMPTY(key, packet)) {
         return false;

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -34,7 +34,7 @@ bool rnp_key_store_g10_from_mem(pgp_io_t *,
                                 rnp_key_store_t *,
                                 rnp_key_store_t *,
                                 pgp_memory_t *);
-bool rnp_key_store_g10_key_to_mem(pgp_io_t *, pgp_key_t *, const uint8_t *, pgp_memory_t *);
+bool rnp_key_store_g10_key_to_mem(pgp_io_t *, pgp_key_t *, pgp_memory_t *);
 bool g10_write_seckey(pgp_output_t *output, pgp_seckey_t *seckey, const char *passphrase);
 pgp_seckey_t *g10_decrypt_seckey(const uint8_t *     data,
                                  size_t              data_len,

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -486,10 +486,7 @@ rnp_key_store_kbx_write_header(rnp_key_store_t *key_store, pgp_memory_t *m)
 }
 
 static bool
-rnp_key_store_kbx_write_pgp(pgp_io_t *     io,
-                            pgp_key_t *    key,
-                            const uint8_t *passphrase,
-                            pgp_memory_t * m)
+rnp_key_store_kbx_write_pgp(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *m)
 {
     int          i, rc;
     size_t       start, key_start, uid_start;
@@ -707,10 +704,7 @@ rnp_key_store_kbx_write_x509(rnp_key_store_t *key_store, pgp_memory_t *m)
 }
 
 bool
-rnp_key_store_kbx_to_mem(pgp_io_t *       io,
-                         rnp_key_store_t *key_store,
-                         const uint8_t *  passphrase,
-                         pgp_memory_t *   memory)
+rnp_key_store_kbx_to_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_t *memory)
 {
     int i;
 
@@ -725,7 +719,7 @@ rnp_key_store_kbx_to_mem(pgp_io_t *       io,
         if (!pgp_key_is_primary_key(&key_store->keys[i])) {
             continue;
         }
-        if (!rnp_key_store_kbx_write_pgp(io, &key_store->keys[i], passphrase, memory)) {
+        if (!rnp_key_store_kbx_write_pgp(io, &key_store->keys[i], memory)) {
             RNP_LOG_FD(io->errs, "Can't write PGP blobs for key %d\n", i);
             return false;
         }

--- a/src/librekey/key_store_kbx.h
+++ b/src/librekey/key_store_kbx.h
@@ -31,6 +31,6 @@
 #include <rekey/rnp_key_store.h>
 
 bool rnp_key_store_kbx_from_mem(pgp_io_t *, rnp_key_store_t *, pgp_memory_t *);
-bool rnp_key_store_kbx_to_mem(pgp_io_t *, rnp_key_store_t *, const uint8_t *, pgp_memory_t *);
+bool rnp_key_store_kbx_to_mem(pgp_io_t *, rnp_key_store_t *, pgp_memory_t *);
 
 #endif // RNP_KEY_STORE_KBX_H

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -434,7 +434,6 @@ rnp_key_store_pgp_read_from_mem(pgp_io_t *       io,
 int
 rnp_key_store_pgp_write_to_mem(pgp_io_t *       io,
                                rnp_key_store_t *key_store,
-                               const uint8_t *  passphrase,
                                const unsigned   armour,
                                pgp_memory_t *   mem)
 {

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -65,8 +65,10 @@ bool rnp_key_store_pgp_read_from_mem(pgp_io_t *,
                                      const unsigned,
                                      pgp_memory_t *);
 
-int rnp_key_store_pgp_write_to_mem(
-  pgp_io_t *, rnp_key_store_t *, const uint8_t *, const unsigned, pgp_memory_t *);
+int rnp_key_store_pgp_write_to_mem(pgp_io_t *,
+                                   rnp_key_store_t *,
+                                   const unsigned,
+                                   pgp_memory_t *);
 
 bool pgp_parse_key_attrs(pgp_key_t *key, const uint8_t *data, size_t data_len);
 

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -240,10 +240,7 @@ rnp_key_store_load_from_mem(rnp_t *          rnp,
 }
 
 bool
-rnp_key_store_write_to_file(rnp_t *          rnp,
-                            rnp_key_store_t *key_store,
-                            const uint8_t *  passphrase,
-                            const unsigned   armour)
+rnp_key_store_write_to_file(rnp_t *rnp, rnp_key_store_t *key_store, const unsigned armour)
 {
     bool         rc;
     pgp_memory_t mem = {0};
@@ -284,8 +281,7 @@ rnp_key_store_write_to_file(rnp_t *          rnp,
                      rnp_strhexdump_upper(grips, grip, 20, ""));
 
             memset(&mem, 0, sizeof(mem));
-            if (!rnp_key_store_g10_key_to_mem(
-                  rnp->io, &key_store->keys[i], passphrase, &mem)) {
+            if (!rnp_key_store_g10_key_to_mem(rnp->io, &key_store->keys[i], &mem)) {
                 pgp_memory_release(&mem);
                 return false;
             }
@@ -301,7 +297,7 @@ rnp_key_store_write_to_file(rnp_t *          rnp,
         return true;
     }
 
-    if (!rnp_key_store_write_to_mem(rnp, key_store, passphrase, armour, &mem)) {
+    if (!rnp_key_store_write_to_mem(rnp, key_store, armour, &mem)) {
         pgp_memory_release(&mem);
         return false;
     }
@@ -314,16 +310,15 @@ rnp_key_store_write_to_file(rnp_t *          rnp,
 bool
 rnp_key_store_write_to_mem(rnp_t *          rnp,
                            rnp_key_store_t *key_store,
-                           const uint8_t *  passphrase,
                            const unsigned   armour,
                            pgp_memory_t *   memory)
 {
     switch (key_store->format) {
     case GPG_KEY_STORE:
-        return rnp_key_store_pgp_write_to_mem(rnp->io, key_store, passphrase, armour, memory);
+        return rnp_key_store_pgp_write_to_mem(rnp->io, key_store, armour, memory);
 
     case KBX_KEY_STORE:
-        return rnp_key_store_kbx_to_mem(rnp->io, key_store, passphrase, memory);
+        return rnp_key_store_kbx_to_mem(rnp->io, key_store, memory);
 
     default:
         fprintf(rnp->io->errs,
@@ -735,16 +730,16 @@ get_key_by_name(pgp_io_t *             io,
                 const rnp_key_store_t *keyring,
                 const char *           name,
                 unsigned *             from,
-                pgp_key_t **     key)
+                pgp_key_t **           key)
 {
     pgp_key_t *kp;
-    uint8_t **       uidp;
-    unsigned         i = 0;
-    pgp_key_t *      keyp;
-    unsigned         savedstart;
-    regex_t          r;
-    uint8_t          keyid[PGP_KEY_ID_SIZE + 1];
-    size_t           len;
+    uint8_t ** uidp;
+    unsigned   i = 0;
+    pgp_key_t *keyp;
+    unsigned   savedstart;
+    regex_t    r;
+    uint8_t    keyid[PGP_KEY_ID_SIZE + 1];
+    size_t     len;
 
     *key = NULL;
 
@@ -809,10 +804,10 @@ get_key_by_name(pgp_io_t *             io,
 
 */
 bool
-rnp_key_store_get_key_by_name(pgp_io_t *              io,
-                              const rnp_key_store_t * keyring,
-                              const char *            name,
-                              pgp_key_t **key)
+rnp_key_store_get_key_by_name(pgp_io_t *             io,
+                              const rnp_key_store_t *keyring,
+                              const char *           name,
+                              pgp_key_t **           key)
 {
     unsigned from;
 
@@ -821,11 +816,8 @@ rnp_key_store_get_key_by_name(pgp_io_t *              io,
 }
 
 bool
-rnp_key_store_get_next_key_by_name(pgp_io_t *             io,
-                                   const rnp_key_store_t *keyring,
-                                   const char *           name,
-                                   unsigned *             n,
-                                   pgp_key_t **     key)
+rnp_key_store_get_next_key_by_name(
+  pgp_io_t *io, const rnp_key_store_t *keyring, const char *name, unsigned *n, pgp_key_t **key)
 {
     return get_key_by_name(io, keyring, name, n, key);
 }


### PR DESCRIPTION
I noticed these are no longer used anywhere, so it seems best to remove them (maybe slightly safer).