### PR TITLE
Streamed PK-based encryption and decryption

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -445,7 +445,7 @@ typedef enum {
     PGP_C_BZIP2 = 3
 } pgp_compression_type_t;
 
-enum { PGP_SE_IP_DATA_VERSION = 1, PGP_PKSK_V3 = 3 };
+enum { PGP_SE_IP_DATA_VERSION = 1, PGP_PKSK_V3 = 3, PGP_SKSK_V4 = 4 };
 
 /** Version.
  * OpenPGP has two different protocol versions: version 3 and version 4.

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -33,6 +33,7 @@
 #include "types.h"
 #include "pass-provider.h"
 #include "key-provider.h"
+#include "list.h"
 
 typedef struct rnp_action_keygen_t {
     struct {
@@ -88,17 +89,19 @@ typedef struct rnp_params_t {
 
 /* rnp operation context : contains additional data about the currently ongoing operation */
 typedef struct rnp_ctx_t {
-    rnp_t *        rnp;       /* rnp structure */
-    char *         filename;  /* name of the input file to store in literal data packet */
-    int64_t        filemtime; /* file modification time to store in literal data packet */
-    int64_t        sigcreate; /* signature creation time */
-    uint64_t       sigexpire; /* signature expiration time */
-    pgp_hash_alg_t halg;      /* hash algorithm */
-    pgp_symm_alg_t ealg;      /* encryption algorithm */
-    int            zalg;      /* compression algorithm used */
-    int            zlevel;    /* compression level */
-    int            overwrite; /* allow to overwrite output file if exists */
-    bool           armour;    /* whether to use ASCII armour on output */
+    rnp_t *        rnp;        /* rnp structure */
+    char *         filename;   /* name of the input file to store in literal data packet */
+    int64_t        filemtime;  /* file modification time to store in literal data packet */
+    int64_t        sigcreate;  /* signature creation time */
+    uint64_t       sigexpire;  /* signature expiration time */
+    pgp_hash_alg_t halg;       /* hash algorithm */
+    pgp_symm_alg_t ealg;       /* encryption algorithm */
+    int            zalg;       /* compression algorithm used */
+    int            zlevel;     /* compression level */
+    int            overwrite;  /* allow to overwrite output file if exists */
+    bool           armour;     /* whether to use ASCII armour on output */
+    list           recipients; /* recipients of the encrypted message */
+    int            passwordc;  /* number of passwords to encrypt message for */
 } rnp_ctx_t;
 
 #endif // __RNP_TYPES__

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -32,6 +32,7 @@
 
 #include "types.h"
 #include "pass-provider.h"
+#include "key-provider.h"
 
 typedef struct rnp_action_keygen_t {
     struct {

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -23,7 +23,6 @@ librnp_la_SOURCES	= \
 	fingerprint.c \
 	generate-key.c \
 	hash.c \
-	key-provider.c \
 	list.c \
 	misc.c \
 	packet-create.c \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -28,6 +28,7 @@ librnp_la_SOURCES	= \
 	misc.c \
 	packet-create.c \
 	pass-provider.c \
+	key-provider.c \
 	pem.c \
 	pgp-key.c \
 	rnp.c \

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -43,9 +43,9 @@ typedef struct pgp_key_request_ctx_t {
     bool             secret;
     pgp_key_search_t stype;
     union {
-        uint8_t id[PGP_KEY_ID_SIZE];
-        uint8_t grip[PGP_FINGERPRINT_SIZE];
-        char *  userid;
+        uint8_t     id[PGP_KEY_ID_SIZE];
+        uint8_t     grip[PGP_FINGERPRINT_SIZE];
+        const char *userid;
     } search;
 } pgp_key_request_ctx_t;
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -55,6 +55,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include "pass-provider.h"
+#include "key-provider.h"
 #include <repgp/repgp.h>
 #include <rekey/rnp_key_store.h>
 #include "memory.h"

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -740,6 +740,7 @@ void
 rnp_ctx_free(rnp_ctx_t *ctx)
 {
     free(ctx->filename);
+    list_destroy(&ctx->recipients);
 }
 
 /* list the keys in a keyring */
@@ -1329,6 +1330,7 @@ rnp_encrypt_stream(rnp_ctx_t *ctx, const char *in, const char *out)
     pgp_dest_t           dst;
     pgp_write_handler_t *handler = NULL;
     rnp_result_t         result;
+    pgp_key_provider_t   keyprov;
     bool                 is_stdin;
     bool                 is_stdout;
 
@@ -1354,6 +1356,9 @@ rnp_encrypt_stream(rnp_ctx_t *ctx, const char *in, const char *out)
     }
 
     handler->passphrase_provider = &ctx->rnp->passphrase_provider;
+    keyprov.callback = rnp_key_provider_keyring;
+    keyprov.userdata = ctx->rnp;
+    handler->key_provider = &keyprov;
     handler->ctx = ctx;
     handler->param = NULL;
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -79,6 +79,7 @@ __RCSID("$NetBSD: rnp.c,v 1.98 2016/06/28 16:34:40 christos Exp $");
 #include <rekey/rnp_key_store.h>
 
 #include "pass-provider.h"
+#include "key-provider.h"
 #include <repgp/repgp.h>
 #include <librepgp/packet-print.h>
 #include <librepgp/packet-show.h>
@@ -1255,6 +1256,7 @@ rnp_process_stream(rnp_ctx_t *ctx, const char *in, const char *out)
     pgp_source_t               src;
     pgp_parse_handler_t *      handler = NULL;
     pgp_parse_handler_param_t *param = NULL;
+    pgp_key_provider_t         keyprov;
     rnp_result_t               result;
     bool                       is_stdin;
     bool                       is_stdout;
@@ -1301,10 +1303,14 @@ rnp_process_stream(rnp_ctx_t *ctx, const char *in, const char *out)
     }
 
     handler->passphrase_provider = &ctx->rnp->passphrase_provider;
+    keyprov.callback = rnp_key_provider_keyring;
+    keyprov.userdata = ctx->rnp;
+    handler->key_provider = &keyprov;
     handler->dest_provider = rnp_parse_handler_dest;
     handler->param = param;
 
     result = process_pgp_source(handler, &src);
+
     if (result != RNP_SUCCESS) {
         (void) fprintf(stderr, "rnp_process_stream: error 0x%x\n", result);
     }

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -70,6 +70,9 @@
 #define PGP_SHA1_HASH_SIZE 20
 #define PGP_CHECKHASH_SIZE PGP_SHA1_HASH_SIZE
 
+/* 16384 bits should be pretty enough for now */
+#define PGP_MPINT_SIZE  (2048 + 2)
+
 /** General-use structure for variable-length data
  */
 
@@ -427,6 +430,25 @@ typedef struct {
     uint8_t                 key[PGP_MAX_KEY_SIZE];
     uint16_t                checksum;
 } pgp_pk_sesskey_t;
+
+/** public-key encrypted session key packet, should replace pgp_pk_sesskey_t later */
+typedef struct {
+    unsigned                version;
+    uint8_t                 key_id[PGP_KEY_ID_SIZE];
+    pgp_pubkey_alg_t        alg;
+    union {
+        uint8_t rsa_m[PGP_MPINT_SIZE];
+        struct {
+            uint8_t eg_g[PGP_MPINT_SIZE];
+            uint8_t eg_m[PGP_MPINT_SIZE];
+        };
+        uint8_t sm2_m[PGP_MPINT_SIZE];
+        struct {
+            uint8_t ecdh_p[PGP_MPINT_SIZE];
+            uint8_t ecdh_m[256];
+        };
+    };
+} pgp_pk_sesskey_pkt_t;
 
 /** pkp_sk_sesskey_t */
 typedef struct {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -71,7 +71,8 @@
 #define PGP_CHECKHASH_SIZE PGP_SHA1_HASH_SIZE
 
 /* 16384 bits should be pretty enough for now */
-#define PGP_MPINT_SIZE  (2048 + 2)
+#define PGP_MPINT_BITS (16384)
+#define PGP_MPINT_SIZE (PGP_MPINT_BITS >> 3)
 
 /** General-use structure for variable-length data
  */
@@ -433,21 +434,31 @@ typedef struct {
 
 /** public-key encrypted session key packet, should replace pgp_pk_sesskey_t later */
 typedef struct {
-    unsigned                version;
-    uint8_t                 key_id[PGP_KEY_ID_SIZE];
-    pgp_pubkey_alg_t        alg;
+    unsigned         version;
+    uint8_t          key_id[PGP_KEY_ID_SIZE];
+    pgp_pubkey_alg_t alg;
     union {
-        uint8_t rsa_m[PGP_MPINT_SIZE];
         struct {
-            uint8_t eg_g[PGP_MPINT_SIZE];
-            uint8_t eg_m[PGP_MPINT_SIZE];
-        };
-        uint8_t sm2_m[PGP_MPINT_SIZE];
+            uint8_t  m[PGP_MPINT_SIZE];
+            unsigned mlen;
+        } rsa;
         struct {
-            uint8_t ecdh_p[PGP_MPINT_SIZE];
-            uint8_t ecdh_m[256];
-        };
-    };
+            uint8_t  g[PGP_MPINT_SIZE];
+            uint8_t  m[PGP_MPINT_SIZE];
+            unsigned glen;
+            unsigned mlen;
+        } eg;
+        struct {
+            uint8_t  m[PGP_MPINT_SIZE];
+            unsigned mlen;
+        } sm2;
+        struct {
+            uint8_t  p[PGP_MPINT_SIZE];
+            uint8_t  m[ECDH_WRAPPED_KEY_SIZE];
+            unsigned plen;
+            unsigned mlen;
+        } ecdh;
+    } params;
 } pgp_pk_sesskey_pkt_t;
 
 /** pkp_sk_sesskey_t */

--- a/src/librepgp/Makefile.am
+++ b/src/librepgp/Makefile.am
@@ -13,4 +13,5 @@ librepgp_la_SOURCES     =  \
     stream-common.c \
     stream-armour.c \
     stream-parse.c \
-    stream-write.c
+    stream-write.c \
+    stream-packet.c

--- a/src/librepgp/stream-armour.c
+++ b/src/librepgp/stream-armour.c
@@ -289,9 +289,7 @@ armoured_src_read(pgp_source_t *src, void *buf, size_t len)
                 param->eofb64 = true;
                 break;
             } else if (bval == 0xff) {
-                (void) fprintf(stderr,
-                               "armoured_src_read: wrong base64 character %c\n",
-                               (char) *(bptr - 1));
+                RNP_LOG("wrong base64 character %c", (char) *(bptr - 1));
                 return -1;
             }
         }
@@ -329,18 +327,18 @@ armoured_src_read(pgp_source_t *src, void *buf, size_t len)
 
             /* reading b64 padding if any */
             if ((eqcount = armour_read_padding(src)) < 0) {
-                (void) fprintf(stderr, "armoured_src_read: wrong padding\n");
+                RNP_LOG("wrong padding");
                 return -1;
             }
 
             /* reading crc */
             if (!armour_read_crc(src)) {
-                (void) fprintf(stderr, "armoured_src_read: wrong crc line\n");
+                RNP_LOG("wrong crc line");
                 return -1;
             }
             /* reading armour trailing line */
             if (!armour_read_trailer(src)) {
-                (void) fprintf(stderr, "armoured_src_read: wrong armour trailer\n");
+                RNP_LOG("armoured_src_read: wrong armour trailer");
                 return -1;
             }
 
@@ -370,7 +368,7 @@ armoured_src_read(pgp_source_t *src, void *buf, size_t len)
 
     if (param->eofb64) {
         if ((dend - dptr + eqcount) % 4 != 0) {
-            (void) fprintf(stderr, "armoured_src_read: wrong b64 padding\n");
+            RNP_LOG("wrong b64 padding");
             return -1;
         }
 
@@ -386,7 +384,7 @@ armoured_src_read(pgp_source_t *src, void *buf, size_t len)
 
         /* we calculate crc when input stream finished instead of when all data is read */
         if (param->crc != param->readcrc) {
-            (void) fprintf(stderr, "armoured_src_read: CRC mismatch\n");
+            RNP_LOG("CRC mismatch");
             return -1;
         }
     } else {
@@ -495,22 +493,22 @@ armour_parse_header(pgp_source_t *src)
     }
 
     if (!(armhdr = find_armour_header(hdr, read, &armhdrlen))) {
-        (void) fprintf(stderr, "parse_armour_header: no armour header\n");
+        RNP_LOG("no armour header");
         return false;
     }
 
     if (armhdr > hdr) {
-        (void) fprintf(stderr, "parse_armour_header: extra data before the header line\n");
+        RNP_LOG("extra data before the header line");
     }
 
     param->type = armour_message_type(armhdr + 5, armhdrlen - 10);
     if (param->type == PGP_ARMOURED_UNKNOWN) {
-        (void) fprintf(stderr, "parse_armour_header: unknown armour header\n");
+        RNP_LOG("unknown armour header");
         return false;
     }
 
     if ((param->armourhdr = malloc(armhdrlen - 9)) == NULL) {
-        (void) fprintf(stderr, "parse_armour_header: allocation failed\n");
+        RNP_LOG("allocation failed");
         return false;
     }
 
@@ -530,13 +528,13 @@ armour_parse_headers(pgp_source_t *src)
 
     do {
         if (!armour_peek_line(param->readsrc, header, sizeof(header) - 1, &hdrlen)) {
-            (void) fprintf(stderr, "armour_parse_headers: failed to peek line\n");
+            RNP_LOG("failed to peek line");
             return false;
         }
 
         if (hdrlen > 0) {
             if ((hdrval = malloc(hdrlen + 1)) == NULL) {
-                (void) fprintf(stderr, "armour_parse_headers: malloc failed\n");
+                RNP_LOG("malloc failed");
                 return false;
             }
 
@@ -558,7 +556,7 @@ armour_parse_headers(pgp_source_t *src)
                 param->charset = hdrval;
             } else {
                 header[hdrlen] = '\0';
-                (void) fprintf(stderr, "armour_parse_headers: unknown header '%s'\n", header);
+                RNP_LOG("unknown header '%s'", header);
             }
 
             src_skip(param->readsrc, hdrlen);
@@ -599,13 +597,13 @@ init_armoured_src(pgp_source_t *src, pgp_source_t *readsrc)
     }
     /* eol */
     if (!armour_skip_eol(param->readsrc)) {
-        (void) fprintf(stderr, "init_armoured_src: no eol after the armour header\n");
+        RNP_LOG("no eol after the armour header");
         errcode = RNP_ERROR_BAD_FORMAT;
         goto finish;
     }
     /* parsing headers */
     if (!armour_parse_headers(src)) {
-        (void) fprintf(stderr, "init_armoured_src: failed to parse headers\n");
+        RNP_LOG("failed to parse headers");
         errcode = RNP_ERROR_BAD_FORMAT;
         goto finish;
     }
@@ -713,7 +711,7 @@ armoured_dst_write(pgp_dest_t *dst, const void *buf, size_t len)
     pgp_dest_armoured_param_t *param = dst->param;
 
     if (!param) {
-        (void) fprintf(stderr, "armoured_dst_write: wrong param\n");
+        RNP_LOG("wrong param");
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -853,7 +851,7 @@ init_armoured_dst(pgp_dest_t *dst, pgp_dest_t *writedst, pgp_armoured_msg_t msgt
     rnp_result_t               ret = RNP_SUCCESS;
 
     if ((param = calloc(1, sizeof(*param))) == NULL) {
-        (void) fprintf(stderr, "init_armoured_dst: allocation failed\n");
+        RNP_LOG("allocation failed");
         return RNP_ERROR_OUT_OF_MEMORY;
     }
 
@@ -870,7 +868,7 @@ init_armoured_dst(pgp_dest_t *dst, pgp_dest_t *writedst, pgp_armoured_msg_t msgt
     param->llen = 76; /* must be multiple of 4 */
 
     if (!armour_message_header(param->type, false, hdr)) {
-        (void) fprintf(stderr, "init_armoured_dst: unknown message type\n");
+        RNP_LOG("unknown message type");
         ret = RNP_ERROR_BAD_PARAMETERS;
         goto finish;
     }
@@ -905,7 +903,7 @@ rnp_dearmour_source(pgp_source_t *src, pgp_dest_t *dst)
 
     read = src_peek(src, readbuf, sizeof(clear_start));
     if (read < sizeof(armor_start)) {
-        (void) fprintf(stderr, "rnp_dearmour_source: can't read enough data from source\n");
+        RNP_LOG("can't read enough data from source");
         res = RNP_ERROR_READ;
         goto finish;
     }
@@ -915,7 +913,7 @@ rnp_dearmour_source(pgp_source_t *src, pgp_dest_t *dst)
     if (strstr((char *) readbuf, armor_start)) {
         /* checking whether it is cleartext */
         if (strstr((char *) readbuf, clear_start)) {
-            (void) fprintf(stderr, "rnp_dearmour_source: source is cleartext, not armored\n");
+            RNP_LOG("source is cleartext, not armored");
             goto finish;
         }
 
@@ -926,7 +924,7 @@ rnp_dearmour_source(pgp_source_t *src, pgp_dest_t *dst)
             goto finish;
         }
     } else {
-        (void) fprintf(stderr, "rnp_dearmour_source: source is not armored data\n");
+        RNP_LOG("source is not armored data");
         goto finish;
     }
 
@@ -939,7 +937,7 @@ rnp_dearmour_source(pgp_source_t *src, pgp_dest_t *dst)
         } else if (read > 0) {
             dst_write(dst, readbuf, read);
             if (dst->werr != RNP_SUCCESS) {
-                (void) fprintf(stderr, "rnp_dearmour_source: failed to output data\n");
+                RNP_LOG("failed to output data");
                 res = RNP_ERROR_WRITE;
                 break;
             }
@@ -972,7 +970,7 @@ rnp_armour_source(pgp_source_t *src, pgp_dest_t *dst, pgp_armoured_msg_t msgtype
         } else if (read > 0) {
             dst_write(&armordst, readbuf, read);
             if (armordst.werr != RNP_SUCCESS) {
-                (void) fprintf(stderr, "rnp_armour_source: failed to output data\n");
+                RNP_LOG("failed to output data");
                 res = RNP_ERROR_WRITE;
                 break;
             }

--- a/src/librepgp/stream-armour.c
+++ b/src/librepgp/stream-armour.c
@@ -34,6 +34,7 @@
 #include "defs.h"
 #include "types.h"
 #include "symmetric.h"
+#include "utils.h"
 
 #define ARMOURED_BLOCK_SIZE (4096)
 

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -41,6 +41,7 @@
 #include "defs.h"
 #include "types.h"
 #include "symmetric.h"
+#include "utils.h"
 
 ssize_t
 src_read(pgp_source_t *src, void *buf, size_t len)

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -125,7 +125,9 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
     }
 
     if (cache->len - cache->pos >= len) {
-        memcpy(buf, &cache->buf[cache->pos], len);
+        if (buf) {
+            memcpy(buf, &cache->buf[cache->pos], len);
+        }
         return len;
     }
 
@@ -138,14 +140,18 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
     while (cache->len < len) {
         read = src->read(src, &cache->buf[cache->len], sizeof(cache->buf) - cache->len);
         if (read == 0) {
-            memcpy(buf, &cache->buf[0], cache->len);
+            if (buf) {
+                memcpy(buf, &cache->buf[0], cache->len);
+            }
             return cache->len;
         } else if (read < 0) {
             return -1;
         } else {
             cache->len += read;
             if (cache->len >= len) {
-                memcpy(buf, &cache->buf[0], len);
+                if (buf) {
+                    memcpy(buf, &cache->buf[0], len);
+                }
                 return len;
             }
         }

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -257,7 +257,7 @@ init_file_src(pgp_source_t *src, const char *path)
     pgp_source_file_param_t *param;
 
     if (stat(path, &st) != 0) {
-        (void) fprintf(stderr, "can't stat \"%s\"\n", path);
+        RNP_LOG("can't stat '%s'", path);
         return RNP_ERROR_READ;
     }
 
@@ -267,7 +267,7 @@ init_file_src(pgp_source_t *src, const char *path)
     fd = open(path, O_RDONLY);
 #endif
     if (fd < 0) {
-        (void) fprintf(stderr, "can't open \"%s\"\n", path);
+        RNP_LOG("can't open '%s'", path);
         return RNP_ERROR_READ;
     }
 
@@ -346,7 +346,7 @@ file_dst_write(pgp_dest_t *dst, const void *buf, size_t len)
     pgp_dest_file_param_t *param = dst->param;
 
     if (!param) {
-        (void) fprintf(stderr, "file_dst_write: wrong param\n");
+        RNP_LOG("wrong param");
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -354,7 +354,7 @@ file_dst_write(pgp_dest_t *dst, const void *buf, size_t len)
     ret = write(param->fd, buf, len);
     if (ret < 0) {
         param->errcode = errno;
-        (void) fprintf(stderr, "file_dst_write: write failed, error %d\n", param->errcode);
+        RNP_LOG("write failed, error %d", param->errcode);
         return RNP_ERROR_WRITE;
     } else {
         param->errcode = 0;
@@ -390,7 +390,7 @@ init_file_dest(pgp_dest_t *dst, const char *path)
     pgp_dest_file_param_t *param;
 
     if (strlen(path) > sizeof(param->path)) {
-        (void) fprintf(stderr, "init_file_dest: path too long\n");
+        RNP_LOG("path too long");
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
@@ -399,7 +399,7 @@ init_file_dest(pgp_dest_t *dst, const char *path)
     }
 
     if (stat(path, &st) == 0) {
-        (void) fprintf(stderr, "init_file_dest: file already exists: \"%s\"\n", path);
+        RNP_LOG("file already exists: '%s'", path);
         return RNP_ERROR_WRITE;
     }
 
@@ -409,7 +409,7 @@ init_file_dest(pgp_dest_t *dst, const char *path)
 #endif
     fd = open(path, flags, 0600);
     if (fd < 0) {
-        (void) fprintf(stderr, "init_file_dest: failed to create file '%s'\n", path);
+        RNP_LOG("failed to create file '%s'", path);
         return false;
     }
 

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -98,7 +98,8 @@ ssize_t src_read(pgp_source_t *src, void *buf, size_t len);
 /** @brief read up to len bytes and keep them in the cache/do not process
  *  Works only for streams with cache
  *  @param src source structure
- *  @param buf preallocated buffer which can store up to len bytes
+ *  @param buf preallocated buffer which can store up to len bytes, or NULL if data should be
+ *  discarded, just making sure that needed input is available in source
  *  @param len number of bytes to read. Must be less then PGP_INPUT_CACHE_SIZE.
  *  @return number of bytes read or -1 in case of error
  **/

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -148,13 +148,13 @@ stream_read_mpi(pgp_source_t *src, uint8_t *mpi, size_t maxlen)
 
     bits = ((unsigned) hdr[0] << 8) | hdr[1];
     if (!bits || (bits > PGP_MPINT_BITS)) {
-        (void) fprintf(stderr, "%s: too large or zero mpi, %d bits", __func__, bits);
+        RNP_LOG("too large or zero mpi, %d bits", bits);
         return -1;
     }
 
     bytes = (bits + 7) >> 3;
     if ((maxlen > 0) && (bytes > maxlen - 2)) {
-        (void) fprintf(stderr, "%s: mpi out of bounds", __func__);
+        RNP_LOG("mpi out of bounds");
         return -1;
     }
 
@@ -164,7 +164,7 @@ stream_read_mpi(pgp_source_t *src, uint8_t *mpi, size_t maxlen)
 
     hbits = bits & 7 ? bits & 7 : 8;
     if ((((unsigned) mpi[0] >> hbits) != 0) || !((unsigned) mpi[0] & (1U << (hbits - 1)))) {
-        (void) fprintf(stderr, "%s: wrong mpi bit count", __func__);
+        RNP_LOG("wrong mpi bit count");
         return -1;
     }
 
@@ -285,12 +285,12 @@ stream_read_packet_body(pgp_source_t *src, pgp_packet_body_t *body)
     }
 
     if (!(body->data = malloc(len))) {
-        (void) fprintf(stderr, "%s: malloc of %d bytes failed\n", __func__, (int) len);
+        RNP_LOG("malloc of %d bytes failed", (int) len);
         return RNP_ERROR_OUT_OF_MEMORY;
     }
 
     if ((read = src_read(src, body->data, read)) < len) {
-        (void) fprintf(stderr, "%s: read %d instead of %d\n", __func__, (int) read, (int) len);
+        RNP_LOG("read %d instead of %d", (int) read, (int) len);
         free(body->data);
         body->data = NULL;
         return RNP_ERROR_READ;
@@ -410,7 +410,7 @@ stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey)
     /* version */
     skey->version = buf[0];
     if (skey->version != 4) {
-        (void) fprintf(stderr, "stream_parse_sk_sesskey: wrong packet version\n");
+        RNP_LOG("wrong packet version");
         return RNP_ERROR_BAD_FORMAT;
     }
 
@@ -449,14 +449,14 @@ stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey)
         }
         break;
     default:
-        (void) fprintf(stderr, "stream_parse_sk_sesskey: wrong s2k specifier\n");
+        RNP_LOG("wrong s2k specifier");
         return RNP_ERROR_BAD_FORMAT;
     }
 
     /* encrypted session key if present */
     if (len > 0) {
         if (len > PGP_MAX_KEY_SIZE + 1) {
-            (void) fprintf(stderr, "stream_parse_sk_sesskey: too long esk\n");
+            RNP_LOG("too long esk");
             return RNP_ERROR_BAD_FORMAT;
         }
         if (src_read(src, skey->enckey, len) != len) {
@@ -491,7 +491,7 @@ stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_pkt_t *pkey)
 
     /* version */
     if (buf[0] != PGP_PKSK_V3) {
-        (void) fprintf(stderr, "%s: wrong packet version\n", __func__);
+        RNP_LOG("wrong packet version");
         return RNP_ERROR_BAD_FORMAT;
     }
     pkey->version = buf[0];
@@ -553,12 +553,12 @@ stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_pkt_t *pkey)
 
         break;
     default:
-        (void) fprintf(stderr, "%s: unknown pk alg %d\n", __func__, (int) pkey->alg);
+        RNP_LOG("unknown pk alg %d", (int) pkey->alg);
         return RNP_ERROR_BAD_FORMAT;
     }
 
     if (len > 0) {
-        (void) fprintf(stderr, "%s: extra %d bytes\n", __func__, (int) len);
+        RNP_LOG("extra %d bytes", (int) len);
         return RNP_ERROR_BAD_FORMAT;
     }
 

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -36,7 +36,6 @@
 #include "symmetric.h"
 #include "crypto/s2k.h"
 #include "signature.h"
-#include "misc.h"
 #include "stream-packet.h"
 
 size_t

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <rnp/rnp_def.h>
+#include "defs.h"
+#include "types.h"
+#include "symmetric.h"
+#include "crypto/s2k.h"
+#include "signature.h"
+#include "misc.h"
+#include "stream-packet.h"
+
+size_t
+write_packet_len(uint8_t *buf, size_t len)
+{
+    if (len < 192) {
+        buf[0] = len;
+        return 1;
+    } else if (len < 8192 + 192) {
+        buf[0] = ((len - 192) >> 8) + 192;
+        buf[1] = (len - 192) & 0xff;
+        return 2;
+    } else {
+        buf[0] = 0xff;
+        buf[1] = (uint8_t)(len >> 24);
+        buf[2] = (uint8_t)(len >> 16);
+        buf[3] = (uint8_t)(len >> 8);
+        buf[4] = (uint8_t)(len);
+        return 5;
+    }
+}
+
+int
+get_packet_type(uint8_t ptag)
+{
+    if (!(ptag & PGP_PTAG_ALWAYS_SET)) {
+        return -1;
+    }
+
+    if (ptag & PGP_PTAG_NEW_FORMAT) {
+        return (int) (ptag & PGP_PTAG_NF_CONTENT_TAG_MASK);
+    } else {
+        return (int) ((ptag & PGP_PTAG_OF_CONTENT_TAG_MASK) >> PGP_PTAG_OF_CONTENT_TAG_SHIFT);
+    }
+}
+
+ssize_t
+stream_read_pkt_len(pgp_source_t *src)
+{
+    uint8_t buf[6];
+    ssize_t read;
+
+    read = src_read(src, buf, 2);
+    if ((read < 2) || !(buf[0] & PGP_PTAG_ALWAYS_SET)) {
+        return -1;
+    }
+
+    if (buf[0] & PGP_PTAG_NEW_FORMAT) {
+        if (buf[1] < 192) {
+            return (ssize_t) buf[1];
+        } else if (buf[1] < 224) {
+            if (src_read(src, &buf[2], 1) < 1) {
+                return -1;
+            }
+            return ((ssize_t)(buf[1] - 192) << 8) + (ssize_t) buf[2] + 192;
+        } else if (buf[1] < 255) {
+            // we do not allow partial length here
+            return -1;
+        } else {
+            if (src_read(src, &buf[2], 4) < 4) {
+                return -1;
+            } else {
+                return ((ssize_t) buf[2] << 24) | ((ssize_t) buf[3] << 16) |
+                       ((ssize_t) buf[4] << 8) | (ssize_t) buf[5];
+            }
+        }
+    } else {
+        switch (buf[0] & PGP_PTAG_OF_LENGTH_TYPE_MASK) {
+        case PGP_PTAG_OLD_LEN_1:
+            return (ssize_t) buf[1];
+        case PGP_PTAG_OLD_LEN_2:
+            if (src_read(src, &buf[2], 1) < 1) {
+                return -1;
+            }
+            return ((ssize_t) buf[1] << 8) | ((ssize_t) buf[2]);
+        case PGP_PTAG_OLD_LEN_4:
+            if (src_read(src, &buf[2], 3) < 3) {
+                return -1;
+            }
+            return ((ssize_t) buf[1] << 24) | ((ssize_t) buf[2] << 16) |
+                   ((ssize_t) buf[3] << 8) | (ssize_t) buf[4];
+        default:
+            return -1;
+        }
+    }
+}
+
+bool
+init_packet_body(pgp_packet_body_t *body, int tag)
+{
+    body->data = malloc(16);
+    if (!body->data) {
+        return false;
+    }
+    body->allocated = 16;
+    body->tag = tag;
+    body->len = 0;
+    return true;
+}
+
+bool
+add_packet_body(pgp_packet_body_t *body, void *data, size_t len)
+{
+    void * newdata;
+    size_t newlen;
+
+    if (body->len + len > body->allocated) {
+        newlen = (body->len + len) * 2;
+        newdata = realloc(body->data, newlen);
+        if (!newdata) {
+            return false;
+        }
+        body->data = newdata;
+        body->allocated = newlen;
+    }
+
+    memcpy(body->data + body->len, data, len);
+    body->len += len;
+
+    return true;
+}
+
+bool
+add_packet_body_byte(pgp_packet_body_t *body, uint8_t byte)
+{
+    if (body->len < body->allocated) {
+        body->data[body->len++] = byte;
+        return true;
+    } else {
+        return add_packet_body(body, &byte, 1);
+    }
+}
+
+void
+free_packet_body(pgp_packet_body_t *body)
+{
+    free(body->data);
+    body->data = NULL;
+}
+
+void
+stream_flush_packet_body(pgp_packet_body_t *body, pgp_dest_t *dst)
+{
+    uint8_t hdr[6];
+    size_t  hlen;
+
+    hdr[0] = body->tag | PGP_PTAG_ALWAYS_SET | PGP_PTAG_NEW_FORMAT;
+    hlen = 1 + write_packet_len(&hdr[1], body->len);
+    dst_write(dst, hdr, hlen);
+    dst_write(dst, body->data, body->len);
+    free(body->data);
+}
+
+rnp_result_t
+stream_read_packet_body(pgp_source_t *src, pgp_packet_body_t *body)
+{
+    uint8_t buf[6];
+    ssize_t len;
+    ssize_t read;
+
+    read = src_peek(src, buf, 1);
+    if (read < 1) {
+        return RNP_ERROR_READ;
+    }
+
+    body->tag = get_packet_type(buf[0]);
+
+    if ((len = stream_read_pkt_len(src)) <= 0) {
+        return RNP_ERROR_READ;
+    }
+
+    if (!(body->data = malloc(len))) {
+        (void) fprintf(stderr, "%s: malloc of %d bytes failed\n", __func__, (int)len);
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+
+    if ((read = src_read(src, body->data, read)) < len) {
+        (void) fprintf(stderr, "%s: read %d instead of %d\n", __func__, (int)read, (int)len);
+        free(body->data);
+        body->data = NULL;
+        return RNP_ERROR_READ;
+    }
+
+    body->allocated = len;
+    body->len = len;
+    return RNP_SUCCESS;
+}
+
+bool
+stream_write_sk_sesskey(pgp_sk_sesskey_t *skey, pgp_dest_t *dst)
+{
+    pgp_packet_body_t pktbody;
+    bool              res;
+
+    if (!init_packet_body(&pktbody, PGP_PTAG_CT_SK_SESSION_KEY)) {
+        return false;
+    }
+
+    res = add_packet_body_byte(&pktbody, 4) && add_packet_body_byte(&pktbody, skey->alg) &&
+          add_packet_body_byte(&pktbody, skey->s2k.specifier) &&
+          add_packet_body_byte(&pktbody, skey->s2k.hash_alg);
+
+    switch (skey->s2k.specifier) {
+    case PGP_S2KS_SIMPLE:
+        break;
+    case PGP_S2KS_SALTED:
+        res = res && add_packet_body(&pktbody, skey->s2k.salt, sizeof(skey->s2k.salt));
+        break;
+    case PGP_S2KS_ITERATED_AND_SALTED:
+        res = res && add_packet_body(&pktbody, skey->s2k.salt, sizeof(skey->s2k.salt)) &&
+              add_packet_body_byte(&pktbody, skey->s2k.iterations);
+        break;
+    }
+
+    if (skey->enckeylen > 0) {
+        res = res && add_packet_body(&pktbody, skey->enckey, skey->enckeylen);
+    }
+
+    if (res) {
+        stream_flush_packet_body(&pktbody, dst);
+        return true;
+    } else {
+        free_packet_body(&pktbody);
+        return false;
+    }
+}
+
+bool
+stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *skey, pgp_dest_t *dst)
+{
+    return false;
+}
+
+rnp_result_t
+stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey)
+{
+    uint8_t buf[4];
+    ssize_t len;
+    ssize_t read;
+
+    /* read packet length */
+    len = stream_read_pkt_len(src);
+    if (len < 0) {
+        return RNP_ERROR_READ;
+    } else if (len < 4) {
+        return RNP_ERROR_BAD_FORMAT;
+    }
+
+    /* version + symalg + s2k type + hash alg */
+    if ((read = src_read(src, buf, 4)) < 4) {
+        return RNP_ERROR_READ;
+    }
+
+    /* version */
+    skey->version = buf[0];
+    if (skey->version != 4) {
+        (void) fprintf(stderr, "stream_parse_sk_sesskey: wrong packet version\n");
+        return RNP_ERROR_BAD_FORMAT;
+    }
+
+    /* symmetric algorithm */
+    skey->alg = buf[1];
+
+    /* s2k */
+    skey->s2k.specifier = buf[2];
+    skey->s2k.hash_alg = buf[3];
+    len -= 4;
+
+    switch (skey->s2k.specifier) {
+    case PGP_S2KS_SIMPLE:
+        break;
+    case PGP_S2KS_SALTED:
+    case PGP_S2KS_ITERATED_AND_SALTED:
+        /* salt */
+        if (len < PGP_SALT_SIZE) {
+            return RNP_ERROR_BAD_FORMAT;
+        }
+        if (src_read(src, skey->s2k.salt, PGP_SALT_SIZE) != PGP_SALT_SIZE) {
+            return RNP_ERROR_READ;
+        }
+        len -= PGP_SALT_SIZE;
+
+        /* iterations */
+        if (skey->s2k.specifier == PGP_S2KS_ITERATED_AND_SALTED) {
+            if (len < 1) {
+                return RNP_ERROR_BAD_FORMAT;
+            }
+            if (src_read(src, buf, 1) != 1) {
+                return RNP_ERROR_READ;
+            }
+            skey->s2k.iterations = (unsigned) buf[0];
+            len--;
+        }
+        break;
+    default:
+        (void) fprintf(stderr, "stream_parse_sk_sesskey: wrong s2k specifier\n");
+        return RNP_ERROR_BAD_FORMAT;
+    }
+
+    /* encrypted session key if present */
+    if (len > 0) {
+        if (len > PGP_MAX_KEY_SIZE + 1) {
+            (void) fprintf(stderr, "stream_parse_sk_sesskey: too long esk\n");
+            return RNP_ERROR_BAD_FORMAT;
+        }
+        if (src_read(src, skey->enckey, len) != len) {
+            return RNP_ERROR_READ;
+        }
+        skey->enckeylen = len;
+    } else {
+        skey->enckeylen = 0;
+    }
+
+    return RNP_SUCCESS;
+}
+
+rnp_result_t
+stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_t *pkey)
+{
+    ssize_t len;
+    ssize_t read;
+    uint8_t buf[10];
+
+    len = stream_read_pkt_len(src);
+    if (len < 0) {
+        return RNP_ERROR_READ;
+    } else if (len < 10) {
+        return RNP_ERROR_BAD_FORMAT;
+    }
+
+    if ((read = src_read(src, buf, 10)) < 10) {
+        return RNP_ERROR_READ;
+    }
+
+    /* version */
+    if (buf[0] != 3) {
+        (void) fprintf(stderr, "%s: wrong packet version\n", __func__);
+        return RNP_ERROR_BAD_FORMAT;
+    }
+
+    /* key id */
+    memcpy(pkey->key_id, &buf[1], 8);
+
+    /* pk alg */
+    pkey->alg = buf[9];
+
+    switch (pkey->alg) {
+        case PGP_PKA_RSA:
+            break;
+        case PGP_PKA_ELGAMAL:
+            break;
+        case PGP_PKA_SM2:
+            break;
+        case PGP_PKA_ECDH:
+            break;
+        default:
+            (void) fprintf(stderr, "%s: unknown pk alg %d\n", __func__, (int)pkey->alg);
+            return RNP_ERROR_BAD_FORMAT;
+    }
+
+    (void) fprintf(stderr, "skipping public key encrypted session key\n");
+    src_skip(src, len);
+
+    return RNP_ERROR_NOT_IMPLEMENTED;
+}

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef STREAM_PACKET_H_
+#define STREAM_PACKET_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include "errors.h"
+#include <repgp/repgp.h>
+#include <rnp/rnp.h>
+#include "stream-common.h"
+
+/* structure to write non-stream packets without need to precalculate the length */
+typedef struct pgp_packet_body_t {
+    int      tag;       /* packet tag */
+    uint8_t *data;      /* packet body data */
+    size_t   len;       /* current len of the data */
+    size_t   allocated; /* allocated bytes in data */
+} pgp_packet_body_t;
+
+/** @brief write new packet length
+ *  @param buf pre-allocated buffer, must have 5 bytes
+ *  @param len packet length
+ *  @return number of bytes, saved in buf
+ **/
+size_t write_packet_len(uint8_t *buf, size_t len);
+
+/** @brief get packet type from the packet header byte
+ *  @param ptag first byte of the packet header
+ *  @return packet type or -1 if ptag is wrong
+ **/
+int get_packet_type(uint8_t ptag);
+
+/** @brief Read packet length for fixed-size (say, small) packet. Returns -1 on error.
+ *  Will also read packet tag byte. We do not allow partial length here as well as large packets (so ignoring possible ssize_t overflow)
+ * 
+ *  @param src source to read length from
+ *  @return length of the packet or -1 if there is read error or packet length is ill-formed
+ **/
+ssize_t stream_read_pkt_len(pgp_source_t *src);
+
+/** @brief initialize writing of packet body
+ *  @param body preallocated structure
+ *  @param tag tag of the packet
+ *  @return true on success or false otherwise
+ **/
+bool init_packet_body(pgp_packet_body_t *body, int tag);
+
+/** @brief add chunk of the data to packet body
+ *  @param body pointer to the structure, initialized with init_packet_body
+ *  @param data non-NULL pointer to the data
+ *  @param len number of bytes to add
+ *  @return true if data was copied successfully, or false otherwise
+ **/
+bool add_packet_body(pgp_packet_body_t *body, void *data, size_t len);
+
+/** @brief add single byte to packet body
+ *  @param body pointer to the structure, initialized with init_packet_body
+ *  @param byte byte to add
+ *  @return true if byte was added successfully, or false otherwise
+ **/
+bool add_packet_body_byte(pgp_packet_body_t *body, uint8_t byte);
+
+/** @brief deallocate data inside of packet body structure
+ *  @param body initialized packet body
+ *  @return void
+ **/
+void free_packet_body(pgp_packet_body_t *body);
+
+/** @brief write packet header, length and body to the dest
+ *  This will also deallocate internally used memory, so no free_packet_body call is needed
+ * 
+ *  @param body populated with data packet body
+ *  @param dst destination to write to
+ *  @return void
+ **/
+void stream_flush_packet_body(pgp_packet_body_t *body, pgp_dest_t *dst);
+
+/** @brief read 'short-length' packet body (including tag and length bytes) from the source
+ *  @param src source to read from
+ *  @param body pre-allocated body structure. Do not call init_packet_body on it!
+ *  @return RNP_SUCCESS or error code if operation failed
+ **/
+rnp_result_t stream_read_packet_body(pgp_source_t *src, pgp_packet_body_t *body);
+
+/* Packet handling functions */
+
+bool stream_write_sk_sesskey(pgp_sk_sesskey_t *skey, pgp_dest_t *dst);
+
+bool stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *skey, pgp_dest_t *dst);
+
+rnp_result_t stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey);
+
+rnp_result_t stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_t *pkey);
+
+
+#endif

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -35,6 +35,9 @@
 #include <rnp/rnp.h>
 #include "stream-common.h"
 
+/* maximum size of the 'small' packet */
+#define PGP_MAX_PKT_SIZE 0x100000
+
 /* structure to write non-stream packets without need to precalculate the length */
 typedef struct pgp_packet_body_t {
     int      tag;       /* packet tag */
@@ -57,8 +60,9 @@ size_t write_packet_len(uint8_t *buf, size_t len);
 int get_packet_type(uint8_t ptag);
 
 /** @brief Read packet length for fixed-size (say, small) packet. Returns -1 on error.
- *  Will also read packet tag byte. We do not allow partial length here as well as large packets (so ignoring possible ssize_t overflow)
- * 
+ *  Will also read packet tag byte. We do not allow partial length here as well as large
+ *packets (so ignoring possible ssize_t overflow)
+ *
  *  @param src source to read length from
  *  @return length of the packet or -1 if there is read error or packet length is ill-formed
  **/
@@ -94,7 +98,7 @@ void free_packet_body(pgp_packet_body_t *body);
 
 /** @brief write packet header, length and body to the dest
  *  This will also deallocate internally used memory, so no free_packet_body call is needed
- * 
+ *
  *  @param body populated with data packet body
  *  @param dst destination to write to
  *  @return void
@@ -116,7 +120,6 @@ bool stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *skey, pgp_dest_t *dst);
 
 rnp_result_t stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey);
 
-rnp_result_t stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_t *pkey);
-
+rnp_result_t stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_pkt_t *pkey);
 
 #endif

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -90,6 +90,14 @@ bool add_packet_body(pgp_packet_body_t *body, void *data, size_t len);
  **/
 bool add_packet_body_byte(pgp_packet_body_t *body, uint8_t byte);
 
+/** @brief add pgp mpi (including header) to packet body
+ *  @param body pointer to the structure, initialized with init_packet_body
+ *  @param mpi bytes of mpi to add
+ *  @param len length of the mpi in bytes
+ *  @return true if mpi was added successfully, or false otherwise
+ **/
+bool add_packet_body_mpi(pgp_packet_body_t *body, uint8_t *mpi, unsigned len);
+
 /** @brief deallocate data inside of packet body structure
  *  @param body initialized packet body
  *  @return void
@@ -116,7 +124,7 @@ rnp_result_t stream_read_packet_body(pgp_source_t *src, pgp_packet_body_t *body)
 
 bool stream_write_sk_sesskey(pgp_sk_sesskey_t *skey, pgp_dest_t *dst);
 
-bool stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *skey, pgp_dest_t *dst);
+bool stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *pkey, pgp_dest_t *dst);
 
 rnp_result_t stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey);
 

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -42,6 +42,7 @@ typedef bool pgp_destination_func_t(pgp_parse_handler_t *handler,
 
 typedef struct pgp_parse_handler_t {
     pgp_passphrase_provider_t *passphrase_provider;
+    pgp_key_provider_t *       key_provider;
     pgp_destination_func_t *   dest_provider;
 
     void *param;

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -93,7 +93,7 @@ typedef struct pgp_dest_partial_param_t {
     size_t      len;     /* bytes cached in part */
 } pgp_dest_partial_param_t;
 
-rnp_result_t
+static rnp_result_t
 partial_dst_write(pgp_dest_t *dst, const void *buf, size_t len)
 {
     pgp_dest_partial_param_t *param = dst->param;
@@ -230,7 +230,7 @@ close_streamed_packet(pgp_dest_packet_param_t *param, bool discard)
     }
 }
 
-rnp_result_t
+static rnp_result_t
 encrypted_dst_write(pgp_dest_t *dst, const void *buf, size_t len)
 {
     pgp_dest_encrypted_param_t *param = dst->param;

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -412,7 +412,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
         pkey.params.eg.mlen = outlen / 2;
     } break;
     default:
-        (void) fprintf(stderr, "%s: unsupported alg: %d", __func__, pubkey->alg);
+        (void) fprintf(stderr, "%s: unsupported alg: %d\n", __func__, pubkey->alg);
         goto finish;
     }
 

--- a/src/librepgp/stream-write.h
+++ b/src/librepgp/stream-write.h
@@ -37,6 +37,7 @@
 
 typedef struct pgp_write_handler_t {
     pgp_passphrase_provider_t *passphrase_provider;
+    pgp_key_provider_t *       key_provider;
     rnp_ctx_t *                ctx;
 
     void *param;

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -346,22 +346,12 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         ctx.filename = strdup(rnp_filename(f));
         ctx.filemtime = rnp_filemtime(f);
     }
+    if (userid) {
+        list_append(&ctx.recipients, userid, strlen(userid) + 1);
+    }
     rnp->pswdtries = rnp_cfg_get_pswdtries(cfg);
 
     switch (cmd) {
-    case CMD_ENCRYPT:
-        ctx.ealg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
-        ctx.zalg = rnp_cfg_getint(cfg, CFG_ZALG);
-        ctx.zlevel = rnp_cfg_getint(cfg, CFG_ZLEVEL);
-
-        if (f == NULL) {
-            cc = stdin_to_mem(cfg, &in, &out, &maxsize);
-            sz = rnp_encrypt_memory(&ctx, userid, in, cc, out, maxsize);
-            ret = show_output(cfg, out, sz, "Bad memory encryption");
-        } else {
-            ret = rnp_encrypt_file(&ctx, userid, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_OK;
-        }
-        break;
     case CMD_CLEARSIGN:
     case CMD_SIGN:
         ctx.halg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
@@ -410,7 +400,10 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         ret = rnp_process_stream(&ctx, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
     }
-    case CMD_SYM_ENCRYPT: {
+    case CMD_SYM_ENCRYPT:
+        ctx.passwordc = 1;
+    /* FALLTHROUGH */
+    case CMD_ENCRYPT: {
         ctx.ealg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
         ctx.zalg = rnp_cfg_getint(cfg, CFG_ZALG);
         ctx.zlevel = rnp_cfg_getint(cfg, CFG_ZLEVEL);

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -88,7 +88,6 @@ enum optdefs {
     CMD_VERIFY,
     CMD_VERIFY_CAT,
     CMD_SYM_ENCRYPT,
-    CMD_SYM_DECRYPT,
     CMD_DEARMOR,
     CMD_LIST_PACKETS,
     CMD_SHOW_KEYS,
@@ -138,7 +137,6 @@ static struct option options[] = {
   {"verify-cat", no_argument, NULL, CMD_VERIFY_CAT},
   {"verify-show", no_argument, NULL, CMD_VERIFY_CAT},
   {"verifyshow", no_argument, NULL, CMD_VERIFY_CAT},
-  {"sym-decrypt", no_argument, NULL, CMD_SYM_DECRYPT},
   {"symmetric", no_argument, NULL, CMD_SYM_ENCRYPT},
   {"dearmor", no_argument, NULL, CMD_DEARMOR},
   /* file listing commands */
@@ -383,23 +381,9 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
                                 rnp_cfg_getbool(cfg, CFG_DETACHED)) == RNP_OK;
         }
         break;
-    case CMD_DECRYPT: {
-        if (f) {
-            const char *out = rnp_cfg_get(cfg, CFG_OUTFILE);
-            repgp_set_input(io, create_filepath_handle(f));
-            repgp_set_output(io, create_filepath_handle(out));
-        } else {
-            repgp_set_input(io, create_stdin_handle());
-            repgp_set_output(io,
-                             create_buffer_handle((size_t) rnp_cfg_getint(cfg, CFG_MAXALLOC)));
-        }
-        ret = (RNP_SUCCESS == repgp_decrypt(&ctx, io));
-        break;
-    }
-    case CMD_SYM_DECRYPT: {
+    case CMD_DECRYPT:
         ret = rnp_process_stream(&ctx, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
-    }
     case CMD_SYM_ENCRYPT:
         ctx.passwordc = 1;
     /* FALLTHROUGH */
@@ -481,10 +465,6 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
         break;
     case CMD_DECRYPT:
         /* for decryption, we need a seckey */
-        rnp_cfg_setbool(cfg, CFG_NEEDSSECKEY, true);
-        *cmd = val;
-        break;
-    case CMD_SYM_DECRYPT:
         rnp_cfg_setbool(cfg, CFG_NEEDSSECKEY, true);
         *cmd = val;
         break;

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -492,6 +492,9 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
         *cmd = val;
         break;
     case CMD_SYM_DECRYPT:
+        rnp_cfg_setbool(cfg, CFG_NEEDSSECKEY, true);
+        *cmd = val;
+        break;
     case CMD_SYM_ENCRYPT:
     case CMD_VERIFY:
     case CMD_VERIFY_CAT:

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -358,7 +358,7 @@ def rnp_decrypt_file(src, dst):
 
 def rnp_symdecrypt_file(src, dst):
     pipe = pswd_pipe(PASSWORD)
-    ret, out, err = run_proc(RNP, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--sym-decrypt', src, '--output', dst])
+    ret, out, err = run_proc(RNP, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--decrypt', src, '--output', dst])
     os.close(pipe)
     if ret != 0:
         raise_err('rnp symmetric decryption failed', out + err)

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -177,9 +177,9 @@ def reg_workfiles(mainname, *exts):
 def clear_workfiles():
     global TEST_WORKFILES
     for fpath in TEST_WORKFILES:
-        try: 
+        try:
             os.remove(fpath)
-        except: 
+        except:
             pass
     TEST_WORKFILES = []
 
@@ -211,7 +211,7 @@ def rnpkey_generate_rsa(bits = None, cleanup = True):
 
     userid = str(bits) + '@rnptest'
     # Open pipe for password
-    pipe = pswd_pipe(PASSWORD) 
+    pipe = pswd_pipe(PASSWORD)
     params = params + ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', userid, '--generate-key']
     # Run key generation
     ret, out, err = run_proc(RNPK, params)
@@ -238,7 +238,7 @@ def rnpkey_generate_rsa(bits = None, cleanup = True):
     ret, out, err = run_proc(GPG, ['--batch', '--passphrase', PASSWORD, '--homedir', GPGDIR, '--import', path.join(RNPDIR, 'pubring.gpg'), path.join(RNPDIR, 'secring.gpg')])
     if ret != 0: raise_err('gpg key import failed', err)
     # Cleanup and return
-    if cleanup: 
+    if cleanup:
         clear_keyrings()
         return None
     else:


### PR DESCRIPTION
This PR completely moves encrypt and decrypt commands (including password-only encryption) to the streamed approach.
Also it makes rnp ready for multiple-recipient encryption and decryption, just some minor CLI modifications are required.
It doesn't remove old encrypt/decrypt functionality - I think it would be better to remove it when signing/verification and cleartext operations will be updated to use streamed approach as well.

It is the part of the issue #424