### PR TITLE
Enarmor/dearmor commands improvements

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -111,7 +111,7 @@ int rnp_format_json(void *, const char *, const int);
 int rnp_write_sshkey(rnp_t *, char *, const char *, char *, size_t);
 
 /**
- * @brief   Armor (convert to ASCII) binary PGP data
+ * @brief   Armor (convert to ASCII) or dearmor (convert back to binary) PGP data
  *
  * @param   ctx  Initialized rnp context. Field armortype may specify the type of armor
  *               header used, otherwise it will be detected automatically from the source.
@@ -120,19 +120,7 @@ int rnp_write_sshkey(rnp_t *, char *, const char *, char *, size_t);
  *
  * @return  RNP_SUCCESS on success, error code on failure
  */
-rnp_result_t rnp_armor_stream(rnp_ctx_t *ctx, const char *in, const char *out);
-
-/**
- * @brief   Dearmor (convert to binary) PGP data.
- *
- * @param   ctx         Initialized rnp context
- * @param   in          Input file path
- * @param   out         Output file path
- *
- * @return  RNP_SUCCESS on success, error code on failure
- */
-rnp_result_t rnp_dearmor_stream(rnp_ctx_t *ctx, const char *in, const char *out);
-
+rnp_result_t rnp_armor_stream(rnp_ctx_t *ctx, bool armor, const char *in, const char *out);
 
 END_DECLS__
 

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -111,18 +111,28 @@ int rnp_format_json(void *, const char *, const int);
 int rnp_write_sshkey(rnp_t *, char *, const char *, char *, size_t);
 
 /**
- * @brief   Perorm data conversion to/from ASCII Armor
+ * @brief   Armor (convert to ASCII) binary PGP data
+ *
+ * @param   ctx  Initialized rnp context. Field armortype may specify the type of armor
+ *               header used, otherwise it will be detected automatically from the source.
+ * @param   in   Input file path
+ * @param   out  Output file path
+ *
+ * @return  RNP_SUCCESS on success, error code on failure
+ */
+rnp_result_t rnp_armor_stream(rnp_ctx_t *ctx, const char *in, const char *out);
+
+/**
+ * @brief   Dearmor (convert to binary) PGP data.
  *
  * @param   ctx         Initialized rnp context
  * @param   in          Input file path
  * @param   out         Output file path
- * @param   is_armor    True if convert to armor, false from armor to binary
- * @param   data_type   When converting to armor, type of the data to be converted
  *
  * @return  RNP_SUCCESS on success, error code on failure
  */
-rnp_result_t rnp_armor_stream(
-  rnp_ctx_t *ctx, const char *in, const char *out, bool is_armor, unsigned data_type);
+rnp_result_t rnp_dearmor_stream(rnp_ctx_t *ctx, const char *in, const char *out);
+
 
 END_DECLS__
 

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -102,6 +102,7 @@ typedef struct rnp_ctx_t {
     bool           armor;      /* whether to use ASCII armor on output */
     list           recipients; /* recipients of the encrypted message */
     int            passwordc;  /* number of passwords to encrypt message for */
+    unsigned       armortype; /* type of the armored message, used in enarmor command */
 } rnp_ctx_t;
 
 #endif // __RNP_TYPES__

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1428,7 +1428,7 @@ rnp_armor_stream(rnp_ctx_t *ctx, bool armor, const char *in, const char *out)
     pgp_dest_t        dst;
     rnp_result_t      result;
     pgp_armored_msg_t msgtype;
-    
+
     if (!rnp_initialize_input(ctx, &src, in)) {
         RNP_LOG("failed to initialize reading");
         return RNP_ERROR_READ;
@@ -1445,7 +1445,7 @@ rnp_armor_stream(rnp_ctx_t *ctx, bool armor, const char *in, const char *out)
         if (msgtype == PGP_ARMORED_UNKNOWN) {
             msgtype = rnp_armor_guess_type(&src);
         }
-    
+
         result = rnp_armor_source(&src, &dst, msgtype);
     } else {
         result = rnp_dearmor_source(&src, &dst);

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1424,9 +1424,10 @@ finish:
 rnp_result_t
 rnp_armor_stream(rnp_ctx_t *ctx, const char *in, const char *out)
 {
-    pgp_source_t src;
-    pgp_dest_t   dst;
-    rnp_result_t result;
+    pgp_source_t      src;
+    pgp_dest_t        dst;
+    rnp_result_t      result;
+    pgp_armored_msg_t msgt;
 
     if (!rnp_initialize_input(ctx, &src, in)) {
         RNP_LOG("failed to initialize reading");

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1422,13 +1422,13 @@ finish:
 }
 
 rnp_result_t
-rnp_armor_stream(rnp_ctx_t *ctx, const char *in, const char *out)
+rnp_armor_stream(rnp_ctx_t *ctx, bool armor, const char *in, const char *out)
 {
     pgp_source_t      src;
     pgp_dest_t        dst;
     rnp_result_t      result;
-    pgp_armored_msg_t msgt;
-
+    pgp_armored_msg_t msgtype;
+    
     if (!rnp_initialize_input(ctx, &src, in)) {
         RNP_LOG("failed to initialize reading");
         return RNP_ERROR_READ;
@@ -1440,40 +1440,16 @@ rnp_armor_stream(rnp_ctx_t *ctx, const char *in, const char *out)
         return RNP_ERROR_WRITE;
     }
 
-    if ((msgt = (pgp_armored_msg_t) ctx->armortype) == PGP_ARMORED_UNKNOWN) {
-        msgt = rnp_armor_guess_type(&src);
+    if (armor) {
+        msgtype = (pgp_armored_msg_t) ctx->armortype;
+        if (msgtype == PGP_ARMORED_UNKNOWN) {
+            msgtype = rnp_armor_guess_type(&src);
+        }
+    
+        result = rnp_armor_source(&src, &dst, msgtype);
+    } else {
+        result = rnp_dearmor_source(&src, &dst);
     }
-
-    result = rnp_armor_source(&src, &dst, msgt);
-
-    if (result != RNP_SUCCESS) {
-        RNP_LOG("error code 0x%x", result);
-    }
-
-    src_close(&src);
-    dst_close(&dst, result != RNP_SUCCESS);
-    return result;
-}
-
-rnp_result_t
-rnp_dearmor_stream(rnp_ctx_t *ctx, const char *in, const char *out)
-{
-    pgp_source_t src;
-    pgp_dest_t   dst;
-    rnp_result_t result;
-
-    if (!rnp_initialize_input(ctx, &src, in)) {
-        RNP_LOG("failed to initialize reading");
-        return RNP_ERROR_READ;
-    }
-
-    if (!rnp_initialize_output(ctx, &dst, out)) {
-        RNP_LOG("failed to initialize writing");
-        src_close(&src);
-        return RNP_ERROR_WRITE;
-    }
-
-    result = rnp_dearmor_source(&src, &dst);
 
     if (result != RNP_SUCCESS) {
         RNP_LOG("error code 0x%x", result);

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -446,7 +446,7 @@ find_armor_header(const char *buf, size_t len, size_t *hdrlen)
     return NULL;
 }
 
-pgp_armored_msg_t
+static pgp_armored_msg_t
 armor_str_to_data_type(const char *str, size_t len)
 {
     if (!str) {

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -477,11 +477,12 @@ armor_str_to_data_type(const char *str, size_t len)
     return PGP_ARMORED_UNKNOWN;
 }
 
-pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src)
+pgp_armored_msg_t
+rnp_armor_guess_type(pgp_source_t *src)
 {
     uint8_t ptag;
     ssize_t read;
-    int ptype;
+    int     ptype;
 
     read = src_peek(src, &ptag, 1);
     if (read < 1) {
@@ -491,22 +492,22 @@ pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src)
     ptype = get_packet_type(ptag);
 
     switch (ptype) {
-        case PGP_PTAG_CT_PK_SESSION_KEY:
-        case PGP_PTAG_CT_SK_SESSION_KEY:
-        case PGP_PTAG_CT_1_PASS_SIG:
-        case PGP_PTAG_CT_SE_DATA:
-        case PGP_PTAG_CT_SE_IP_DATA:
-        case PGP_PTAG_CT_COMPRESSED:
-        case PGP_PTAG_CT_LITDATA:
-            return PGP_ARMORED_MESSAGE;
-        case PGP_PTAG_CT_PUBLIC_KEY:
-            return PGP_ARMORED_PUBLIC_KEY;
-        case PGP_PTAG_CT_SECRET_KEY:
-            return PGP_ARMORED_SECRET_KEY;
-        case PGP_PTAG_CT_SIGNATURE:
-            return PGP_ARMORED_SIGNATURE;
-        default:
-            return PGP_ARMORED_UNKNOWN;
+    case PGP_PTAG_CT_PK_SESSION_KEY:
+    case PGP_PTAG_CT_SK_SESSION_KEY:
+    case PGP_PTAG_CT_1_PASS_SIG:
+    case PGP_PTAG_CT_SE_DATA:
+    case PGP_PTAG_CT_SE_IP_DATA:
+    case PGP_PTAG_CT_COMPRESSED:
+    case PGP_PTAG_CT_LITDATA:
+        return PGP_ARMORED_MESSAGE;
+    case PGP_PTAG_CT_PUBLIC_KEY:
+        return PGP_ARMORED_PUBLIC_KEY;
+    case PGP_PTAG_CT_SECRET_KEY:
+        return PGP_ARMORED_SECRET_KEY;
+    case PGP_PTAG_CT_SIGNATURE:
+        return PGP_ARMORED_SIGNATURE;
+    default:
+        return PGP_ARMORED_UNKNOWN;
     }
 }
 

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "stream-armor.h"
+#include "stream-packet.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -452,21 +453,21 @@ armor_str_to_data_type(const char *str, size_t len)
         return PGP_ARMORED_UNKNOWN;
     }
 
-    if (!strncmp(str, "BEGIN PGP MESSAGE", len) || !strncmp("msg", str, len)) {
+    if (!strncmp(str, "BEGIN PGP MESSAGE", len)) {
         return PGP_ARMORED_MESSAGE;
     }
 
     if (!strncmp(str, "BEGIN PGP PUBLIC KEY BLOCK", len) ||
-        !strncmp(str, "BEGIN PGP PUBLIC KEY", len) || !strncmp("pubkey", str, len)) {
+        !strncmp(str, "BEGIN PGP PUBLIC KEY", len)) {
         return PGP_ARMORED_PUBLIC_KEY;
     }
 
     if (!strncmp(str, "BEGIN PGP SECRET KEY BLOCK", len) ||
-        !strncmp(str, "BEGIN PGP SECRET KEY", len) || !strncmp("seckey", str, len)) {
+        !strncmp(str, "BEGIN PGP SECRET KEY", len)) {
         return PGP_ARMORED_SECRET_KEY;
     }
 
-    if (!strncmp(str, "BEGIN PGP SIGNATURE", len) || !strncmp("sign", str, len)) {
+    if (!strncmp(str, "BEGIN PGP SIGNATURE", len)) {
         return PGP_ARMORED_SIGNATURE;
     }
 
@@ -474,6 +475,39 @@ armor_str_to_data_type(const char *str, size_t len)
         return PGP_ARMORED_CLEARTEXT;
     }
     return PGP_ARMORED_UNKNOWN;
+}
+
+pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src)
+{
+    uint8_t ptag;
+    ssize_t read;
+    int ptype;
+
+    read = src_peek(src, &ptag, 1);
+    if (read < 1) {
+        return PGP_ARMORED_UNKNOWN;
+    }
+
+    ptype = get_packet_type(ptag);
+
+    switch (ptype) {
+        case PGP_PTAG_CT_PK_SESSION_KEY:
+        case PGP_PTAG_CT_SK_SESSION_KEY:
+        case PGP_PTAG_CT_1_PASS_SIG:
+        case PGP_PTAG_CT_SE_DATA:
+        case PGP_PTAG_CT_SE_IP_DATA:
+        case PGP_PTAG_CT_COMPRESSED:
+        case PGP_PTAG_CT_LITDATA:
+            return PGP_ARMORED_MESSAGE;
+        case PGP_PTAG_CT_PUBLIC_KEY:
+            return PGP_ARMORED_PUBLIC_KEY;
+        case PGP_PTAG_CT_SECRET_KEY:
+            return PGP_ARMORED_SECRET_KEY;
+        case PGP_PTAG_CT_SIGNATURE:
+            return PGP_ARMORED_SIGNATURE;
+        default:
+            return PGP_ARMORED_UNKNOWN;
+    }
 }
 
 static bool

--- a/src/librepgp/stream-armor.h
+++ b/src/librepgp/stream-armor.h
@@ -70,6 +70,12 @@ rnp_result_t rnp_dearmor_source(pgp_source_t *src, pgp_dest_t *dst);
  **/
 rnp_result_t rnp_armor_source(pgp_source_t *src, pgp_dest_t *dst, pgp_armored_msg_t msgtype);
 
+/* @brief Guess the corresponding armored message type by first byte(s) of PGP message
+ * @param src initialized source with binary PGP message data
+ * @return corresponding enum element or PGP_ARMORED_UNKNOWN
+ **/
+pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src);
+
 /* @param  str   String containing armor data type
  * @param  len   Length of the str
  *

--- a/src/librepgp/stream-armor.h
+++ b/src/librepgp/stream-armor.h
@@ -76,12 +76,4 @@ rnp_result_t rnp_armor_source(pgp_source_t *src, pgp_dest_t *dst, pgp_armored_ms
  **/
 pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src);
 
-/* @param  str   String containing armor data type
- * @param  len   Length of the str
- *
- * @return Enum element corresponding to value in str or
- *         PGP_ARMORED_UNKNOWN if corresponding element not found
- */
-pgp_armored_msg_t armor_str_to_data_type(const char *str, size_t len);
-
 #endif

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -495,6 +495,7 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
         break;
     case CMD_DEARMOR:
         *cmd = val;
+        rnp_cfg_setint(cfg, CFG_KEYSTORE_DISABLED, 1);
         break;
     case CMD_ENARMOR: {
         pgp_armored_msg_t msgt = PGP_ARMORED_UNKNOWN;

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -438,11 +438,11 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         break;
     }
     case CMD_DEARMOR:
-        ret = rnp_dearmor_stream(&ctx, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
+        ret = rnp_armor_stream(&ctx, false, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
     case CMD_ENARMOR:
         ctx.armortype = rnp_cfg_getint_default(cfg, CFG_ARMOR_DATA_TYPE, PGP_ARMORED_UNKNOWN);
-        ret = rnp_armor_stream(&ctx, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
+        ret = rnp_armor_stream(&ctx, true, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
     case CMD_SHOW_KEYS:
         ret = (repgp_validate_pubkeys_signatures(&ctx) == RNP_SUCCESS);

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -292,8 +292,8 @@ rnp_cfg_getint(rnp_cfg_t *cfg, const char *key)
 int
 rnp_cfg_getint_default(rnp_cfg_t *cfg, const char *key, int def)
 {
-    int ret = rnp_cfg_getint(cfg, key);
-    return ret ? ret : def;
+    const char *val = rnp_cfg_get(cfg, key);
+    return val ? atoi(val) : def;
 }
 
 /** @brief return boolean value for the key if there is one

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -88,7 +88,7 @@ int rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
 bool rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
 void rnp_cfg_free(rnp_cfg_t *cfg);
 
-/**
+/*
  *  @brief      Returns integer value for the key if there is one, or default value otherwise
  *
  *  @param cfg  rnp config, must be allocated and initialized
@@ -108,7 +108,7 @@ int rnp_cfg_getint_default(rnp_cfg_t *cfg, const char *key, int def);
  *
  * @pre     dst is correctly initialized and not NULL
  *
- */
+ **/
 void rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
 
 bool rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params);

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -769,19 +769,18 @@ def rnp_encryption_s2k():
         rnp_encryption_s2k_gpg(ciphers[i % len(ciphers)], hashes[i % len(hashes)], s2kmodes[i % len(s2kmodes)])
 
 def rnp_armor():
-    for data_type in ['msg', 'pubkey', 'seckey', 'sign']:
-        src_beg,dst_beg = reg_workfiles('beg','.src','.dst')
-        src_mid, dst_mid = reg_workfiles('mid','.src', '.dst')
-        src_fin, dst_fin = reg_workfiles('fin','.src', '.dst')
+    src_beg, dst_beg, dst_mid, dst_fin = reg_workfiles('beg','.src','.dst', '.mid.dst', '.fin.dst')
 
-        random_text(src_beg, 10)
+    for data_type in ['msg', 'pubkey', 'seckey', 'sign']:
+        random_text(src_beg, 1000)
 
         ret, out, err = run_proc(RNP, ['--enarmor', data_type, src_beg, '--output', dst_beg])
         ret, out, err = run_proc(RNP, ['--dearmor', dst_beg, '--output', dst_mid])
         ret, out, err = run_proc(RNP, ['--enarmor', data_type, dst_mid, '--output', dst_fin])
+
         compare_files(dst_beg, dst_fin, "RNP armor/dearmor test failed")
         compare_files(src_beg, dst_mid, "RNP armor/dearmor test failed")
-        clear_workfiles()
+        remove_files(dst_beg, dst_mid, dst_fin)
 
 def rnp_misc_operations():
     rnp_genkey_rsa(KEY_ENCRYPT)


### PR DESCRIPTION
This PR improves some things within the enarmor/dearmor commands:
- adds automatic guessing of the message type
- refactored to better match the architecture:
  - separated to use two functions, armor/dearmor (currently it looks like a lot of code duplication, but with PR #519 it will look much better)
  - moved msgtype parameter to rnp_ctx_t
  - moved msgtype parameter parsing to the CLI level
