### PR TITLE
Change symmetric password encryption to not use provider in lower layers

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -122,6 +122,13 @@ int rnp_write_sshkey(rnp_t *, char *, const char *, char *, size_t);
  */
 rnp_result_t rnp_armor_stream(rnp_ctx_t *ctx, bool armor, const char *in, const char *out);
 
+rnp_result_t rnp_encrypt_set_pass_info(rnp_symmetric_pass_info_t *info,
+                                       const char *               password,
+                                       pgp_hash_alg_t             hash_alg,
+                                       size_t                     iterations,
+                                       pgp_symm_alg_t             s2k_cipher);
+rnp_result_t rnp_encrypt_add_password(rnp_ctx_t *ctx);
+
 END_DECLS__
 
 #endif /* !RNP_H_ */

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -87,6 +87,12 @@ typedef struct rnp_params_t {
     pgp_passphrase_provider_t passphrase_provider;
 } rnp_params_t;
 
+typedef struct rnp_symmetric_pass_info_t {
+    pgp_s2k_t      s2k;
+    pgp_symm_alg_t s2k_cipher;
+    uint8_t        key[PGP_MAX_KEY_SIZE];
+} rnp_symmetric_pass_info_t;
+
 /* rnp operation context : contains additional data about the currently ongoing operation */
 typedef struct rnp_ctx_t {
     rnp_t *        rnp;        /* rnp structure */
@@ -101,8 +107,8 @@ typedef struct rnp_ctx_t {
     bool           overwrite;  /* allow to overwrite output file if exists */
     bool           armor;      /* whether to use ASCII armor on output */
     list           recipients; /* recipients of the encrypted message */
-    int            passwordc;  /* number of passwords to encrypt message for */
-    unsigned       armortype; /* type of the armored message, used in enarmor command */
+    list           passwords;  /* list of rnp_symmetric_pass_info_t */
+    unsigned       armortype;  /* type of the armored message, used in enarmor command */
 } rnp_ctx_t;
 
 #endif // __RNP_TYPES__

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -432,7 +432,7 @@ init_file_dest(pgp_dest_t *dst, const char *path)
     fd = open(path, flags, 0600);
     if (fd < 0) {
         RNP_LOG("failed to create file '%s'", path);
-        return false;
+        return RNP_ERROR_WRITE;
     }
 
     if ((param = calloc(1, sizeof(*param))) == NULL) {

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -519,10 +519,8 @@ init_encrypted_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *wr
     bool                        singlepass = true;
     unsigned                    pkeycount = 0;
     uint8_t                     enckey[PGP_MAX_KEY_SIZE] = {0}; /* content encryption key */
-    uint8_t                     s2key[PGP_MAX_KEY_SIZE];        /* s2k calculated key */
     uint8_t                     enchdr[PGP_MAX_BLOCK_SIZE + 2]; /* encrypted header */
     uint8_t                     mdcver = 1;
-    char                        passphrase[MAX_PASSPHRASE_LENGTH] = {0};
     unsigned                    keylen;
     unsigned                    blsize;
     rnp_result_t                ret = RNP_SUCCESS;
@@ -626,8 +624,6 @@ init_encrypted_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *wr
 
 finish:
     pgp_forget(enckey, sizeof(enckey));
-    pgp_forget(s2key, sizeof(s2key));
-    pgp_forget(passphrase, sizeof(passphrase));
     if (ret != RNP_SUCCESS) {
         encrypted_dst_close(dst, true);
     }

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -400,7 +400,9 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         ret = rnp_process_stream(&ctx, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
     case CMD_SYM_ENCRYPT:
-        ctx.passwordc = 1;
+        ctx.ealg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
+        ctx.halg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
+        rnp_encrypt_add_password(&ctx);
     /* FALLTHROUGH */
     case CMD_ENCRYPT: {
         ctx.ealg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -402,7 +402,11 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
     case CMD_SYM_ENCRYPT:
         ctx.ealg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
         ctx.halg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
-        rnp_encrypt_add_password(&ctx);
+        ret = rnp_encrypt_add_password(&ctx);
+        if (ret) {
+            RNP_LOG("Failed to add password");
+            goto done;
+        }
     /* FALLTHROUGH */
     case CMD_ENCRYPT: {
         ctx.ealg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));


### PR DESCRIPTION
The main thing here is just moving password retrieval out of the `init_encrypted_dst` code path and instead deriving the key for passwords immediately.

Also adds support for setting the s2k cipher that will wrap the session key (when applicable). (We'll probably want to add a `--s2k-cipher` CLI arg at some point)

The reason for this change is that with FFI I'm aiming to use password parameters directly when possible. It just makes for a very awkward API in some places otherwise.

I will admit that in some ways this could be viewed as less secure since previously I believe the pass+derived key were isolated to one function, and now the key ends up in `ctx->passwords` until used. I think it's practically no difference though and is a decent compromise.