### PR TITLE
Possibility to specify working directory for perf tests

### DIFF
--- a/build_common.inc.sh
+++ b/build_common.inc.sh
@@ -26,7 +26,7 @@ rnpbuild_reconf() {
 
 rnpbuild_configure() {
 	export CFLAGS=${CFLAGS:-"-g3 -O0"}
-	./configure
+	./configure ${CONFIG_FLAGS}
 }
 
 rnpbuild_main() {

--- a/build_common.inc.sh
+++ b/build_common.inc.sh
@@ -25,7 +25,7 @@ rnpbuild_reconf() {
 }
 
 rnpbuild_configure() {
-	export CFLAGS="-g3 -O0"
+	export CFLAGS=${CFLAGS:-"-g3 -O0"}
 	./configure
 }
 

--- a/src/tests/cli_perf.py
+++ b/src/tests/cli_perf.py
@@ -31,7 +31,9 @@ def setup():
     RNPK = rnp_file_path('src/rnpkeys/rnpkeys')
     GPG = find_utility('gpg')
     WORKDIR = os.getcwd()
-    if not '/tmp/' in WORKDIR:
+    if len(sys.argv) > 1:
+        WORKDIR = sys.argv[1]
+    elif not '/tmp/' in WORKDIR:
         WORKDIR = tempfile.mkdtemp(prefix = 'rnpptmp')
         RMWORKDIR = True
 
@@ -220,6 +222,17 @@ def cleanup():
     except:
         pass
     return
+
+# Usage ./cli_perf.py [working_directory]
+#
+# It's better to use RAMDISK to perform tests
+# in order to speed up disk reads/writes
+#
+# On linux:
+# mkdir -p /tmp/working
+# sudo mount -t tmpfs -o size=512m tmpfs /tmp/working
+# ./cli_perf.py /tmp/working
+# sudo umount /tmp/working
 
 if __name__ == '__main__':
     setup()

--- a/src/tests/cli_perf.py
+++ b/src/tests/cli_perf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import tempfile
@@ -44,7 +44,7 @@ def setup():
     os.mkdir(GPGDIR, 0700)
 
     # Generating key
-    pipe = pswd_pipe(PASSWORD) 
+    pipe = pswd_pipe(PASSWORD)
     params = ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', 'performance@rnp', '--generate-key']
     # Run key generation
     ret, out, err = run_proc(RNPK, params)
@@ -83,7 +83,7 @@ def rnp_symencrypt_file(src, dst, cipher, zlevel = 6, zalgo = 'zip', armour = Fa
         params += ['--armor']
     ret, out, err = run_proc(RNP, params)
     os.close(pipe)
-    if ret != 0: 
+    if ret != 0:
         raise_err('rnp symmetric encryption failed', err)
 
 def rnp_decrypt_file(src, dst):
@@ -103,7 +103,7 @@ def gpg_symencrypt_file(src, dst, cipher = 'AES', zlevel = 6, zalgo = 1, armour 
 
 def gpg_decrypt_file(src, dst, keypass):
     ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase', keypass, '--trust-model', 'always', '-o', dst, '-d', src])
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg decryption failed', err)
 
 def print_test_results(fsize, iterations, rnptime, gpgtime, operation):


### PR DESCRIPTION
In order to eliminate slow disk accesses and speed up performance testing, it would good to have possibility to use ramdisk for perf testing.

This patch adds possibility to optionally specify working directory.