### PR TITLE
Fix PGP keyring subsig MPI loading, add tests.

### DIFF
--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -165,6 +165,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_repgp_decrypt),
       cmocka_unit_test(test_repgp_verify),
       cmocka_unit_test(test_repgp_list_packets),
+      cmocka_unit_test(test_generated_key_sigs),
       cmocka_unit_test(test_ffi_api),
       cmocka_unit_test(test_ffi_homedir),
       cmocka_unit_test(test_ffi_keygen_json_pair),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -103,6 +103,8 @@ void test_repgp_verify(void **state);
 
 void test_repgp_list_packets(void **state);
 
+void test_generated_key_sigs(void **state);
+
 void test_ffi_api(void **state);
 
 void test_ffi_homedir(void **state);


### PR DESCRIPTION
I noticed our `key->subsigs` always have NULL MPIs for v4 sigs and realized we weren't properly loading these.
During the `CT_SIGNATURE_HEADER` callback, the sig MPIs haven't been populated yet (need to wait for `CT_SIGNATURE_FOOTER`). `CT_SIGNATURE_HEADER` is more of a heads up before the subpackets start flooding in (so we use it to expand the array).

Anyways, I went ahead and wrote some lengthy tests for generated keyring sigs.

(netpgp cvs appears to still have this issue for v4 sigs, so I guess we inherited it)