### PR TITLE
repgp: Check usage flag before encrypting

### DIFF
--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -1064,3 +1064,20 @@ pgp_key_write_packets(const pgp_key_t *key, pgp_output_t *output)
     }
     return true;
 }
+
+pgp_key_t *
+find_suitable_subkey(const pgp_key_t *primary, uint8_t desired_usage)
+{
+    // fixme copied fron rnp.c
+    if (!primary || DYNARRAY_IS_EMPTY(primary, subkey)) {
+        return NULL;
+    }
+
+    for (unsigned i = primary->subkeyc; i-- > 0;) {
+        pgp_key_t *subkey = primary->subkeys[i];
+        if (subkey->key_flags & desired_usage) {
+            return subkey;
+        }
+    }
+    return NULL;
+}

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -228,4 +228,18 @@ bool pgp_key_add_userid(pgp_key_t *            key,
 
 bool pgp_key_write_packets(const pgp_key_t *key, pgp_output_t *output);
 
+/**
+ *
+ * @brief   Search the list of subkeys in reverse order with the
+ *          assumption that the last subkey in the list would be
+ *          the newest created.
+ *
+ * @param   primary
+ * @param   desired_usage
+ *
+ * @returns Last created subkey with desired usage flag set
+ *          or NULL if not found
+ */
+pgp_key_t *find_suitable_subkey(const pgp_key_t *primary, uint8_t desired_usage);
+
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -470,24 +470,6 @@ formatbignum(char *buffer, BIGNUM *bn)
     return cc;
 }
 
-/* find a subkey that includes any of the desired key flags */
-static pgp_key_t *
-find_suitable_subkey(const pgp_key_t *primary, uint8_t desired_usage)
-{
-    if (!primary || DYNARRAY_IS_EMPTY(primary, subkey)) {
-        return NULL;
-    }
-    // search in reverse with the assumption that the last
-    // in the list would be the newest created subkey, for now
-    for (unsigned i = primary->subkeyc; i-- > 0;) {
-        pgp_key_t *subkey = primary->subkeys[i];
-        if (subkey->key_flags & desired_usage) {
-            return subkey;
-        }
-    }
-    return NULL;
-}
-
 #ifdef HAVE_SYS_RESOURCE_H
 
 /* When system resource consumption limit controls are available this

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -45,26 +45,8 @@ struct rnp_keyring_st {
 };
 
 struct rnp_key_st {
-    pgp_key_t *    key;
+    pgp_key_t *key;
 };
-
-static pgp_key_t *
-find_suitable_subkey(const pgp_key_t *primary, uint8_t desired_usage)
-{
-    // fixme copied fron rnp.c
-    if (!primary || DYNARRAY_IS_EMPTY(primary, subkey)) {
-        return NULL;
-    }
-    // search in reverse with the assumption that the last
-    // in the list would be the newest created subkey, for now
-    for (unsigned i = primary->subkeyc; i-- > 0;) {
-        pgp_key_t *subkey = primary->subkeys[i];
-        if (subkey->key_flags & desired_usage) {
-            return subkey;
-        }
-    }
-    return NULL;
-}
 
 static pgp_io_t g_ffi_io;
 
@@ -77,25 +59,26 @@ rnp_set_io(FILE *output_stream, FILE *error_stream, FILE *result_stream)
 }
 
 static const char *
-operation_description(uint8_t op) {
+operation_description(uint8_t op)
+{
     switch (op) {
-      case PGP_OP_ADD_SUBKEY:
+    case PGP_OP_ADD_SUBKEY:
         return "add subkey";
-      case PGP_OP_SIGN:
+    case PGP_OP_SIGN:
         return "sign";
-      case PGP_OP_DECRYPT:
+    case PGP_OP_DECRYPT:
         return "decrypt";
-      case PGP_OP_UNLOCK:
+    case PGP_OP_UNLOCK:
         return "unlock";
-      case PGP_OP_PROTECT:
+    case PGP_OP_PROTECT:
         return "protect";
-      case PGP_OP_UNPROTECT:
+    case PGP_OP_UNPROTECT:
         return "unprotect";
-      case PGP_OP_DECRYPT_SYM:
+    case PGP_OP_DECRYPT_SYM:
         return "decrypt (symmetric)";
-      case PGP_OP_ENCRYPT_SYM:
+    case PGP_OP_ENCRYPT_SYM:
         return "encrypt (symmetric)";
-      default:
+    default:
         return "unknown";
     }
 }
@@ -107,7 +90,7 @@ rnp_passphrase_cb_bounce(const pgp_passphrase_ctx_t *ctx,
                          void *                      userdata_void)
 {
     struct rnp_passphrase_cb_data *userdata = (struct rnp_passphrase_cb_data *) userdata_void;
-    rnp_key_t key = NULL;
+    rnp_key_t                      key = NULL;
 
     if (!userdata->cb_fn) {
         return false;
@@ -718,8 +701,7 @@ rnp_keyring_save_to_file(rnp_keyring_t ring, const char *path)
 }
 
 rnp_result_t
-rnp_keyring_save_to_mem(
-  rnp_keyring_t ring, int flags, uint8_t *buf[], size_t *buf_len)
+rnp_keyring_save_to_mem(rnp_keyring_t ring, int flags, uint8_t *buf[], size_t *buf_len)
 {
     bool         armor = (flags & RNP_EXPORT_FLAG_ARMORED);
     pgp_memory_t memory;
@@ -1678,7 +1660,7 @@ rnp_result_t
 rnp_generate_key_json(rnp_keyring_t     pubring,
                       rnp_keyring_t     secring,
                       rnp_get_key_cb    getkeycb,
-                      void * getkeycb_ctx,
+                      void *            getkeycb_ctx,
                       rnp_passphrase_cb getpasscb,
                       void *            getpasscb_ctx,
                       const char *      json,
@@ -2171,8 +2153,7 @@ rnp_key_protect(rnp_key_t key, const char *passphrase)
         return RNP_ERROR_NULL_POINTER;
 
     // TODO allow setting protection params
-    bool ok =
-      pgp_key_protect_passphrase(key->key, key->key->format, NULL, passphrase);
+    bool ok = pgp_key_protect_passphrase(key->key, key->key->format, NULL, passphrase);
 
     if (ok)
         return RNP_SUCCESS;

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -321,7 +321,18 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    pubkey = &userkey->key.pubkey;
+    /* Use primary key if good for encryption,
+     * otherwise look in subkey list */
+    if (pgp_key_can_encrypt(userkey)) {
+        pubkey = &userkey->key.pubkey;
+    } else {
+        pgp_key_t *subkey = find_suitable_subkey(userkey, PGP_KF_ENCRYPT);
+        if (!subkey) {
+            return RNP_ERROR_NO_SUITABLE_KEY;
+        }
+        pubkey = &subkey->key.pubkey;
+    }
+
     /* Fill pkey */
     pkey.version = PGP_PKSK_V3;
     pkey.alg = pubkey->alg;


### PR DESCRIPTION
Code was trying to encrypt always with primary key. Primary keys are mostly used for signing.

With this patch code will check if key used for encryption has PGP_KF_ENCRYPT flag, if not it will try to look in subkeys for encryption key. It will fail if proper key is not found