### PR TITLE
Generate ECDH key as subkey to ECDSA key

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -83,7 +83,7 @@ bool  rnp_find_key(rnp_t *, const char *);
 char *rnp_get_key(rnp_t *, const char *, const char *);
 char *rnp_export_key(rnp_t *, const char *);
 int   rnp_import_key(rnp_t *, char *);
-int   rnp_generate_key(rnp_t *);
+bool  rnp_generate_key(rnp_t *);
 int   rnp_secret_count(rnp_t *);
 int   rnp_public_count(rnp_t *);
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1084,7 +1084,7 @@ rnp_public_count(rnp_t *rnp)
     return rnp->pubring ? ((rnp_key_store_t *) rnp->pubring)->keyc : 0;
 }
 
-int
+bool
 rnp_generate_key(rnp_t *rnp)
 {
     RNP_MSG("Generating a new key...\n");

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1090,79 +1090,65 @@ rnp_generate_key(rnp_t *rnp)
     RNP_MSG("Generating a new key...\n");
 
     rnp_action_keygen_t *action = &rnp->action.generate_key_ctx;
-    pgp_key_t *          primary_sec = NULL;
-    pgp_key_t *          primary_pub = NULL;
-    pgp_key_t *          subkey_sec = NULL;
-    pgp_key_t *          subkey_pub = NULL;
+    pgp_key_t            primary_sec = {0};
+    pgp_key_t            primary_pub = {0};
+    pgp_key_t            subkey_sec = {0};
+    pgp_key_t            subkey_pub = {0};
     char *               cp = NULL;
-    bool                 ok = false;
     key_store_format_t   key_format = ((rnp_key_store_t *) rnp->secring)->format;
 
-    primary_sec = calloc(1, sizeof(*primary_sec));
-    primary_pub = calloc(1, sizeof(*primary_pub));
-    subkey_sec = calloc(1, sizeof(*subkey_sec));
-    subkey_pub = calloc(1, sizeof(*subkey_pub));
-    if (!primary_sec || !primary_pub || !subkey_sec || !subkey_pub) {
-        goto end;
-    }
     if (!pgp_generate_keypair(&action->primary.keygen,
                               &action->subkey.keygen,
                               true,
-                              primary_sec,
-                              primary_pub,
-                              subkey_sec,
-                              subkey_pub,
+                              &primary_sec,
+                              &primary_pub,
+                              &subkey_sec,
+                              &subkey_pub,
                               key_format)) {
         RNP_LOG("failed to generate keys");
-        goto end;
+        return false;
     }
 
     // show the primary key
-    pgp_sprint_key(rnp->io, NULL, primary_pub, &cp, "pub", &primary_pub->key.pubkey, 0);
+    pgp_sprint_key(rnp->io, NULL, &primary_pub, &cp, "pub", &primary_pub.key.pubkey, 0);
     (void) fprintf(stdout, "%s", cp);
     free(cp);
 
     // protect the primary key
     if (!pgp_key_protect(
-          primary_sec, key_format, &action->primary.protection, &rnp->passphrase_provider)) {
-        goto end;
+          &primary_sec, key_format, &action->primary.protection, &rnp->passphrase_provider)) {
+        return false;
     }
 
     // show the subkey
-    pgp_sprint_key(rnp->io, NULL, subkey_pub, &cp, "sub", &subkey_pub->key.pubkey, 0);
+    pgp_sprint_key(rnp->io, NULL, &subkey_pub, &cp, "sub", &subkey_pub.key.pubkey, 0);
     (void) fprintf(stdout, "%s", cp);
     free(cp);
 
     // protect the subkey
     if (!pgp_key_protect(
-          subkey_sec, key_format, &action->subkey.protection, &rnp->passphrase_provider)) {
+          &subkey_sec, key_format, &action->subkey.protection, &rnp->passphrase_provider)) {
         RNP_LOG("failed to protect keys");
-        goto end;
+        return false;
     }
 
     // add them all to the key store
-    if (!rnp_key_store_add_key(rnp->io, rnp->secring, primary_sec) ||
-        !rnp_key_store_add_key(rnp->io, rnp->secring, subkey_sec) ||
-        !rnp_key_store_add_key(rnp->io, rnp->pubring, primary_pub) ||
-        !rnp_key_store_add_key(rnp->io, rnp->pubring, subkey_pub)) {
+    if (!rnp_key_store_add_key(rnp->io, rnp->secring, &primary_sec) ||
+        !rnp_key_store_add_key(rnp->io, rnp->secring, &subkey_sec) ||
+        !rnp_key_store_add_key(rnp->io, rnp->pubring, &primary_pub) ||
+        !rnp_key_store_add_key(rnp->io, rnp->pubring, &subkey_pub)) {
         RNP_LOG("failed to add keys to key store");
-        goto end;
+        return false;
     }
 
     // update the keyring on disk
     if (!rnp_key_store_write_to_file(rnp->io, rnp->secring, 0) ||
         !rnp_key_store_write_to_file(rnp->io, rnp->pubring, 0)) {
         RNP_LOG("failed to write keyring");
-        goto end;
+        return false;
     }
 
-    ok = true;
-end:
-    free(primary_sec);
-    free(primary_pub);
-    free(subkey_sec);
-    free(subkey_pub);
-    return ok;
+    return true;
 }
 
 /* encrypt a file */

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -197,7 +197,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
             // copy keygen crypto and protection from primary to subkey
             action->subkey.keygen.crypto = primary_desc->crypto;
             action->subkey.protection = *protection;
-        } else if (rnp_generate_key_expert_mode(rnp) != PGP_E_OK) {
+        } else if (rnp_generate_key_expert_mode(rnp) != RNP_SUCCESS) {
             RNP_LOG("Critical error: Key generation failed");
             return false;
         }

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -41,7 +41,7 @@ typedef enum {
     OPT_DEBUG
 } optdefs_t;
 
-pgp_errcode_t rnp_generate_key_expert_mode(rnp_t *rnp);
+rnp_result_t rnp_generate_key_expert_mode(rnp_t *rnp);
 bool rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f);
 int setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg);
 void print_praise(void);

--- a/src/rnpkeys/tui.c
+++ b/src/rnpkeys/tui.c
@@ -142,12 +142,12 @@ ask_bitlen(FILE *input_fp)
  *              [out] Function fills corresponding to key type and length
  * @param   cfg [in]  Requested configuration
  *
- * @returns PGP_E_OK on success
- *          PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG algorithm not supported
- *          PGP_E_FAIL indicates bug in the implementation
+ * @returns RNP_SUCCESS on success
+ *          RNP_ERROR_BAD_PARAMETERS unsupported parameters supplied
+ *          RNP_ERROR_GENERIC indicates problem in implementation
  *
 -------------------------------------------------------------------------------- */
-pgp_errcode_t
+rnp_result_t
 rnp_generate_key_expert_mode(rnp_t *rnp)
 {
     FILE *                       input_fd = rnp->user_input_fp ? rnp->user_input_fp : stdin;
@@ -171,13 +171,13 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
     case PGP_PKA_ECDSA: {
         crypto->ecc.curve = ask_curve(input_fd);
         if (PGP_HASH_UNKNOWN == crypto->hash_alg) {
-            return PGP_E_ALG_UNSUPPORTED_HASH_ALG;
+            return RNP_ERROR_BAD_PARAMETERS;
         }
 
         size_t digest_length = 0;
         if (!pgp_digest_length(crypto->hash_alg, &digest_length)) {
             // Implementation error
-            return PGP_E_FAIL;
+            return RNP_ERROR_BAD_PARAMETERS;
         }
 
         /*
@@ -207,7 +207,7 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
             break;
         default:
             // Should never happen as ask_curve checks it
-            return PGP_E_FAIL;
+            return RNP_ERROR_GENERIC;
         }
     } break;
     case PGP_PKA_EDDSA:
@@ -218,12 +218,12 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
         crypto->ecc.curve = PGP_CURVE_SM2_P_256;
         break;
     default:
-        return PGP_E_ALG_UNSUPPORTED_PUBLIC_KEY_ALG;
+        return RNP_ERROR_BAD_PARAMETERS;
     }
     // TODO this is mostly to get tests passing
     subkey_desc->crypto = primary_desc->crypto;
     primary_protection->hash_alg = crypto->hash_alg;
     *subkey_protection = *primary_protection;
 
-    return PGP_E_OK;
+    return RNP_SUCCESS;
 }

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -599,7 +599,9 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdh_256, strlen(test_ecdh_256)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDH);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.subkey.keygen.crypto.key_alg, PGP_PKA_ECDH);
     rnp_assert_int_equal(rstate,
                          rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
                          PGP_CURVE_NIST_P_256);
@@ -610,7 +612,9 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdh_384, strlen(test_ecdh_384)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDH);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.subkey.keygen.crypto.key_alg, PGP_PKA_ECDH);
     rnp_assert_int_equal(rstate,
                          rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
                          PGP_CURVE_NIST_P_384);
@@ -621,7 +625,9 @@ rnpkeys_generatekey_testExpertMode(void **state)
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdh_521, strlen(test_ecdh_521)));
     rnp_assert_int_equal(
-      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDH);
+      rstate, rnp.action.generate_key_ctx.primary.keygen.crypto.key_alg, PGP_PKA_ECDSA);
+    rnp_assert_int_equal(
+      rstate, rnp.action.generate_key_ctx.subkey.keygen.crypto.key_alg, PGP_PKA_ECDH);
     rnp_assert_int_equal(rstate,
                          rnp.action.generate_key_ctx.primary.keygen.crypto.ecc.curve,
                          PGP_CURVE_NIST_P_521);


### PR DESCRIPTION
As mentioned in #344 the ECDH key generated by rnp can't be imported to GnuPG and other way around. At the time ECDH was implemented the functionality needed for generation a key with a subkey wasn't fully supported.
Needed functionality for subkey generation is now implemented so we can carry on with ECDH key generation, so that it's compatible with GnuPG

Closes #488