### PR TITLE
(rnp) Adds option symmetric to --dearmor

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -94,7 +94,6 @@ int          rnp_sign_file(rnp_ctx_t *, const char *, const char *, const char *
 rnp_result_t rnp_verify_file(rnp_ctx_t *, const char *, const char *);
 rnp_result_t rnp_process_stream(rnp_ctx_t *, const char *, const char *);
 rnp_result_t rnp_encrypt_stream(rnp_ctx_t *, const char *, const char *);
-rnp_result_t rnp_dearmor_stream(rnp_ctx_t *, const char *, const char *);
 
 /* memory signing and encryption */
 int rnp_sign_memory(rnp_ctx_t *, const char *, const char *, size_t, char *, size_t, bool);
@@ -110,6 +109,20 @@ int rnp_format_json(void *, const char *, const int);
 
 /* save pgp key in ssh format */
 int rnp_write_sshkey(rnp_t *, char *, const char *, char *, size_t);
+
+/**
+ * @brief   Perorm data conversion to/from ASCII Armor
+ *
+ * @param   ctx         Initialized rnp context
+ * @param   in          Input file path
+ * @param   out         Output file path
+ * @param   is_armour   True if convert to armour, false from armor to binary
+ * @param   data_type   When converting to armour, type of the data to be converted
+ *
+ * @return  RNP_SUCCESS on success, error code on failure
+ */
+rnp_result_t rnp_armour_stream(
+  rnp_ctx_t *ctx, const char *in, const char *out, bool is_armour, unsigned data_type);
 
 END_DECLS__
 

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -78,12 +78,12 @@ typedef struct rnp_params_t {
     const char *errs; /* error stream : may be <stdout> */
     const char *ress; /* results stream : maye be <stdout>, <stderr> or file name/path */
 
-    const char *ks_pub_format; /* format of the public key store */
-    const char *ks_sec_format; /* format of the secret key store */
-    char *      pubpath;       /* public keystore path */
-    char *      secpath;       /* secret keystore path */
-    char *      defkey;        /* default/preferred key id */
-
+    const char *ks_pub_format;     /* format of the public key store */
+    const char *ks_sec_format;     /* format of the secret key store */
+    char *      pubpath;           /* public keystore path */
+    char *      secpath;           /* secret keystore path */
+    char *      defkey;            /* default/preferred key id */
+    bool        keystore_disabled; /* indicates wether keystore must be initialized */
     pgp_passphrase_provider_t passphrase_provider;
 } rnp_params_t;
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -641,16 +641,18 @@ rnp_init(rnp_t *rnp, const rnp_params_t *params)
     rnp->pswdtries = MAX_PASSPHRASE_ATTEMPTS;
 
     /* set keystore type and pathes */
-    rnp->pubring = rnp_key_store_new(params->ks_pub_format, params->pubpath);
-    if (rnp->pubring == NULL) {
-        fputs("rnp: can't create empty pubring keystore\n", io->errs);
-        return RNP_ERROR_BAD_PARAMETERS;
-    }
+    if (!params->keystore_disabled) {
+        rnp->pubring = rnp_key_store_new(params->ks_pub_format, params->pubpath);
+        if (rnp->pubring == NULL) {
+            fputs("rnp: can't create empty pubring keystore\n", io->errs);
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
 
-    rnp->secring = rnp_key_store_new(params->ks_sec_format, params->secpath);
-    if (rnp->secring == NULL) {
-        fputs("rnp: can't create empty secring keystore\n", io->errs);
-        return RNP_ERROR_BAD_PARAMETERS;
+        rnp->secring = rnp_key_store_new(params->ks_sec_format, params->secpath);
+        if (rnp->secring == NULL) {
+            fputs("rnp: can't create empty secring keystore\n", io->errs);
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
     }
 
     return RNP_SUCCESS;

--- a/src/librepgp/stream-armour.h
+++ b/src/librepgp/stream-armour.h
@@ -70,4 +70,12 @@ rnp_result_t rnp_dearmour_source(pgp_source_t *src, pgp_dest_t *dst);
  **/
 rnp_result_t rnp_armour_source(pgp_source_t *src, pgp_dest_t *dst, pgp_armoured_msg_t msgtype);
 
+/* @param  str   String containing armour data type
+ * @param  len   Length of the str
+ *
+ * @return Enum element corresponding to value in str or
+ *         PGP_ARMOURED_UNKNOWN if corresponding element not found
+ */
+pgp_armoured_msg_t armour_str_to_data_type(const char *str, size_t len);
+
 #endif

--- a/src/rnp/Makefile.am
+++ b/src/rnp/Makefile.am
@@ -1,13 +1,9 @@
-AM_CFLAGS		= $(WARNCFLAGS)
+AM_CFLAGS       = $(WARNCFLAGS)
+dist_man_MANS   = rnp.1
 
-bin_PROGRAMS		= rnp
-
-rnp_SOURCES		= \
+bin_PROGRAMS	= rnp
+rnp_CPPFLAGS	= -I$(top_srcdir)/include -I$(top_srcdir)/src/ $(JSONC_INCLUDES) $(BOTAN_INCLUDES)
+rnp_LDADD		= ../lib/librnp.la ../librekey/librekey.la ../librepgp/librepgp.la
+rnp_SOURCES     = \
     rnp.c \
     rnpcfg.c
-
-rnp_CPPFLAGS		= -I$(top_srcdir)/include $(JSONC_INCLUDES) $(BOTAN_INCLUDES)
-
-rnp_LDADD		= ../lib/librnp.la ../librekey/librekey.la ../librepgp/librepgp.la
-
-dist_man_MANS		= rnp.1

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -493,13 +493,15 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
     case CMD_VERIFY_CAT:
     case CMD_LIST_PACKETS:
     case CMD_SHOW_KEYS:
+        *cmd = val;
+        break;
     case CMD_DEARMOR:
-    case CMD_ENARMOR: {
+    case CMD_ENARMOR:
         *cmd = val;
         rnp_cfg_setint(
           cfg, CFG_ARMOUR_DATA_TYPE, armour_str_to_data_type(arg, arg ? strlen(arg) : 0));
+        rnp_cfg_setint(cfg, CFG_KEYSTORE_DISABLED, 1);
         break;
-    }
     case CMD_HELP:
         print_usage(usage);
         exit(EXIT_SUCCESS);
@@ -754,7 +756,8 @@ main(int argc, char **argv)
         goto finish;
     }
 
-    if (!rnp_key_store_load_keys(&rnp, rnp_cfg_getbool(&cfg, CFG_NEEDSSECKEY))) {
+    if (!rnp_params.keystore_disabled &&
+        !rnp_key_store_load_keys(&rnp, rnp_cfg_getbool(&cfg, CFG_NEEDSSECKEY))) {
         fputs("fatal: failed to load keys\n", stderr);
         ret = EXIT_ERROR;
         goto finish;

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -517,6 +517,11 @@ rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params)
 
     /* getting path to keyrings. If it is specified by user in 'homedir' param then it is
      * considered as the final path, no .rnp/.ssh is added */
+    params->keystore_disabled = rnp_cfg_getint_default(cfg, CFG_KEYSTORE_DISABLED, 0);
+    if (params->keystore_disabled) {
+        return true;
+    }
+
     if ((homedir = rnp_cfg_get(cfg, CFG_HOMEDIR)) == NULL) {
         homedir = getenv("HOME");
         defhomedir = true;

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -289,6 +289,13 @@ rnp_cfg_getint(rnp_cfg_t *cfg, const char *key)
     return val ? atoi(val) : 0;
 }
 
+int
+rnp_cfg_getint_default(rnp_cfg_t *cfg, const char *key, int def)
+{
+    int ret = rnp_cfg_getint(cfg, key);
+    return ret ? ret : def;
+}
+
 /** @brief return boolean value for the key if there is one
  *  @param cfg rnp config, must be allocated and initialized
  *  @param key must be null-terminated string

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -32,10 +32,13 @@
 /* cfg variables known by rnp */
 #define CFG_OVERWRITE "overwrite" /* overwrite output file if it is already exist or fail */
 #define CFG_ARMOUR "armour"       /* armour output data or not */
-#define CFG_DETACHED "detached"   /* produce the detached signature */
-#define CFG_OUTFILE "outfile"     /* name/path of the output file */
-#define CFG_RESULTS "results"     /* name/path for results, not used right now */
-#define CFG_MAXALLOC "maxalloc"   /* maximum memory allocation during the reading from stdin */
+#define CFG_ARMOUR_DATA_TYPE                                                       \
+    "armour_type"               /* armour data type, used with ``enarmour`` option \
+                                   */
+#define CFG_DETACHED "detached" /* produce the detached signature */
+#define CFG_OUTFILE "outfile"   /* name/path of the output file */
+#define CFG_RESULTS "results"   /* name/path for results, not used right now */
+#define CFG_MAXALLOC "maxalloc" /* maximum memory allocation during the reading from stdin */
 #define CFG_KEYSTOREFMT "keystorefmt" /* keyring format : GPG, SSH */
 #define CFG_SSHKEYFILE "sshkeyfile"   /* SSH key file */
 #define CFG_SUBDIRGPG "subdirgpg"     /* gpg/rnp files subdirectory: .rnp by default */
@@ -85,7 +88,18 @@ int rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
 bool rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
 void rnp_cfg_free(rnp_cfg_t *cfg);
 
-/* -----------------------------------------------------------------------------
+/**
+ *  @brief      Returns integer value for the key if there is one, or default value otherwise
+ *
+ *  @param cfg  rnp config, must be allocated and initialized
+ *  @param key  must be null-terminated string
+ *  @param def  value returned if key not found
+ *
+ *  @return     Integer value or def if there is no value or it is non-integer
+ **/
+int rnp_cfg_getint_default(rnp_cfg_t *cfg, const char *key, int def);
+
+/*
  * @brief   Copies or overrides configuration
  *
  * @param   dst resulting configuration object
@@ -94,7 +108,7 @@ void rnp_cfg_free(rnp_cfg_t *cfg);
  *
  * @pre     dst is correctly initialized and not NULL
  *
--------------------------------------------------------------------------------- */
+ */
 void rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
 
 bool rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -66,6 +66,8 @@
 #define CFG_EXPERT "expert"             /* expert key generation mode */
 #define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
 #define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
+#define CFG_KEYSTORE_DISABLED \
+    "disable_keystore" /* indicates wether keystore must be initialized */
 
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -178,7 +178,7 @@ def run_test(func, *args):
 
 def rnpkey_generate_rsa(bits = None, cleanup = True):
     # Setup command line params
-    if bits: 
+    if bits:
         params = ['--numbits', str(bits)]
     else:
         params = []
@@ -240,7 +240,7 @@ def rnpkey_generate_multiple():
     ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
     if ret != 0: raise_err('key list failed', err)
     match = re.match(RE_MULTIPLE_KEY_5, out)
-    if not match: 
+    if not match:
         raise_err('wrong key list output', out)
 
     # Cleanup and return
@@ -281,7 +281,7 @@ def rnpkey_import_from_gpg(cleanup = True):
 
 def rnpkey_export_to_gpg(cleanup = True):
     # Open pipe for password
-    pipe = pswd_pipe(PASSWORD) 
+    pipe = pswd_pipe(PASSWORD)
     # Run key generation
     ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', 'rsakey@rnp', '--generate-key'])
     os.close(pipe)
@@ -311,7 +311,7 @@ def rnp_encrypt_file(recipient, src, dst, zlevel = 6, zalgo = 'zip', armour = Fa
     if armour:
         params += ['--armor']
     ret, out, err = run_proc(RNP, params)
-    if ret != 0: 
+    if ret != 0:
         raise_err('rnp encryption failed', err)
 
 def rnp_symencrypt_file(src, dst, cipher, zlevel = 6, zalgo = 'zip', armour = False):
@@ -321,7 +321,7 @@ def rnp_symencrypt_file(src, dst, cipher, zlevel = 6, zalgo = 'zip', armour = Fa
         params += ['--armor']
     ret, out, err = run_proc(RNP, params)
     os.close(pipe)
-    if ret != 0: 
+    if ret != 0:
         raise_err('rnp symmetric encryption failed', err)
 
 def rnp_decrypt_file(src, dst):
@@ -355,7 +355,7 @@ def rnp_sign_cleartext(src, dst, signer):
     pipe = pswd_pipe(PASSWORD)
     ret, out, err = run_proc(RNP, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', signer, '--output', dst, '--clearsign', src])
     os.close(pipe)
-    if ret != 0: 
+    if ret != 0:
         raise_err('rnp cleartext signing failed', err)
 
 def rnp_verify_file(src, dst, signer = None):
@@ -384,11 +384,11 @@ def rnp_verify_detached(sig, signer = None):
 def rnp_verify_cleartext(src, signer = None):
     params = ['--homedir', RNPDIR, '--verify', src]
     ret, out, err = run_proc(RNP, params)
-    if ret != 0: 
+    if ret != 0:
         raise_err('rnp verification failed', err + out)
     # Check RNP output
     match = re.match(RE_RNP_GOOD_SIGNATURE, err)
-    if not match: 
+    if not match:
         raise_err('wrong rnp verification output', err)
     if signer and (not match.group(1).strip() == signer.strip()):
         raise_err('rnp verification failed, wrong signer')
@@ -425,48 +425,48 @@ def gpg_symencrypt_file(src, dst, cipher = 'AES', zlevel = 6, zalgo = 1, armour 
 
 def gpg_decrypt_file(src, dst, keypass):
     ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase', keypass, '--trust-model', 'always', '-o', dst, '-d', src])
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg decryption failed', err)
 
 def gpg_verify_file(src, dst, signer = None):
     ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '-o', dst, '--verify', src])
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg verification failed', err)
     # Check GPG output
     match = re.match(RE_GPG_GOOD_SIGNATURE, err)
-    if not match: 
+    if not match:
         raise_err('wrong gpg verification output', err)
     if signer and (not match.group(1) == signer):
         raise_err('gpg verification failed, wrong signer')
 
 def gpg_verify_detached(src, sig, signer = None):
     ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '--verify', sig, src])
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg detached verification failed', err)
     # Check GPG output
     match = re.match(RE_GPG_GOOD_SIGNATURE, err)
-    if not match: 
+    if not match:
         raise_err('wrong gpg detached verification output', err)
     if signer and (not match.group(1) == signer):
         raise_err('gpg detached verification failed, wrong signer')
 
 def gpg_verify_cleartext(src, signer = None):
     ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '--verify', src])
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg cleartext verification failed', err)
     # Check GPG output
     match = re.match(RE_GPG_GOOD_SIGNATURE, err)
-    if not match: 
+    if not match:
         raise_err('wrong gpg verification output', err)
     if signer and (not match.group(1) == signer):
         raise_err('gpg verification failed, wrong signer')
 
 def gpg_sign_file(src, dst, signer, zlevel = 6, zalgo = 1, armour = False):
     params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '-z', str(zlevel), '--compress-algo', str(zalgo), '--batch', '--yes', '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '-o', dst, '-s', src]
-    if armour: 
+    if armour:
         params.insert(2, '--armor')
     ret, out, err = run_proc(GPG, params)
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg signing failed', err)
 
 def gpg_sign_detached(src, signer, armour = False):
@@ -474,13 +474,13 @@ def gpg_sign_detached(src, signer, armour = False):
     if armour:
         params.insert(2, '--armor')
     ret, out, err = run_proc(GPG, params)
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg detached signing failed', err)
 
 def gpg_sign_cleartext(src, dst, signer):
     params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '-o', dst, '--clearsign', src]
     ret, out, err = run_proc(GPG, params)
-    if ret != 0: 
+    if ret != 0:
         raise_err('gpg cleartext signing failed', err)
 
 '''
@@ -539,7 +539,7 @@ def rnp_encryption():
     for cipher in ciphers:
         for size in sizes:
             run_test(rnp_encryption_gpg_to_rnp, cipher, size)
-    
+
     # Import secret keyring to GPG
     gpg_import_secring()
     # Encrypt cleartext with RNP and decrypt with GPG
@@ -738,7 +738,7 @@ def rnp_encryption_no_mdc():
     # Decrypt encrypted file with RNP
     rnp_decrypt_file(dst, dec)
     compare_files(src, dec, 'rnp decrypted data differs')
-    
+
 def rnp_encryption_s2k():
     src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
     random_text(src, 64000)
@@ -768,6 +768,21 @@ def rnp_encryption_s2k():
     for i in range(0, 80):
         rnp_encryption_s2k_gpg(ciphers[i % len(ciphers)], hashes[i % len(hashes)], s2kmodes[i % len(s2kmodes)])
 
+def rnp_armour():
+    for data_type in ['msg', 'pubkey', 'seckey', 'sign']:
+        src_beg,dst_beg = reg_workfiles('beg','.src','.dst')
+        src_mid, dst_mid = reg_workfiles('mid','.src', '.dst')
+        src_fin, dst_fin = reg_workfiles('fin','.src', '.dst')
+
+        random_text(src_beg, 10)
+
+        ret, out, err = run_proc(RNP, ['--enarmor', data_type, src_beg, '--output', dst_beg])
+        ret, out, err = run_proc(RNP, ['--dearmor', dst_beg, '--output', dst_mid])
+        ret, out, err = run_proc(RNP, ['--enarmor', data_type, dst_mid, '--output', dst_fin])
+        compare_files(dst_beg, dst_fin, "RNP armour/dearmour test failed")
+        compare_files(src_beg, dst_mid, "RNP armour/dearmour test failed")
+        clear_workfiles()
+
 def rnp_misc_operations():
     rnp_genkey_rsa(KEY_ENCRYPT)
     rnp_genkey_rsa(KEY_SIGN_GPG)
@@ -776,6 +791,7 @@ def rnp_misc_operations():
 
     run_test(rnp_encryption_no_mdc)
     run_test(rnp_encryption_s2k)
+    run_test(rnp_armour)
 
 def run_rnp_tests():
     # 1. Encryption / decryption against GPG


### PR DESCRIPTION
Option that makes it possible to convert from binary format to ASCII Armor. This functionality was mainly implemented in order to test performance of pure base64 implementation, but I found it may be useful for anybody who wants to convert from one format to another (for whatever reason).

Usage:
```
rnp --enarmor=msg input > middle
rnp --dearmor middle > output 

> diff input output
>
```