### PR TITLE
Fix rnp_strcasecmp.

### DIFF
--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -913,7 +913,7 @@ rnp_strcasecmp(const char *s1, const char *s2)
 {
     int n;
 
-    for (n = 0; *s1 && *s2 && (n = tolower((uint8_t) *s1) - tolower((uint8_t) *s2)) == 0;
+    for (n = 0; (n = tolower((uint8_t) *s1) - tolower((uint8_t) *s2)) == 0 && *s1;
          s1++, s2++) {
     }
     return n;


### PR DESCRIPTION
I encountered a tricky bug while working on FFI and had to track this down.

Previously, strings like "test1" and "test198281939823" would compare equal. I ran some tests on random strings of random lengths for 10 min or so and confirmed this produces correct results (compared to a known-good impl).