### PR TITLE
Don't require from user to provide ``--hash`` for signing with secp384r1 and secp521r1

### DIFF
--- a/src/lib/crypto/ecdsa.c
+++ b/src/lib/crypto/ecdsa.c
@@ -174,3 +174,13 @@ end:
     botan_pk_op_verify_destroy(verifier);
     return ret;
 }
+
+pgp_hash_alg_t
+ecdsa_get_min_hash(pgp_curve_t curve)
+{
+    return (curve == PGP_CURVE_NIST_P_256) ?
+             PGP_HASH_SHA256 :
+             (curve == PGP_CURVE_NIST_P_384) ?
+             PGP_HASH_SHA384 :
+             (curve == PGP_CURVE_NIST_P_521) ? PGP_HASH_SHA512 : PGP_HASH_UNKNOWN;
+}

--- a/src/lib/crypto/ecdsa.h
+++ b/src/lib/crypto/ecdsa.h
@@ -41,4 +41,14 @@ rnp_result_t pgp_ecdsa_verify_hash(const pgp_ecc_sig_t *   sign,
                                    size_t                  hash_len,
                                    const pgp_ecc_pubkey_t *pubkey);
 
+/*
+ * @brief   Returns hash wich should be used with the curve
+ *
+ * @param   curve Curve ID
+ *
+ * @returns  Either ID of the hash algorithm, or PGP_HASH_UNKNOWN
+ *           if not found
+ */
+pgp_hash_alg_t ecdsa_get_min_hash(pgp_curve_t curve);
+
 #endif // ECDSA_H_

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -1087,6 +1087,13 @@ pgp_pick_hash_alg(rnp_ctx_t *ctx, const pgp_seckey_t *seckey)
 {
     if (seckey->pubkey.alg == PGP_PKA_DSA) {
         return PGP_HASH_SHA1;
+    } else if (seckey->pubkey.alg == PGP_PKA_ECDSA) {
+        size_t               dlen_key = 0, dlen_ctx = 0;
+        const pgp_hash_alg_t h_key = ecdsa_get_min_hash(seckey->pubkey.key.ecc.curve);
+        if (!pgp_digest_length(h_key, &dlen_key) || !pgp_digest_length(ctx->halg, &dlen_ctx)) {
+            return PGP_HASH_UNKNOWN;
+        }
+        return (dlen_key > dlen_ctx) ? h_key : ctx->halg;
     } else {
         return ctx->halg;
     }


### PR DESCRIPTION
It seems from some time, we require user to provide a hash algo to be used when signing with ECDSA. For some cases it may be good idea, but for majority of cases this process should be automatic.

With this fix ``rnp`` will chose hash which can be used with given curve securely.