### PR TITLE
Check pgp_build_pubkey return value (and callers).

### DIFF
--- a/src/lib/signature.h
+++ b/src/lib/signature.h
@@ -88,9 +88,9 @@ bool pgp_check_direct_sig(const pgp_pubkey_t *,
                           const pgp_pubkey_t *,
                           const uint8_t *);
 bool pgp_check_hash_sig(pgp_hash_t *, const pgp_sig_t *, const pgp_pubkey_t *);
-void pgp_sig_start_key_sig(
+bool pgp_sig_start_key_sig(
   pgp_create_sig_t *, const pgp_pubkey_t *, const uint8_t *, pgp_sig_type_t, pgp_hash_alg_t);
-void pgp_sig_start_subkey_sig(pgp_create_sig_t *,
+bool pgp_sig_start_subkey_sig(pgp_create_sig_t *,
                               const pgp_pubkey_t *,
                               const pgp_pubkey_t *,
                               pgp_sig_type_t,


### PR DESCRIPTION
I ran into a tricky issue with some local changes, and I saw tests aren't catching it, so this is just trying to improve some error checking in this area.

(`signature.c` still has a lot of room for improvement on error checking, but I'm just doing this one piece since it caused me some trouble.)