### PR TITLE
Fix wrong define name, which is actually big-endian.

### DIFF
--- a/src/lib/fingerprint.c
+++ b/src/lib/fingerprint.c
@@ -39,7 +39,7 @@ static int
 hash_uint32(pgp_hash_t *hash, uint32_t n)
 {
     uint8_t ibuf[4];
-    STORE32LE(ibuf, n);
+    STORE32BE(ibuf, n);
     pgp_hash_add(hash, ibuf, sizeof(ibuf));
     return sizeof(ibuf);
 }

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -528,7 +528,7 @@ pgp_memory_make_packet(pgp_memory_t *out, pgp_content_enum tag)
         out->buf[2] = (uint8_t)(out->length - 192);
     } else {
         out->buf[1] = 0xff;
-        STORE32LE(&out->buf[2], out->length);
+        STORE32BE(&out->buf[2], out->length);
     }
 
     out->length += extra + 1;

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -433,7 +433,7 @@ savepubkey(char *res, char *f, size_t size)
 static int
 formatstring(char *buffer, const uint8_t *s, size_t len)
 {
-    STORE32LE(buffer, len);
+    STORE32BE(buffer, len);
     (void) memcpy(&buffer[4], s, len);
     return 4 + (int) len;
 }

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -98,8 +98,8 @@ do {                                        \
         (((uint8_t*)(y))[0] & 0xFF) <<  0;  \
 } while(0)
 
-/* Store little-endian 32-bit value x in y */
-#define STORE32LE(x, y)                                 \
+/* Store big-endian 32-bit value x in y */
+#define STORE32BE(x, y)                                 \
 do {                                                    \
     ((uint8_t*)(x))[0] = (uint8_t)((y) >> 24) & 0xff;   \
     ((uint8_t*)(x))[1] = (uint8_t)((y) >> 16) & 0xff;   \

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -456,7 +456,7 @@ static int
 pu32(pgp_memory_t *mem, uint32_t f)
 {
     uint8_t p[4];
-    STORE32LE(p, f);
+    STORE32BE(p, f);
     return pgp_memory_add(mem, p, 4);
 }
 
@@ -593,21 +593,21 @@ rnp_key_store_kbx_write_pgp(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *m)
         p = m->buf + uid_start + (12 * i);
         pt = m->length - start;
 
-        STORE32LE(p, pt);
+        STORE32BE(p, pt);
         pt = strlen((const char *) key->uids[i]);
         if (!pgp_memory_add(m, key->uids[i], pt)) {
             return false;
         }
 
         p += 4;
-        STORE32LE(p, pt);
+        STORE32BE(p, pt);
     }
 
     // write keyblock and fix the offset/length
     key_start = m->length;
     pt = key_start - start;
     p = m->buf + start + 8;
-    STORE32LE(p, pt);
+    STORE32BE(p, pt);
 
     pgp_writer_set_memory(&output, m);
 
@@ -630,13 +630,13 @@ rnp_key_store_kbx_write_pgp(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *m)
     pt = m->length - key_start;
     p = m->buf + start + 12;
 
-    STORE32LE(p, pt);
+    STORE32BE(p, pt);
 
     // fix the length of blob
     pt = m->length - start + 20;
     p = m->buf + start;
 
-    STORE32LE(p, pt);
+    STORE32BE(p, pt);
 
     // checksum
     if (!pgp_hash_create(&hash, PGP_HASH_SHA1)) {

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -50,7 +50,7 @@ write_packet_len(uint8_t *buf, size_t len)
         return 2;
     } else {
         buf[0] = 0xff;
-        STORE32LE(&buf[1], len);
+        STORE32BE(&buf[1], len);
         return 5;
     }
 }

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -919,7 +919,7 @@ init_literal_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *writ
         dst_write(param->writedst, handler->ctx->filename, flen);
     }
     /* timestamp */
-    STORE32LE(buf, handler->ctx->filemtime);
+    STORE32BE(buf, handler->ctx->filemtime);
     dst_write(param->writedst, buf, 4);
 
 finish:

--- a/src/librepgp/validate.c
+++ b/src/librepgp/validate.c
@@ -229,7 +229,7 @@ check_binary_sig(const uint8_t *     data,
     switch (sig->info.version) {
     case PGP_V3:
         trailer[0] = sig->info.type;
-        STORE32LE(&trailer[1], sig->info.birthtime);
+        STORE32BE(&trailer[1], sig->info.birthtime);
         pgp_hash_add(&hash, trailer, 5);
         break;
 
@@ -241,7 +241,7 @@ check_binary_sig(const uint8_t *     data,
         trailer[0] = 0x04; /* version */
         trailer[1] = 0xFF;
         hashedlen = (unsigned) sig->info.v4_hashlen;
-        STORE32LE(&trailer[2], hashedlen);
+        STORE32BE(&trailer[2], hashedlen);
         pgp_hash_add(&hash, trailer, 6);
         break;
 


### PR DESCRIPTION
The define was accidentally named STORE32LE, while actually it is BE.