### PR TITLE
Passphrase command line parameter

### DIFF
--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -161,6 +161,22 @@ rnp_passphrase_provider_file(const pgp_passphrase_ctx_t *ctx,
 }
 
 bool
+rnp_passphrase_provider_string(const pgp_passphrase_ctx_t *ctx,
+                               char *                      passphrase,
+                               size_t                      passphrase_size,
+                               void *                      userdata)
+{
+    char *passc = (char *) userdata;
+
+    if (!passc) {
+        return false;
+    }
+
+    strncpy(passphrase, passc, passphrase_size - 1);
+    return true;
+}
+
+bool
 pgp_request_passphrase(const pgp_passphrase_provider_t *provider,
                        const pgp_passphrase_ctx_t *     ctx,
                        char *                           passphrase,

--- a/src/lib/pass-provider.h
+++ b/src/lib/pass-provider.h
@@ -58,4 +58,8 @@ bool rnp_passphrase_provider_file(const pgp_passphrase_ctx_t *ctx,
                                   char *                      passphrase,
                                   size_t                      passphrase_size,
                                   void *                      userdata);
+bool rnp_passphrase_provider_string(const pgp_passphrase_ctx_t *ctx,
+                                    char *                      passphrase,
+                                    size_t                      passphrase_size,
+                                    void *                      userdata);
 #endif

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -318,7 +318,12 @@ rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key)
 void
 rnp_cfg_free(rnp_cfg_t *cfg)
 {
-    int i;
+    int         i;
+    const char *passwd = rnp_cfg_get(cfg, CFG_PASSWD);
+
+    if (passwd) {
+        pgp_forget((void *) passwd, strlen(passwd) + 1);
+    }
 
     for (i = 0; i < cfg->count; i++) {
         free(cfg->vals[i]);
@@ -419,7 +424,8 @@ conffile(const char *homedir, char *userid, size_t length)
  *  @return true if path constructed successfully, or false otherwise
  **/
 static bool
-rnp_path_compose(const char *dir, const char *subdir, const char *filename, char *res, size_t res_size)
+rnp_path_compose(
+  const char *dir, const char *subdir, const char *filename, char *res, size_t res_size)
 {
     int pos;
 
@@ -517,8 +523,10 @@ rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params)
             if ((subdir = rnp_cfg_get(cfg, CFG_SUBDIRGPG)) == NULL) {
                 subdir = SUBDIRECTORY_RNP;
             }
-            rnp_path_compose(homedir, defhomedir ? subdir : NULL, PUBRING_KBX, pubpath, sizeof(pubpath));
-            rnp_path_compose(homedir, defhomedir ? subdir : NULL, SECRING_G10, secpath, sizeof(secpath));
+            rnp_path_compose(
+              homedir, defhomedir ? subdir : NULL, PUBRING_KBX, pubpath, sizeof(pubpath));
+            rnp_path_compose(
+              homedir, defhomedir ? subdir : NULL, SECRING_G10, secpath, sizeof(secpath));
 
             bool pubpath_exists = stat(pubpath, &st) == 0;
             bool secpath_exists = stat(secpath, &st) == 0;

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -48,6 +48,7 @@
 #define CFG_VERBOSE "verbose" /* verbose logging */
 #define CFG_HOMEDIR "homedir" /* home directory - folder with keyrings and so on */
 #define CFG_PASSFD "pass-fd"  /* password file descriptor */
+#define CFG_PASSWD "password" /* password as command-line constant */
 #define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
 #define CFG_DURATION "duration"         /* signature validity duration */

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -7,6 +7,7 @@ import shutil
 import random
 import string
 from subprocess import Popen, PIPE
+import subprocess
 from timeit import default_timer as perf_timer
 
 RNP_ROOT = None
@@ -90,4 +91,10 @@ def run_proc(proc, params):
         print output
 
     return (retcode, output, errout)
+
+def run_proc_fast(proc, params):
+    with open(os.devnull, 'w') as devnull:
+        proc = Popen([proc] + params, stdout=devnull, stderr=devnull)
+    return proc.wait()
+    #return subprocess.call([proc] + params)
 

--- a/src/tests/cli_perf.py
+++ b/src/tests/cli_perf.py
@@ -57,7 +57,7 @@ def setup():
     ret, out, err = run_proc(GPG, ['--batch', '--passphrase', '', '--homedir', GPGDIR, '--import', path.join(RNPDIR, 'pubring.gpg'), path.join(RNPDIR, 'secring.gpg')])
 
     # Generating small file for tests
-    SMALLSIZE = 33120;
+    SMALLSIZE = 3312;
     st = 'lorem ipsum dol ' * (SMALLSIZE/16)
     with open(path.join(WORKDIR, SMALLFILE), 'w+') as small_file:
         small_file.write(st)


### PR DESCRIPTION
This PR adds --passphrase command line parameter handling, and introduces 'string' password provider. Also it updates performance test with some fixes and improvements.
It was added for easier handling of passphrase in performance and CLI tests, however most likely users will make use of it as well. Despite the fact of quite low security properties of such approach.
