### PR TITLE
docs: Update dev guide with info on ret variable initial values.

### DIFF
--- a/Developers Guide.md
+++ b/Developers Guide.md
@@ -334,6 +334,13 @@ Do:
     return val;
   }
   ```
+* Do use a default failure (not success) value for `ret` variables. Example:
+  ```
+  rnp_result_t ret = RNP_ERROR_GENERIC;
+  // ...
+
+  return ret;
+  ```
 
 Do not:
 * Do not use the static storage class for local variables, *unless* they


### PR DESCRIPTION
This is a change I'd like to suggest to avoid issues like de4165f4ff46ec4c1a6bee3fd0e670b5a4fc5f80.

It's a minor thing, but basically this guideline is suggesting "default to failure" so that in the cases like the above, if you forget to set an appropriate error code, the function won't return success even when it actually failed.

IOW, do this:

```c
rnp_result_t ret = RNP_ERROR_GENERIC;
// later on, if all is well
ret = RNP_SUCCESS;
done:
return ret;
```

Instead of:
```c
rnp_result_t ret = RNP_SUCCESS;
if (something_failed) {
    // forgot to set ret here!
    goto done;
}
done:
return ret;
```