### PR TITLE
Make string passphrase provider a bit stricter.

### DIFF
--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -160,7 +160,7 @@ rnp_passphrase_provider_string(const pgp_passphrase_ctx_t *ctx,
 {
     char *passc = (char *) userdata;
 
-    if (!passc) {
+    if (!passc || strlen(passc) >= (passphrase_size - 1)) {
         return false;
     }
 


### PR DESCRIPTION
This is just to prevent the (unlikely) possibility of truncating a password with the strncpy below.