### PR TITLE
Misc changes for CLI tests and hash interface

### DIFF
--- a/ci/main.sh
+++ b/ci/main.sh
@@ -37,5 +37,5 @@ cd src/tests
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${GPG21_INSTALL}/lib"
 export LD_LIBRARY_PATH
-env RNPC_GPG_PATH="${GPG21_INSTALL}/bin/gpg" python2 cli_tests.py all --debug
+env RNPC_GPG_PATH="${GPG21_INSTALL}/bin/gpg" python2 cli_tests.py -w -v
 

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -67,14 +67,14 @@
  * lookup_value lookup value
  * ret          return value
  */
-#define ARRAY_LOOKUP_BY_ID(array, id_field, ret_field, lookup_value, ret)   \
-    do {                                                                    \
-        for (size_t i__ = 0; i__ < ARRAY_SIZE(array); i__++) {              \
-            if ((array)[i__].id_field == (lookup_value)) {                  \
-                (ret) = (array)[i__].ret_field;                             \
-                break;                                                      \
-            }                                                               \
-        }                                                                   \
+#define ARRAY_LOOKUP_BY_ID(array, id_field, ret_field, lookup_value, ret) \
+    do {                                                                  \
+        for (size_t i__ = 0; i__ < ARRAY_SIZE(array); i__++) {            \
+            if ((array)[i__].id_field == (lookup_value)) {                \
+                (ret) = (array)[i__].ret_field;                           \
+                break;                                                    \
+            }                                                             \
+        }                                                                 \
     } while (0)
 
 /* Formating helpers */
@@ -108,32 +108,28 @@ void *      pgp_new(size_t);
 #define BITS_TO_BYTES(b) (((b) + (CHAR_BIT - 1)) / CHAR_BIT)
 
 /* Load little-endian 32-bit from y to x in portable fashion */
-#define LOAD32LE(x, y)                      \
-do {                                        \
-    x = (((uint8_t*)(y))[3] & 0xFF) << 24 | \
-        (((uint8_t*)(y))[2] & 0xFF) << 16 | \
-        (((uint8_t*)(y))[1] & 0xFF) <<  8 | \
-        (((uint8_t*)(y))[0] & 0xFF) <<  0;  \
-} while(0)
+#define LOAD32LE(x, y)                                                                  \
+    do {                                                                                \
+        x = (((uint8_t *) (y))[3] & 0xFF) << 24 | (((uint8_t *) (y))[2] & 0xFF) << 16 | \
+            (((uint8_t *) (y))[1] & 0xFF) << 8 | (((uint8_t *) (y))[0] & 0xFF) << 0;    \
+    } while (0)
 
 /* Store big-endian 32-bit value x in y */
-#define STORE32BE(x, y)                                 \
-do {                                                    \
-    ((uint8_t*)(x))[0] = (uint8_t)((y) >> 24) & 0xff;   \
-    ((uint8_t*)(x))[1] = (uint8_t)((y) >> 16) & 0xff;   \
-    ((uint8_t*)(x))[2] = (uint8_t)((y) >>  8) & 0xff;   \
-    ((uint8_t*)(x))[3] = (uint8_t)((y) >>  0) & 0xff;   \
-} while(0)
+#define STORE32BE(x, y)                                     \
+    do {                                                    \
+        ((uint8_t *) (x))[0] = (uint8_t)((y) >> 24) & 0xff; \
+        ((uint8_t *) (x))[1] = (uint8_t)((y) >> 16) & 0xff; \
+        ((uint8_t *) (x))[2] = (uint8_t)((y) >> 8) & 0xff;  \
+        ((uint8_t *) (x))[3] = (uint8_t)((y) >> 0) & 0xff;  \
+    } while (0)
 
 /* Swap endianness of 32-bit value */
 #if defined(__GNUC__) || defined(__clang__)
-#define BSWAP32(x)    __builtin_bswap32(x)
+#define BSWAP32(x) __builtin_bswap32(x)
 #else
-#define BSWAP32(x)              \
-    ((x & 0x000000FF) << 24 |   \
-    (x & 0x0000FF00) << 8 |     \
-    (x & 0x00FF0000) >> 8 |     \
-    (x & 0xFF000000) >> 24)
+#define BSWAP32(x)                                                            \
+    ((x & 0x000000FF) << 24 | (x & 0x0000FF00) << 8 | (x & 0x00FF0000) >> 8 | \
+     (x & 0xFF000000) >> 24)
 #endif
 
 #endif

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -39,6 +39,9 @@
 
 #define RNP_LOG(...) RNP_LOG_FD(stderr, __VA_ARGS__)
 
+/* number of elements in an array */
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*(a)))
+
 #define CHECK(exp, val, err)                          \
     do {                                              \
         if ((exp) != (val)) {                         \
@@ -55,6 +58,24 @@
             repgp_parser_content_free(pkt);                    \
         }                                                      \
     } while (/* CONSTCOND */ 0)
+
+/*
+ * @params
+ * array:       array of the structures to lookup
+ * id_field     name of the field to compare against
+ * ret_field    filed to return
+ * lookup_value lookup value
+ * ret          return value
+ */
+#define ARRAY_LOOKUP_BY_ID(array, id_field, ret_field, lookup_value, ret)   \
+    do {                                                                    \
+        for (size_t i__ = 0; i__ < ARRAY_SIZE(array); i__++) {              \
+            if ((array)[i__].id_field == (lookup_value)) {                  \
+                (ret) = (array)[i__].ret_field;                             \
+                break;                                                      \
+            }                                                               \
+        }                                                                   \
+    } while (0)
 
 /* Formating helpers */
 #define PRItime "ll"
@@ -74,9 +95,6 @@
 #ifndef RNP_UNCONST
 #define RNP_UNCONST(a) ((void *) (unsigned long) (const void *) (a))
 #endif
-
-/* number of elements in an array */
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(*(a)))
 
 /* debugging helpers*/
 int  rnp_set_debug(const char *);

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -1,17 +1,13 @@
 import sys
 import distutils.spawn
-import tempfile
-from os import path
-import os
-import shutil
 import random
 import string
+import logging
+import os
+from os import path
 from subprocess import Popen, PIPE
-import subprocess
-from timeit import default_timer as perf_timer
 
 RNP_ROOT = None
-DEBUG = False
 
 class CLIError(Exception):
     def __init__(self, message, log = None):
@@ -19,15 +15,10 @@ class CLIError(Exception):
         self.log = log
 
     def __str__(self):
-        if DEBUG and self.log:
-            return self.message + '\n' + self.log
-        else:
-            return self.message
+        logging.info(self.message)
+        logging.debug(self.log.strip())
 
 def raise_err(msg, log = None):
-    #if log and DEBUG:
-    #    print log
-    #raise NameError(msg)
     raise CLIError(msg, log)
 
 def size_to_readable(num, suffix = 'B'):
@@ -43,7 +34,7 @@ def pswd_pipe(password):
         fw.write(password)
         fw.write('\n')
         fw.write(password)
-        
+
     return pr
 
 def random_text(path, size):
@@ -62,7 +53,7 @@ def file_text(path):
 def find_utility(name, exitifnone = True):
     path = distutils.spawn.find_executable(name)
     if not path and exitifnone:
-        print 'Cannot find utility {}. Exiting.'.format(name)
+        logging.error('Cannot find utility {}. Exiting.'.format(name))
         sys.exit(1)
 
     return path
@@ -81,14 +72,12 @@ def rnp_file_path(relpath, check = True):
     return fpath
 
 def run_proc(proc, params):
-    if DEBUG:
-        sys.stderr.write(proc + ' ' + ' '.join(params) + '\n')
+    logging.debug((proc + ' ' + ' '.join(params)).strip())
     process = Popen([proc] + params, stdout=PIPE, stderr=PIPE)
     output, errout = process.communicate()
     retcode = process.poll()
-    if DEBUG:
-        print errout
-        print output
+    logging.debug(errout.strip())
+    logging.debug(output.strip())
 
     return (retcode, output, errout)
 
@@ -96,5 +85,3 @@ def run_proc_fast(proc, params):
     with open(os.devnull, 'w') as devnull:
         proc = Popen([proc] + params, stdout=devnull, stderr=devnull)
     return proc.wait()
-    #return subprocess.call([proc] + params)
-

--- a/src/tests/cli_perf.py
+++ b/src/tests/cli_perf.py
@@ -2,13 +2,22 @@
 
 import sys
 import tempfile
-from os import path
-import os
 import shutil
-import subprocess
+import inspect
+import os
+import logging
+from os import path
 from timeit import default_timer as perf_timer
-from cli_common import find_utility, run_proc, run_proc_fast, pswd_pipe, rnp_file_path, random_text, file_text, size_to_readable, raise_err
-import cli_common
+from argparse import ArgumentParser
+from cli_common import (
+    find_utility,
+    run_proc,
+    run_proc_fast,
+    pswd_pipe,
+    rnp_file_path,
+    size_to_readable,
+    raise_err
+)
 
 RNP = ''
 RNPK = ''
@@ -25,20 +34,23 @@ SMALLFILE = 'smalltest.txt'
 LARGEFILE = 'largetest.txt'
 PASSWORD = 'password'
 
-def setup():
+def setup(workdir):
     # Searching for rnp and gnupg
     global RNP, GPG, RNPK, WORKDIR, RNPDIR, GPGDIR, SMALLSIZE, RMWORKDIR
+    logging.basicConfig(stream=sys.stdout, format="%(message)s")
+    logging.getLogger().setLevel(logging.INFO)
+
     RNP = rnp_file_path('src/rnp/rnp')
     RNPK = rnp_file_path('src/rnpkeys/rnpkeys')
     GPG = find_utility('gpg')
     WORKDIR = os.getcwd()
-    if len(sys.argv) > 1:
-        WORKDIR = sys.argv[1]
+    if workdir:
+        WORKDIR = workdir
     elif not '/tmp/' in WORKDIR:
         WORKDIR = tempfile.mkdtemp(prefix = 'rnpptmp')
         RMWORKDIR = True
 
-    print 'Setting up test in {} ...'.format(WORKDIR)
+    logging.debug('Setting up test in {} ...'.format(WORKDIR))
 
     # Creating working directory and populating it with test files
     RNPDIR = path.join(WORKDIR, '.rnp')
@@ -69,8 +81,6 @@ def setup():
     with open(path.join(WORKDIR, LARGEFILE), 'w') as fd:
         for i in range(0, LARGESIZE / 1024 - 1):
             fd.write(st)
-
-    return
 
 def run_iterated(iterations, func, src, dst, *args):
     runtime = 0
@@ -113,8 +123,7 @@ def gpg_decrypt_file(src, dst, keypass):
 
 def print_test_results(fsize, rnptime, gpgtime, operation):
     if not rnptime or not gpgtime:
-        print '{}:TEST FAILED'.format(operation)
-        return
+        logging.info('{}:TEST FAILED'.format(operation))
 
     if fsize == SMALLSIZE:
         rnpruns = 1.0 / rnptime
@@ -123,10 +132,10 @@ def print_test_results(fsize, rnptime, gpgtime, operation):
 
         if rnpruns >= gpgruns:
             percents = (rnpruns - gpgruns) / gpgruns * 100
-            print '{:<30}: RNP is {:>3.0f}% FASTER then GnuPG ({})'.format(operation, percents, runstr)
+            logging.info('{:<30}: RNP is {:>3.0f}% FASTER then GnuPG ({})'.format(operation, percents, runstr))
         else:
             percents = (gpgruns - rnpruns) / gpgruns * 100
-            print '{:<30}: RNP is {:>3.0f}% SLOWER then GnuPG ({})'.format(operation, percents, runstr)
+            logging.info('{:<30}: RNP is {:>3.0f}% SLOWER then GnuPG ({})'.format(operation, percents, runstr))
     else:
         rnpspeed = fsize / 1024.0 / 1024.0 / rnptime
         gpgspeed = fsize / 1024.0 / 1024.0 / gpgtime
@@ -134,12 +143,10 @@ def print_test_results(fsize, rnptime, gpgtime, operation):
 
         if rnpspeed >= gpgspeed:
             percents = (rnpspeed - gpgspeed) / gpgspeed * 100
-            print '{:<30}: RNP is {:>3.0f}% FASTER then GnuPG ({})'.format(operation, percents, spdstr)
+            logging.info('{:<30}: RNP is {:>3.0f}% FASTER then GnuPG ({})'.format(operation, percents, spdstr))
         else:
             percents = (gpgspeed - rnpspeed) / gpgspeed * 100
-            print '{:<30}: RNP is {:>3.0f}% SLOWER then GnuPG ({})'.format(operation, percents, spdstr)
-
-    return
+            logging.info('{:<30}: RNP is {:>3.0f}% SLOWER then GnuPG ({})'.format(operation, percents, spdstr))
 
 def get_file_params(filetype):
     if filetype == 'small':
@@ -152,79 +159,92 @@ def get_file_params(filetype):
     gpgout = path.join(WORKDIR, outfile + '.gpg')
     return (infile, rnpout, gpgout, iterations, fsize)
 
-def run_tests():
+
+class Benchmark(object):
     rnphome = ['--homedir', RNPDIR]
     gpghome = ['--homedir', GPGDIR]
 
-    # Running each operation iteratively for a small and large file(s), calculating the average
-    # 1. Encryption
-    print '#1. Small file symmetric encryption'
-    infile, rnpout, gpgout, iterations, fsize = get_file_params('small')
-    for armor in [False, True]:
-        tmrnp = run_iterated(iterations, rnp_symencrypt_file, infile, rnpout, 'AES128', 0, 'zip', armor)
-        tmgpg = run_iterated(iterations, gpg_symencrypt_file, infile, gpgout, 'AES128', 0, 1, armor)
-        testname = 'ENCRYPT-SMALL-{}'.format('ARMOR' if armor else 'BINARY')
-        print_test_results(fsize, tmrnp, tmgpg, testname)
+    def small_file_symmetric_encryption(self):
+        # Running each operation iteratively for a small and large file(s), calculating the average
+        # 1. Encryption
+        '''
+        Small file symmetric encryption
+        '''
+        infile, rnpout, gpgout, iterations, fsize = get_file_params('small')
+        for armor in [False, True]:
+            tmrnp = run_iterated(iterations, rnp_symencrypt_file, infile, rnpout, 'AES128', 0, 'zip', armor)
+            tmgpg = run_iterated(iterations, gpg_symencrypt_file, infile, gpgout, 'AES128', 0, 1, armor)
+            testname = 'ENCRYPT-SMALL-{}'.format('ARMOR' if armor else 'BINARY')
+            print_test_results(fsize, tmrnp, tmgpg, testname)
 
-    print '#2. Large file symmetric encryption'
-    infile, rnpout, gpgout, iterations, fsize = get_file_params('large')
-    for cipher in ['AES128', 'AES192', 'AES256', 'TWOFISH', 'BLOWFISH', 'CAST5', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256']:
-        tmrnp = run_iterated(iterations, rnp_symencrypt_file, infile, rnpout, cipher, 0, 'zip', False)
-        tmgpg = run_iterated(iterations, gpg_symencrypt_file, infile, gpgout, cipher, 0, 1, False)
-        testname = 'ENCRYPT-{}-BINARY'.format(cipher)
-        print_test_results(fsize, tmrnp, tmgpg, testname)
+    def large_file_symmetric_encryption(self):
+        '''
+        Large file symmetric encryption
+        '''
+        infile, rnpout, gpgout, iterations, fsize = get_file_params('large')
+        for cipher in ['AES128', 'AES192', 'AES256', 'TWOFISH', 'BLOWFISH', 'CAST5', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256']:
+            tmrnp = run_iterated(iterations, rnp_symencrypt_file, infile, rnpout, cipher, 0, 'zip', False)
+            tmgpg = run_iterated(iterations, gpg_symencrypt_file, infile, gpgout, cipher, 0, 1, False)
+            testname = 'ENCRYPT-{}-BINARY'.format(cipher)
+            print_test_results(fsize, tmrnp, tmgpg, testname)
 
-    print '#3. Large file armored encryption'
-    tmrnp = run_iterated(iterations, rnp_symencrypt_file, infile, rnpout, 'AES128', 0, 'zip', True)
-    tmgpg = run_iterated(iterations, gpg_symencrypt_file, infile, gpgout, 'AES128', 0, 1, True)
-    print_test_results(fsize, tmrnp, tmgpg, 'ENCRYPT-LARGE-ARMOR')
+    def large_file_armored_encryption(self):
+        '''
+        Large file armored encryption
+        '''
+        infile, rnpout, gpgout, iterations, fsize = get_file_params('large')
+        tmrnp = run_iterated(iterations, rnp_symencrypt_file, infile, rnpout, 'AES128', 0, 'zip', True)
+        tmgpg = run_iterated(iterations, gpg_symencrypt_file, infile, gpgout, 'AES128', 0, 1, True)
+        print_test_results(fsize, tmrnp, tmgpg, 'ENCRYPT-LARGE-ARMOR')
 
-    print '#4. Small file symmetric decryption'
-    infile, rnpout, gpgout, iterations, fsize = get_file_params('small')
-    inenc = infile + '.enc'
-    for armor in [False, True]:
-        gpg_symencrypt_file(infile, inenc, 'AES', 0, 1, armor)
+    def small_file_symmetric_decryption(self):
+        '''
+        Small file symmetric decryption
+        '''
+        infile, rnpout, gpgout, iterations, fsize = get_file_params('small')
+        inenc = infile + '.enc'
+        for armor in [False, True]:
+            gpg_symencrypt_file(infile, inenc, 'AES', 0, 1, armor)
+            tmrnp = run_iterated(iterations, rnp_decrypt_file, inenc, rnpout)
+            tmgpg = run_iterated(iterations, gpg_decrypt_file, inenc, gpgout, PASSWORD)
+            testname = 'DECRYPT-SMALL-{}'.format('ARMOR' if armor else 'BINARY')
+            print_test_results(fsize, tmrnp, tmgpg, testname)
+            os.remove(inenc)
+
+    def large_file_symmetric_decryption(self):
+        '''
+        Large file symmetric decryption
+        '''
+        infile, rnpout, gpgout, iterations, fsize = get_file_params('large')
+        inenc = infile + '.enc'
+        for cipher in ['AES128', 'AES192', 'AES256', 'TWOFISH', 'BLOWFISH', 'CAST5', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256']:
+            gpg_symencrypt_file(infile, inenc, cipher, 0, 1, False)
+            tmrnp = run_iterated(iterations, rnp_decrypt_file, inenc, rnpout)
+            tmgpg = run_iterated(iterations, gpg_decrypt_file, inenc, gpgout, PASSWORD)
+            testname = 'DECRYPT-{}-BINARY'.format(cipher)
+            print_test_results(fsize, tmrnp, tmgpg, testname)
+            os.remove(inenc)
+
+    def large_file_armored_decryption(self):
+        '''
+        Large file armored decryption
+        '''
+        infile, rnpout, gpgout, iterations, fsize = get_file_params('large')
+        inenc = infile + '.enc'
+        gpg_symencrypt_file(infile, inenc, 'AES128', 0, 1, True)
         tmrnp = run_iterated(iterations, rnp_decrypt_file, inenc, rnpout)
         tmgpg = run_iterated(iterations, gpg_decrypt_file, inenc, gpgout, PASSWORD)
-        testname = 'DECRYPT-SMALL-{}'.format('ARMOR' if armor else 'BINARY')
-        print_test_results(fsize, tmrnp, tmgpg, testname)
+        print_test_results(fsize, tmrnp, tmgpg, 'DECRYPT-LARGE-ARMOR')
         os.remove(inenc)
 
-    print '#5. Large file symmetric decryption'
-    infile, rnpout, gpgout, iterations, fsize = get_file_params('large')
-    inenc = infile + '.enc'
-    for cipher in ['AES128', 'AES192', 'AES256', 'TWOFISH', 'BLOWFISH', 'CAST5', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256']:
-        gpg_symencrypt_file(infile, inenc, cipher, 0, 1, False)
-        tmrnp = run_iterated(iterations, rnp_decrypt_file, inenc, rnpout)
-        tmgpg = run_iterated(iterations, gpg_decrypt_file, inenc, gpgout, PASSWORD)
-        testname = 'DECRYPT-{}-BINARY'.format(cipher)
-        print_test_results(fsize, tmrnp, tmgpg, testname)
-        os.remove(inenc)
-
-    print '#6. Large file armored decryption'
-    gpg_symencrypt_file(infile, inenc, 'AES128', 0, 1, True)
-    tmrnp = run_iterated(iterations, rnp_decrypt_file, inenc, rnpout)
-    tmgpg = run_iterated(iterations, gpg_decrypt_file, inenc, gpgout, PASSWORD)
-    print_test_results(fsize, tmrnp, tmgpg, 'DECRYPT-LARGE-ARMOR')
-    os.remove(inenc)
-
-    # 3. Signing
-    #print '\n#3. Signing\n'
-    # 4. Verification
-    #print '\n#4. Verification\n'
-    # 5. Cleartext signing
-    #print '\n#5. Cleartext signing and verification\n'
-    # 6. Detached signature
-    #print '\n#6. Detached signing and verification\n'
-
-    return
-
-def cleanup():
-    try:
-        shutil.rmtree(WORKDIR)
-    except:
-        pass
-    return
+        # 3. Signing
+        #print '\n#3. Signing\n'
+        # 4. Verification
+        #print '\n#4. Verification\n'
+        # 5. Cleartext signing
+        #print '\n#5. Cleartext signing and verification\n'
+        # 6. Detached signature
+        #print '\n#6. Detached signing and verification\n'
 
 # Usage ./cli_perf.py [working_directory]
 #
@@ -234,10 +254,41 @@ def cleanup():
 # On linux:
 # mkdir -p /tmp/working
 # sudo mount -t tmpfs -o size=512m tmpfs /tmp/working
-# ./cli_perf.py /tmp/working
+# ./cli_perf.py -w /tmp/working
 # sudo umount /tmp/working
 
+
 if __name__ == '__main__':
-    setup()
-    run_tests()
-    cleanup()
+
+    # parse options
+    parser = ArgumentParser(description="RNP benchmarking")
+    parser.add_argument("-b", "--bench", dest="benchmarks",
+                      help="Name of the comma-separated benchmarks to run", metavar="benchmarks")
+    parser.add_argument("-w", "--workdir", dest="workdir",
+                      help="Working directory to use", metavar="workdir")
+    parser.add_argument("-l", "--list", help="Print list of available benchmarks and exit", action="store_true")
+    args = parser.parse_args()
+
+    # get list of benchamrks to run
+    bench_methods = [ x[0] for x in inspect.getmembers(Benchmark,predicate=inspect.ismethod) if not x[0].startswith("_") ]
+
+    if args.list:
+        for name in bench_methods:
+            logging.info(("\t " + name))
+        sys.exit(0)
+
+    if args.benchmarks:
+        bench_methods = filter(lambda x: x in args.benchmarks.split(","), bench_methods)
+
+    # setup operations
+    setup(args.workdir)
+
+    for name in bench_methods:
+        method = getattr(Benchmark, name)
+        logging.info(("\n" + name + "(): " + inspect.getdoc(method)))
+        method(Benchmark())
+
+    try:
+        shutil.rmtree(WORKDIR)
+    except:
+        logging.info(("Cleanup failed"))

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -2,16 +2,24 @@
 
 import sys
 import tempfile
-import getopt
 import os
 from os import path
 import shutil
 import re
-import random
-import string
 import time
-from cli_common import find_utility, run_proc, pswd_pipe, rnp_file_path, random_text, file_text, raise_err
-import cli_common
+import unittest
+import itertools
+import logging
+
+from cli_common import (
+    find_utility,
+    run_proc,
+    pswd_pipe,
+    rnp_file_path,
+    random_text,
+    file_text,
+    raise_err
+)
 
 WORKDIR = ''
 RNP = ''
@@ -19,12 +27,12 @@ RNPK = ''
 GPG = ''
 RNPDIR = ''
 PASSWORD = 'password'
-RMWORKDIR = False
-# Set DEBUG to True to halt on the first error
-DEBUG = False
+RMWORKDIR = True
 TESTS_SUCCEEDED = []
 TESTS_FAILED = []
 TEST_WORKFILES = []
+
+
 # Key userids
 KEY_ENCRYPT = 'encryption@rnp'
 KEY_SIGN_RNP = 'signing@rnp'
@@ -81,38 +89,18 @@ r'using .* key .*' \
 r'signature .*' \
 r'uid\s+(.*)\s*$'
 
-def setup():
-    # Setting up directories.
-    global RMWORKDIR, WORKDIR, RNPDIR, RNP, RNPK, GPG, GPGDIR
-    WORKDIR = os.getcwd()
-    if not '/tmp/' in WORKDIR:
-        WORKDIR = tempfile.mkdtemp(prefix = 'rnpctmp')
-        RMWORKDIR = True
-
-    print 'Running in ' + WORKDIR
-
-    RNPDIR = path.join(WORKDIR, '.rnp')
-    RNP = rnp_file_path('src/rnp/rnp')
-    RNPK = rnp_file_path('src/rnpkeys/rnpkeys')
-    os.mkdir(RNPDIR, 0700)
-
-    GPGDIR = path.join(WORKDIR, '.gpg')
-    GPG = os.getenv('RNPC_GPG_PATH') or find_utility('gpg')
-
-    os.mkdir(GPGDIR, 0700)
-
-    return
-
 def check_packets(fname, regexp):
     ret, output, err = run_proc(GPG, ['--list-packets', fname])
     if ret != 0:
-        print err
+        logging.error(err)
         return None
     else:
         result = re.match(regexp, output)
-        if not result and DEBUG:
-            print 'Wrong packets: \n' + output
+        if not result:
+            logging.debug('Wrong packets:')
+            logging.debug(output)
         return result
+
 
 def clear_keyrings():
     shutil.rmtree(RNPDIR, ignore_errors=True)
@@ -125,9 +113,11 @@ def clear_keyrings():
             time.sleep(0.1)
     os.mkdir(GPGDIR, 0700)
 
+
 def compare_files(src, dst, message):
     if file_text(src) != file_text(dst):
         raise_err(message)
+
 
 def remove_files(*args):
     try:
@@ -136,229 +126,103 @@ def remove_files(*args):
     except:
         pass
 
+
 def reg_workfiles(mainname, *exts):
     global TEST_WORKFILES
     res = []
     for ext in exts:
         fpath = path.join(WORKDIR, mainname + ext)
         if fpath in TEST_WORKFILES:
-            print 'Warning! Path {} is already in TEST_WORKFILES'.format(fpath)
+            logging.warn('Warning! Path {} is already in TEST_WORKFILES'.format(fpath))
         else:
             TEST_WORKFILES += [fpath]
         res += [fpath]
-
     return res
+
 
 def clear_workfiles():
     global TEST_WORKFILES
     for fpath in TEST_WORKFILES:
         try:
             os.remove(fpath)
-        except:
+        except OSError:
             pass
     TEST_WORKFILES = []
 
-def run_test(func, *args):
-    global TESTS_SUCCEEDED, TESTS_FAILED
-    name = '{}({})'.format(func.__name__, ', '.join(map(str, args)))
-    if DEBUG:
-        print 'RUNNING : ' + name
-    try:
-        func(*args)
-        print 'SUCCESS : ' + name
-        TESTS_SUCCEEDED += [name]
-        clear_workfiles()
-    except Exception as e:
-        TESTS_FAILED += [name]
-        if DEBUG:
-            raise
-        else:
-            clear_workfiles()
-            print 'FAILURE : {}'.format(name)
 
-def rnpkey_generate_rsa(bits = None, cleanup = True):
-    # Setup command line params
-    if bits:
-        params = ['--numbits', str(bits)]
-    else:
-        params = []
-        bits = 2048
-
-    userid = str(bits) + '@rnptest'
-    # Open pipe for password
+def rnp_genkey_rsa(userid, bits=2048):
     pipe = pswd_pipe(PASSWORD)
-    params = params + ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', userid, '--generate-key']
-    # Run key generation
-    ret, out, err = run_proc(RNPK, params)
-    os.close(pipe)
-    if ret != 0: raise_err('key generation failed', err)
-    # Check packets using the gpg
-    match = check_packets(path.join(RNPDIR, 'pubring.gpg'), RE_RSA_KEY)
-    if not match : raise_err('generated key check failed')
-    keybits = int(match.group(1))
-    if keybits > bits or keybits <= bits - 8 : raise_err('wrong key bits')
-    keyid = match.group(2)
-    if not match.group(3) == userid: raise_err('wrong user id')
-    # List keys using the rnpkeys
-    ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
-    if ret != 0: raise_err('key list failed', err)
-    match = re.match(RE_RSA_KEY_LIST, out)
-    # Compare key ids
-    if not match: raise_err('wrong key list output', out)
-    if not match.group(3)[-16:] == match.group(2) or not match.group(2) == keyid.lower():
-        raise_err('wrong key ids')
-    if not match.group(1) == str(bits):
-        raise_err('wrong key bits in list')
-    # Import key to the gnupg
-    ret, out, err = run_proc(GPG, ['--batch', '--passphrase', PASSWORD, '--homedir', GPGDIR, '--import', path.join(RNPDIR, 'pubring.gpg'), path.join(RNPDIR, 'secring.gpg')])
-    if ret != 0: raise_err('gpg key import failed', err)
-    # Cleanup and return
-    if cleanup:
-        clear_keyrings()
-        return None
-    else:
-        return keyid
-
-def rnpkey_generate_multiple():
-    # Generate 5 keys with different user ids
-    for i in range(0, 5):
-        # generate the next key
-        pipe = pswd_pipe(PASSWORD)
-        userid = str(i) + '@rnp-multiple'
-        ret, out, err = run_proc(RNPK, ['--numbits', '2048', '--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', userid, '--generate-key'])
-        os.close(pipe)
-        if ret != 0: raise_err('key generation failed', err)
-        # list keys using the rnpkeys, checking whether it reports correct key number
-        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
-        if ret != 0: raise_err('key list failed', err)
-        match = re.match(RE_MULTIPLE_KEY_LIST, out)
-        if not match: raise_err('wrong key list output', out)
-        if not match.group(1) == str((i + 1) * 2):
-            raise_err('wrong key count', out)
-
-    # Checking the 5 keys output
-    ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
-    if ret != 0: raise_err('key list failed', err)
-    match = re.match(RE_MULTIPLE_KEY_5, out)
-    if not match:
-        raise_err('wrong key list output', out)
-
-    # Cleanup and return
-    clear_keyrings()
-    return
-
-def rnpkey_import_from_gpg(cleanup = True):
-    # Generate key in GnuPG
-    ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--passphrase', '', '--quick-generate-key', 'rsakey@gpg', 'rsa'])
-    if ret != 0: raise_err('gpg key generation failed', err)
-    # Getting fingerprint of the generated key
-    ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--list-keys'])
-    match = re.match(RE_GPG_SINGLE_RSA_KEY, out)
-    if not match: raise_err('wrong gpg key list output', out)
-    keyfp = match.group(1)
-    # Exporting generated public key
-    ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--armor', '--export', keyfp])
-    if ret != 0: raise_err('gpg : public key export failed', err)
-    pubpath = path.join(RNPDIR, keyfp + '-pub.asc')
-    with open(pubpath, 'w+') as f:
-        f.write(out)
-    # Exporting generated secret key
-    ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--armor', '--export-secret-key', keyfp])
-    if ret != 0: raise_err('gpg : secret key export failed', err)
-    secpath = path.join(RNPDIR, keyfp + '-sec.asc')
-    with open(secpath, 'w+') as f:
-        f.write(out)
-    # Importing public key to rnp
-    ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--import-key', pubpath])
-    if ret != 0: raise_err('rnp : public key import failed', err)
-    # Importing secret key to rnp
-    ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--import-key', secpath])
-    if ret != 0: raise_err('rnp : secret key import failed', err)
-    # We do not check keyrings after the import - imported by RNP keys are not saved yet
-
-    if cleanup:
-        clear_keyrings()
-
-def rnpkey_export_to_gpg(cleanup = True):
-    # Open pipe for password
-    pipe = pswd_pipe(PASSWORD)
-    # Run key generation
-    ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', 'rsakey@rnp', '--generate-key'])
-    os.close(pipe)
-    if ret != 0: raise_err('key generation failed', err)
-    # Export key
-    ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export-key', 'rsakey@rnp'])
-    if ret != 0: raise_err('key export failed', err)
-    pubpath = path.join(RNPDIR, 'rnpkey-pub.asc')
-    with open(pubpath, 'w+') as f:
-        f.write(out)
-    # Import key with GPG
-    ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--import', pubpath])
-    if ret != 0: raise_err('gpg : public key import failed', err)
-
-    if cleanup:
-        clear_keyrings()
-
-def rnp_genkey_rsa(userid, bits = 2048):
-    pipe = pswd_pipe(PASSWORD)
-    ret, out, err = run_proc(RNPK, ['--numbits', str(bits), '--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', userid, '--generate-key'])
+    ret, _, err = run_proc(RNPK, ['--numbits', str(bits), '--homedir',
+                                    RNPDIR, '--pass-fd', str(pipe), '--userid', userid, '--generate-key'])
     os.close(pipe)
     if ret != 0:
         raise_err('rsa key generation failed', err)
 
-def rnp_encrypt_file(recipient, src, dst, zlevel = 6, zalgo = 'zip', armor = False):
-    params = ['--homedir', RNPDIR, '--userid', recipient, '-z', str(zlevel), '--' + zalgo, '--encrypt', src, '--output', dst]
+def rnp_encrypt_file(recipient, src, dst, zlevel=6, zalgo='zip', armor=False):
+    params = ['--homedir', RNPDIR, '--userid', recipient, '-z',
+              str(zlevel), '--' + zalgo, '--encrypt', src, '--output', dst]
     if armor:
         params += ['--armor']
-    ret, out, err = run_proc(RNP, params)
+    ret, _, err = run_proc(RNP, params)
     if ret != 0:
         raise_err('rnp encryption failed', err)
 
-def rnp_symencrypt_file(src, dst, cipher, zlevel = 6, zalgo = 'zip', armor = False):
+
+def rnp_symencrypt_file(src, dst, cipher, zlevel=6, zalgo='zip', armor=False):
     pipe = pswd_pipe(PASSWORD)
-    params = ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--cipher', cipher, '-z', str(zlevel), '--' + zalgo, '-c', src, '--output', dst]
+    params = ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--cipher', cipher, '-z', str(
+        zlevel), '--' + zalgo, '-c', src, '--output', dst]
     if armor:
         params += ['--armor']
-    ret, out, err = run_proc(RNP, params)
+    ret, _, err = run_proc(RNP, params)
     os.close(pipe)
     if ret != 0:
         raise_err('rnp symmetric encryption failed', err)
 
+
 def rnp_decrypt_file(src, dst):
     pipe = pswd_pipe(PASSWORD)
-    ret, out, err = run_proc(RNP, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--decrypt', src, '--output', dst])
+    ret, out, err = run_proc(
+        RNP, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--decrypt', src, '--output', dst])
     os.close(pipe)
     if ret != 0:
         raise_err('rnp decryption failed', out + err)
 
-def rnp_sign_file(src, dst, signer, armor = False):
+
+def rnp_sign_file(src, dst, signer, armor=False):
     pipe = pswd_pipe(PASSWORD)
-    params = ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', signer, '--sign', src, '--output', dst]
+    params = ['--homedir', RNPDIR, '--pass-fd',
+              str(pipe), '--userid', signer, '--sign', src, '--output', dst]
     if armor:
         params += ['--armor']
-    ret, out, err = run_proc(RNP, params)
+    ret, _, err = run_proc(RNP, params)
     os.close(pipe)
     if ret != 0:
         raise_err('rnp signing failed', err)
 
-def rnp_sign_detached(src, signer, armor = False):
+
+def rnp_sign_detached(src, signer, armor=False):
     pipe = pswd_pipe(PASSWORD)
-    params = ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', signer, '--sign', '--detach', src]
+    params = ['--homedir', RNPDIR, '--pass-fd',
+              str(pipe), '--userid', signer, '--sign', '--detach', src]
     if armor:
         params += ['--armor']
-    ret, out, err = run_proc(RNP, params)
+    ret, _, err = run_proc(RNP, params)
     os.close(pipe)
     if ret != 0:
         raise_err('rnp detached signing failed', err)
 
+
 def rnp_sign_cleartext(src, dst, signer):
     pipe = pswd_pipe(PASSWORD)
-    ret, out, err = run_proc(RNP, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', signer, '--output', dst, '--clearsign', src])
+    ret, _, err = run_proc(RNP, ['--homedir', RNPDIR, '--pass-fd', str(
+        pipe), '--userid', signer, '--output', dst, '--clearsign', src])
     os.close(pipe)
     if ret != 0:
         raise_err('rnp cleartext signing failed', err)
 
-def rnp_verify_file(src, dst, signer = None):
+
+def rnp_verify_file(src, dst, signer=None):
     params = ['--homedir', RNPDIR, '--verify-cat', src, '--output', dst]
     ret, out, err = run_proc(RNP, params)
     if ret != 0:
@@ -370,7 +234,8 @@ def rnp_verify_file(src, dst, signer = None):
     if signer and (not match.group(1).strip() == signer.strip()):
         raise_err('rnp verification failed, wrong signer')
 
-def rnp_verify_detached(sig, signer = None):
+
+def rnp_verify_detached(sig, signer=None):
     ret, out, err = run_proc(RNP, ['--homedir', RNPDIR, '--verify', sig])
     if ret != 0:
         raise_err('rnp detached verification failed', err + out)
@@ -381,7 +246,8 @@ def rnp_verify_detached(sig, signer = None):
     if signer and (not match.group(1).strip() == signer.strip()):
         raise_err('rnp detached verification failed, wrong signer')
 
-def rnp_verify_cleartext(src, signer = None):
+
+def rnp_verify_cleartext(src, signer=None):
     params = ['--homedir', RNPDIR, '--verify', src]
     ret, out, err = run_proc(RNP, params)
     if ret != 0:
@@ -393,43 +259,55 @@ def rnp_verify_cleartext(src, signer = None):
     if signer and (not match.group(1).strip() == signer.strip()):
         raise_err('rnp verification failed, wrong signer')
 
-def gpg_import_pubring(kpath = None):
+
+def gpg_import_pubring(kpath=None):
     if not kpath:
         kpath = path.join(RNPDIR, 'pubring.gpg')
-    ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--import', kpath])
+    ret, _, err = run_proc(
+        GPG, ['--batch', '--homedir', GPGDIR, '--import', kpath])
     if ret != 0:
         raise_err('gpg key import failed', err)
 
-def gpg_import_secring(kpath = None):
+
+def gpg_import_secring(kpath=None):
     if not kpath:
         kpath = path.join(RNPDIR, 'secring.gpg')
-    ret, out, err = run_proc(GPG, ['--batch', '--passphrase', PASSWORD, '--homedir', GPGDIR, '--import', kpath])
+    ret, _, err = run_proc(
+        GPG, ['--batch', '--passphrase', PASSWORD, '--homedir', GPGDIR, '--import', kpath])
     if ret != 0:
         raise_err('gpg secret key import failed', err)
 
-def gpg_encrypt_file(src, dst, cipher = 'AES', zlevel = 6, zalgo = 1, armor = False):
-    params = ['--homedir', GPGDIR, '-e', '-z', str(zlevel), '--compress-algo', str(zalgo), '-r', KEY_ENCRYPT, '--batch', '--cipher-algo', cipher, '--trust-model', 'always', '--output', dst, src]
+
+def gpg_encrypt_file(src, dst, cipher='AES', zlevel=6, zalgo=1, armor=False):
+    params = ['--homedir', GPGDIR, '-e', '-z', str(zlevel), '--compress-algo', str(
+        zalgo), '-r', KEY_ENCRYPT, '--batch', '--cipher-algo', cipher, '--trust-model', 'always', '--output', dst, src]
     if armor:
         params.insert(2, '--armor')
     ret, out, err = run_proc(GPG, params)
     if ret != 0:
         raise_err('gpg encryption failed for cipher ' + cipher, err)
 
-def gpg_symencrypt_file(src, dst, cipher = 'AES', zlevel = 6, zalgo = 1, armor = False):
-    params = ['--homedir', GPGDIR, '-c', '-z', str(zlevel), '--s2k-count', '65536', '--compress-algo', str(zalgo), '--batch', '--passphrase', PASSWORD, '--cipher-algo', cipher, '--output', dst, src]
+
+def gpg_symencrypt_file(src, dst, cipher='AES', zlevel=6, zalgo=1, armor=False):
+    params = ['--homedir', GPGDIR, '-c', '-z', str(zlevel), '--s2k-count', '65536', '--compress-algo', str(
+        zalgo), '--batch', '--passphrase', PASSWORD, '--cipher-algo', cipher, '--output', dst, src]
     if armor:
         params.insert(2, '--armor')
     ret, out, err = run_proc(GPG, params)
     if ret != 0:
         raise_err('gpg symmetric encryption failed for cipher ' + cipher, err)
 
+
 def gpg_decrypt_file(src, dst, keypass):
-    ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase', keypass, '--trust-model', 'always', '-o', dst, '-d', src])
+    ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch',
+                                   '--yes', '--passphrase', keypass, '--trust-model', 'always', '-o', dst, '-d', src])
     if ret != 0:
         raise_err('gpg decryption failed', err)
 
-def gpg_verify_file(src, dst, signer = None):
-    ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '-o', dst, '--verify', src])
+
+def gpg_verify_file(src, dst, signer=None):
+    ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch',
+                                   '--yes', '--trust-model', 'always', '-o', dst, '--verify', src])
     if ret != 0:
         raise_err('gpg verification failed', err)
     # Check GPG output
@@ -439,8 +317,10 @@ def gpg_verify_file(src, dst, signer = None):
     if signer and (not match.group(1) == signer):
         raise_err('gpg verification failed, wrong signer')
 
-def gpg_verify_detached(src, sig, signer = None):
-    ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '--verify', sig, src])
+
+def gpg_verify_detached(src, sig, signer=None):
+    ret, _, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch',
+                                   '--yes', '--trust-model', 'always', '--verify', sig, src])
     if ret != 0:
         raise_err('gpg detached verification failed', err)
     # Check GPG output
@@ -450,8 +330,10 @@ def gpg_verify_detached(src, sig, signer = None):
     if signer and (not match.group(1) == signer):
         raise_err('gpg detached verification failed, wrong signer')
 
-def gpg_verify_cleartext(src, signer = None):
-    ret, out, err = run_proc(GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '--verify', src])
+
+def gpg_verify_cleartext(src, signer=None):
+    ret, _, err = run_proc(
+        GPG, ['--homedir', GPGDIR, '--batch', '--yes', '--trust-model', 'always', '--verify', src])
     if ret != 0:
         raise_err('gpg cleartext verification failed', err)
     # Check GPG output
@@ -461,27 +343,34 @@ def gpg_verify_cleartext(src, signer = None):
     if signer and (not match.group(1) == signer):
         raise_err('gpg verification failed, wrong signer')
 
-def gpg_sign_file(src, dst, signer, zlevel = 6, zalgo = 1, armor = False):
-    params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '-z', str(zlevel), '--compress-algo', str(zalgo), '--batch', '--yes', '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '-o', dst, '-s', src]
+
+def gpg_sign_file(src, dst, signer, zlevel=6, zalgo=1, armor=False):
+    params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '-z', str(zlevel), '--compress-algo', str(
+        zalgo), '--batch', '--yes', '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '-o', dst, '-s', src]
     if armor:
         params.insert(2, '--armor')
-    ret, out, err = run_proc(GPG, params)
+    ret, _, err = run_proc(GPG, params)
     if ret != 0:
         raise_err('gpg signing failed', err)
 
-def gpg_sign_detached(src, signer, armor = False):
-    params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '--detach-sign', src]
+
+def gpg_sign_detached(src, signer, armor=False):
+    params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes',
+              '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '--detach-sign', src]
     if armor:
         params.insert(2, '--armor')
-    ret, out, err = run_proc(GPG, params)
+    ret, _, err = run_proc(GPG, params)
     if ret != 0:
         raise_err('gpg detached signing failed', err)
 
+
 def gpg_sign_cleartext(src, dst, signer):
-    params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase', PASSWORD, '--trust-model', 'always', '-u', signer, '-o', dst, '--clearsign', src]
-    ret, out, err = run_proc(GPG, params)
+    params = ['--homedir', GPGDIR, '--pinentry-mode=loopback', '--batch', '--yes', '--passphrase',
+              PASSWORD, '--trust-model', 'always', '-u', signer, '-o', dst, '--clearsign', src]
+    ret, _, err = run_proc(GPG, params)
     if ret != 0:
         raise_err('gpg cleartext signing failed', err)
+
 
 '''
     Things to try here later on:
@@ -491,7 +380,11 @@ def gpg_sign_cleartext(src, dst, signer):
     - different compression levels/algorithms
 '''
 
-def rnp_encryption_gpg_to_rnp(cipher, filesize, zlevel = 6, zalgo = 1):
+
+def gpg_to_rnp_encryption(cipher, filesize, zlevel=6, zalgo=1):
+    '''
+    Encrypts with GPG and decrypts with RNP
+    '''
     src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
     # Generate random file of required size
     random_text(src, filesize)
@@ -502,8 +395,15 @@ def rnp_encryption_gpg_to_rnp(cipher, filesize, zlevel = 6, zalgo = 1):
         rnp_decrypt_file(dst, dec)
         compare_files(src, dec, 'rnp decrypted data differs')
         remove_files(dst, dec)
+    clear_workfiles()
 
-def rnp_encryption_rnp_to_gpg(filesize, zlevel = 6, zalgo = 'zip'):
+
+def file_encryption_rnp_to_gpg(filesize, zlevel=6, zalgo='zip'):
+    '''
+    Encrypts with RNP and decrypts with GPG and RNP
+    '''
+    # TODO: Would be better to do "with reg_workfiles() as src,dst,enc ... and
+    # do cleanup at the end"
     src, dst, enc = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
     # Generate random file of required size
     random_text(src, filesize)
@@ -518,6 +418,7 @@ def rnp_encryption_rnp_to_gpg(filesize, zlevel = 6, zalgo = 'zip'):
         rnp_decrypt_file(enc, dst)
         compare_files(src, dst, 'rnp decrypted data differs')
         remove_files(enc, dst)
+    clear_workfiles()
 
 '''
     Things to try later:
@@ -525,30 +426,8 @@ def rnp_encryption_rnp_to_gpg(filesize, zlevel = 6, zalgo = 'zip'):
     - decryption with generated by GPG and imported keys
 '''
 
-def rnp_encryption():
-    # Generate keypair in RNP
-    rnp_genkey_rsa(KEY_ENCRYPT)
-    # Add some other keys to the keyring
-    rnp_genkey_rsa('dummy1@rnp', 1024)
-    rnp_genkey_rsa('dummy2@rnp', 1024)
-    # Import keyring to the GPG
-    gpg_import_pubring()
-    # Encrypt cleartext file with GPG and decrypt it with RNP, using different ciphers and file sizes
-    ciphers = ['AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
-    sizes = [20, 1000, 5000, 20000, 150000, 1000000]
-    for cipher in ciphers:
-        for size in sizes:
-            run_test(rnp_encryption_gpg_to_rnp, cipher, size)
 
-    # Import secret keyring to GPG
-    gpg_import_secring()
-    # Encrypt cleartext with RNP and decrypt with GPG
-    for size in sizes:
-        run_test(rnp_encryption_rnp_to_gpg, size)
-    # Cleanup
-    clear_keyrings()
-
-def rnp_sym_encryption_gpg_to_rnp(cipher, filesize, zlevel = 6, zalgo = 1):
+def rnp_sym_encryption_gpg_to_rnp(cipher, filesize, zlevel=6, zalgo=1):
     src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
     # Generate random file of required size
     random_text(src, filesize)
@@ -559,8 +438,10 @@ def rnp_sym_encryption_gpg_to_rnp(cipher, filesize, zlevel = 6, zalgo = 1):
         rnp_decrypt_file(dst, dec)
         compare_files(src, dec, 'rnp decrypted data differs')
         remove_files(dst, dec)
+    clear_workfiles()
 
-def rnp_sym_encryption_rnp_to_gpg(cipher, filesize, zlevel = 6, zalgo = 'zip'):
+
+def rnp_sym_encryption_rnp_to_gpg(cipher, filesize, zlevel=6, zalgo='zip'):
     src, dst, enc = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
     # Generate random file of required size
     random_text(src, filesize)
@@ -575,29 +456,8 @@ def rnp_sym_encryption_rnp_to_gpg(cipher, filesize, zlevel = 6, zalgo = 'zip'):
         rnp_decrypt_file(enc, dst)
         compare_files(src, dst, 'rnp decrypted data differs')
         remove_files(enc, dst)
+    clear_workfiles()
 
-def rnp_sym_encryption():
-    # Currently rnp fails when keyring is empty
-    rnp_genkey_rsa(KEY_ENCRYPT)
-    # Encrypt cleartext with GPG and decrypt with RNP
-    ciphers = ['AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
-    sizes = [20, 1000, 5000, 20000, 150000, 1000000]
-
-    for cipher in ciphers:
-        for size in sizes:
-            run_test(rnp_sym_encryption_gpg_to_rnp, cipher, size, 0, 1)
-            run_test(rnp_sym_encryption_gpg_to_rnp, cipher, size, 6, 1)
-            run_test(rnp_sym_encryption_gpg_to_rnp, cipher, size, 6, 2)
-            run_test(rnp_sym_encryption_gpg_to_rnp, cipher, size, 6, 3)
-
-    ciphers = ['cast5', 'idea', 'blowfish', 'twofish', 'aes128', 'aes192', 'aes256', 'camellia128', 'camellia192', 'camellia256', 'tripledes']
-    # Encrypt cleartext with RNP and decrypt with GPG
-    for cipher in ciphers:
-        for size in sizes:
-            run_test(rnp_sym_encryption_rnp_to_gpg, cipher, size, 0)
-            run_test(rnp_sym_encryption_rnp_to_gpg, cipher, size, 6, 'zip')
-            run_test(rnp_sym_encryption_rnp_to_gpg, cipher, size, 6, 'zlib')
-            run_test(rnp_sym_encryption_rnp_to_gpg, cipher, size, 6, 'bzip2')
 
 def rnp_signing_rnp_to_gpg(filesize):
     src, sig, ver = reg_workfiles('cleartext', '.txt', '.sig', '.ver')
@@ -614,6 +474,8 @@ def rnp_signing_rnp_to_gpg(filesize):
         gpg_verify_file(sig, ver, KEY_SIGN_RNP)
         compare_files(src, ver, 'gpg verified data differs')
         remove_files(sig, ver)
+    clear_workfiles()
+
 
 def rnp_detached_signing_rnp_to_gpg(filesize):
     src, sig, asc = reg_workfiles('cleartext', '.txt', '.txt.sig', '.txt.asc')
@@ -628,6 +490,8 @@ def rnp_detached_signing_rnp_to_gpg(filesize):
         # Verify signed message with GPG
         gpg_verify_detached(src, sigpath, KEY_SIGN_RNP)
         remove_files(sigpath)
+    clear_workfiles()
+
 
 def rnp_cleartext_signing_rnp_to_gpg(filesize):
     src, asc = reg_workfiles('cleartext', '.txt', '.txt.asc')
@@ -639,8 +503,10 @@ def rnp_cleartext_signing_rnp_to_gpg(filesize):
     rnp_verify_cleartext(asc, KEY_SIGN_RNP)
     # Verify signed message with GPG
     gpg_verify_cleartext(asc, KEY_SIGN_RNP)
+    clear_workfiles()
 
-def rnp_signing_gpg_to_rnp(filesize, zlevel = 6, zalgo = 1):
+
+def rnp_signing_gpg_to_rnp(filesize, zlevel=6, zalgo=1):
     src, sig, ver = reg_workfiles('cleartext', '.txt', '.sig', '.ver')
     # Generate random file of required size
     random_text(src, filesize)
@@ -651,6 +517,8 @@ def rnp_signing_gpg_to_rnp(filesize, zlevel = 6, zalgo = 1):
         rnp_verify_file(sig, ver, KEY_SIGN_GPG)
         compare_files(src, ver, 'rnp verified data differs')
         remove_files(sig, ver)
+    clear_workfiles()
+
 
 def rnp_detached_signing_gpg_to_rnp(filesize):
     src, sig, asc = reg_workfiles('cleartext', '.txt', '.txt.sig', '.txt.asc')
@@ -662,6 +530,8 @@ def rnp_detached_signing_gpg_to_rnp(filesize):
         sigpath = asc if armor else sig
         # Verify file with RNP
         rnp_verify_detached(sigpath, KEY_SIGN_GPG)
+    clear_workfiles()
+
 
 def rnp_cleartext_signing_gpg_to_rnp(filesize):
     src, asc = reg_workfiles('cleartext', '.txt', '.txt.asc')
@@ -673,136 +543,30 @@ def rnp_cleartext_signing_gpg_to_rnp(filesize):
     rnp_verify_cleartext(asc, KEY_SIGN_GPG)
     # Verify signed message with GPG
     gpg_verify_cleartext(asc, KEY_SIGN_GPG)
+    clear_workfiles()
 
-'''
-    Things to try later:
-    - different public key algorithms
-    - different hash algorithms where applicable
-    - cleartext signing/verification
-    - detached signing/verification
-'''
-def rnp_signing():
-    # Generate keypair in RNP
-    rnp_genkey_rsa(KEY_SIGN_RNP)
-    # Add some other keys to the keyring
-    rnp_genkey_rsa('dummy1@rnp', 1024)
-    rnp_genkey_rsa('dummy2@rnp', 1024)
-    # Import keyring to the GPG
-    gpg_import_pubring()
-    sizes = [20, 1000, 5000, 20000, 150000, 1000000]
-    for size in sizes:
-        run_test(rnp_signing_rnp_to_gpg, size)
-        run_test(rnp_detached_signing_rnp_to_gpg, size)
-        run_test(rnp_cleartext_signing_rnp_to_gpg, size)
-    # Generate additional keypair in RNP
-    rnp_genkey_rsa(KEY_SIGN_GPG)
-    # Import secret keyring to the GPG
-    gpg_import_secring()
-    for size in sizes:
-        run_test(rnp_signing_gpg_to_rnp, size)
-        run_test(rnp_detached_signing_gpg_to_rnp, size)
-        run_test(rnp_cleartext_signing_gpg_to_rnp, size)
-    # Cleanup
-    clear_keyrings()
 
-def rnp_compression():
-    # Compression is currently implemented only for encrypted messages
-    rnp_genkey_rsa(KEY_ENCRYPT)
-    rnp_genkey_rsa(KEY_SIGN_GPG)
-    gpg_import_pubring()
-    gpg_import_secring()
+def setup(loglvl):
+    # Setting up directories.
+    global RMWORKDIR, WORKDIR, RNPDIR, RNP, RNPK, GPG, GPGDIR
+    logging.basicConfig(stream=sys.stderr, format="%(message)s")
+    logging.getLogger().setLevel(loglvl)
+    WORKDIR = os.getcwd()
+    if not '/tmp/' in WORKDIR:
+        WORKDIR = tempfile.mkdtemp(prefix='rnpctmp')
+        RMWORKDIR = True
 
-    levels = [0, 2, 4, 6, 9]
-    algosrnp = ['zip', 'zlib', 'bzip2']
-    algosgpg = [1, 2, 3]
-    sizes = [20, 1000, 5000, 20000, 150000, 1000000]
+    logging.info('Running in ' + WORKDIR)
 
-    for size in sizes:
-        for algo in [0, 1, 2]:
-            for level in levels:
-                run_test(rnp_encryption_gpg_to_rnp, 'AES', size, level, algosgpg[algo])
-                run_test(rnp_encryption_rnp_to_gpg, size, level, algosrnp[algo])
-                run_test(rnp_signing_gpg_to_rnp, size, level, algosgpg[algo])
-    # Cleanup
-    clear_keyrings()
+    RNPDIR = path.join(WORKDIR, '.rnp')
+    RNP = rnp_file_path('src/rnp/rnp')
+    RNPK = rnp_file_path('src/rnpkeys/rnpkeys')
+    os.mkdir(RNPDIR, 0700)
 
-def rnp_encryption_no_mdc():
-    src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
-    # Generate random file of required size
-    random_text(src, 64000)
-    # Encrypt cleartext file with GPG
-    params = ['--homedir', GPGDIR, '-c', '-z', '0', '--disable-mdc', '--s2k-count', '65536', '--batch', '--passphrase', PASSWORD, '--output', dst, src]
-    ret, out, err = run_proc(GPG, params)
-    if ret != 0:
-        raise_err('gpg symmetric encryption failed', err)
-    # Decrypt encrypted file with RNP
-    rnp_decrypt_file(dst, dec)
-    compare_files(src, dec, 'rnp decrypted data differs')
+    GPGDIR = path.join(WORKDIR, '.gpg')
+    GPG = os.getenv('RNPC_GPG_PATH') or find_utility('gpg')
+    os.mkdir(GPGDIR, 0700)
 
-def rnp_encryption_s2k():
-    src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
-    random_text(src, 64000)
-
-    ciphers = ['AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
-    hashes = ['SHA1', 'RIPEMD160', 'SHA256', 'SHA384', 'SHA512', 'SHA224']
-    s2kmodes = [0, 1, 3]
-
-    def rnp_encryption_s2k_gpg(cipher, hash, s2k = None, iterations = None):
-        params = ['--homedir', GPGDIR, '-c', '--s2k-cipher-algo', cipher, '--s2k-digest-algo', hash, '--batch', '--passphrase', PASSWORD, '--output', dst, src]
-
-        if s2k is not None:
-            params.insert(7, '--s2k-mode')
-            params.insert(8, str(s2k))
-
-            if iterations is not None:
-                params.insert(9, '--s2k-count')
-                params.insert(10, str(iterations))
-
-        ret, out, err = run_proc(GPG, params)
-        if ret != 0:
-            raise_err('gpg symmetric encryption failed', err)
-        rnp_decrypt_file(dst, dec)
-        compare_files(src, dec, 'rnp decrypted data differs')
-        remove_files(dst, dec)
-
-    for i in range(0, 80):
-        rnp_encryption_s2k_gpg(ciphers[i % len(ciphers)], hashes[i % len(hashes)], s2kmodes[i % len(s2kmodes)])
-
-def rnp_armor():
-    src_beg, dst_beg, dst_mid, dst_fin = reg_workfiles('beg','.src','.dst', '.mid.dst', '.fin.dst')
-
-    for data_type in ['msg', 'pubkey', 'seckey', 'sign']:
-        random_text(src_beg, 1000)
-
-        ret, out, err = run_proc(RNP, ['--enarmor', data_type, src_beg, '--output', dst_beg])
-        ret, out, err = run_proc(RNP, ['--dearmor', dst_beg, '--output', dst_mid])
-        ret, out, err = run_proc(RNP, ['--enarmor', data_type, dst_mid, '--output', dst_fin])
-
-        compare_files(dst_beg, dst_fin, "RNP armor/dearmor test failed")
-        compare_files(src_beg, dst_mid, "RNP armor/dearmor test failed")
-        remove_files(dst_beg, dst_mid, dst_fin)
-
-def rnp_misc_operations():
-    rnp_genkey_rsa(KEY_ENCRYPT)
-    rnp_genkey_rsa(KEY_SIGN_GPG)
-    gpg_import_pubring()
-    gpg_import_secring()
-
-    run_test(rnp_encryption_no_mdc)
-    run_test(rnp_encryption_s2k)
-    run_test(rnp_armor)
-
-def run_rnp_tests():
-    # 1. Encryption / decryption against GPG
-    rnp_encryption()
-    # 2. Signing / verification against GPG
-    rnp_signing()
-    # 3. Compression / decompression
-    rnp_compression()
-    # 4. Symmetric encryption
-    rnp_sym_encryption()
-    # 5. Misc operations, edge cases and uncommon configurations
-    rnp_misc_operations()
 
 '''
     Things to try here later on:
@@ -810,82 +574,387 @@ def run_rnp_tests():
     - different key protection levels/algorithms
     - armored import/export
 '''
-def run_rnpkeys_tests():
-    # 1. Generate default RSA key
-    run_test(rnpkey_generate_rsa)
-    # 2. Generate 4096-bit RSA key
-    run_test(rnpkey_generate_rsa, 4096)
-    # 3. Generate multiple RSA keys and check if they are all available
-    run_test(rnpkey_generate_multiple)
-    # 4. Generate key with GnuPG and import it to rnp
-    run_test(rnpkey_import_from_gpg)
-    # 5. Generate key with RNP and export it and then import to GnuPG
-    run_test(rnpkey_export_to_gpg)
+class Keystore(unittest.TestCase):
+    def tearDown(self):
+        clear_workfiles()
 
-def run_tests():
-    global DEBUG
-
-    # Parsing command line parameters
-    try:
-        opts, args = getopt.getopt(sys.argv, 'hd', ['help', 'debug'])
-    except getopt.GetoptError:
-        print "Wrong usage. Run cli_tests --help"
-        sys.exit(2)
-
-    tests = []
-
-    for arg in args[1:]:
-        if arg in ['-h', '--help']:
-            print 'Usage:\ncli_tests [-h | --help] [rnp] [rnpkeys] [all] [-d | --debug]'
-            sys.exit(0)
-        elif arg in ['-d', '--debug']:
-            DEBUG = True
-            cli_common.DEBUG = True
-        elif arg == 'all':
-            tests += ['rnp', 'rnpkeys']
-        elif arg in ['rnp', 'rnpkeys']:
-            tests += [arg]
+    @staticmethod
+    def _rnpkey_generate_rsa(bits= None):
+        # Setup command line params
+        if bits:
+            params = ['--numbits', str(bits)]
         else:
-            print 'Wrong parameter: {}. Run cli_tests -h for help.'.format(arg)
-            sys.exit(2)
+            params = []
+            bits = 2048
 
-    if len(tests) == 0:
-        print 'You must specify at least one test group to run. See cli_tests -h for help.'
-        sys.exit(2)
+        userid = str(bits) + '@rnptest'
+        # Open pipe for password
+        pipe = pswd_pipe(PASSWORD)
+        params = params + ['--homedir', RNPDIR, '--pass-fd',
+                        str(pipe), '--userid', userid, '--generate-key']
+        # Run key generation
+        ret, out, err = run_proc(RNPK, params)
+        os.close(pipe)
+        if ret != 0:
+            raise_err('key generation failed', err)
+        # Check packets using the gpg
+        match = check_packets(path.join(RNPDIR, 'pubring.gpg'), RE_RSA_KEY)
+        if not match:
+            raise_err('generated key check failed')
+        keybits = int(match.group(1))
+        if keybits > bits or keybits <= bits - 8:
+            raise_err('wrong key bits')
+        keyid = match.group(2)
+        if not match.group(3) == userid:
+            raise_err('wrong user id')
+        # List keys using the rnpkeys
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
+        if ret != 0:
+            raise_err('key list failed', err)
+        match = re.match(RE_RSA_KEY_LIST, out)
+        # Compare key ids
+        if not match:
+            raise_err('wrong key list output', out)
+        if not match.group(3)[-16:] == match.group(2) or not match.group(2) == keyid.lower():
+            raise_err('wrong key ids')
+        if not match.group(1) == str(bits):
+            raise_err('wrong key bits in list')
+        # Import key to the gnupg
+        ret, out, err = run_proc(GPG, ['--batch', '--passphrase', PASSWORD, '--homedir', GPGDIR,
+                                    '--import', path.join(RNPDIR, 'pubring.gpg'), path.join(RNPDIR, 'secring.gpg')])
+        if ret != 0:
+            raise_err('gpg key import failed', err)
+        # Cleanup and return
+        clear_keyrings()
 
-    # Parameters are ok so we can proceed
+    def test_generate_default_rsa_key(self):
+        Keystore._rnpkey_generate_rsa()
 
-    setup()
+    def test_generate_4096_rsa_key(self):
+        Keystore._rnpkey_generate_rsa(4096)
 
-    if 'rnpkeys' in tests:
-        run_rnpkeys_tests()
-    if 'rnp' in tests:
-        run_rnp_tests()
+    def test_generate_multiple_rsa_key__check_if_available(self):
+        '''
+        Generate multiple RSA keys and check if they are all available
+        '''
+        clear_keyrings()
+        # Generate 5 keys with different user ids
+        for i in range(0, 5):
+            # generate the next key
+            pipe = pswd_pipe(PASSWORD)
+            userid = str(i) + '@rnp-multiple'
+            ret, out, err = run_proc(RNPK, ['--numbits', '2048', '--homedir', RNPDIR,
+                                            '--pass-fd', str(pipe), '--userid', userid, '--generate-key'])
+            os.close(pipe)
+            if ret != 0:
+                raise_err('key generation failed', err)
+            # list keys using the rnpkeys, checking whether it reports correct key
+            # number
+            ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
+            if ret != 0:
+                raise_err('key list failed', err)
+            match = re.match(RE_MULTIPLE_KEY_LIST, out)
+            if not match:
+                raise_err('wrong key list output', out)
+            if not match.group(1) == str((i + 1) * 2):
+                raise_err('wrong key count', out)
 
-    succeeded = len(TESTS_SUCCEEDED)
-    failed = len(TESTS_FAILED)
-    print '\nRun {} tests, {} succeeded and {} failed.\n'.format(succeeded + failed, succeeded, failed)
-    if failed > 0:
-        print 'Failed tests:\n' + '\n'.join(TESTS_FAILED)
-        sys.exit(1)
+        # Checking the 5 keys output
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--list-keys'])
+        if ret != 0:
+            raise_err('key list failed', err)
+        match = re.match(RE_MULTIPLE_KEY_5, out)
+        if not match:
+            raise_err('wrong key list output', out)
 
-def cleanup():
-    if DEBUG:
-        return
+        # Cleanup and return
+        clear_keyrings()
 
-    try:
-        if RMWORKDIR:
-            shutil.rmtree(WORKDIR)
-        else:
-            shutil.rmtree(RNPDIR)
-            shutil.rmtree(GPGDIR)
-    except:
-        pass
+    def test_generate_key_with_gpg_import_to_rnp(self):
+        '''
+        Generate key with GnuPG and import it to rnp
+        '''
+        # Generate key in GnuPG
+        ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR,
+                                    '--passphrase', '', '--quick-generate-key', 'rsakey@gpg', 'rsa'])
+        if ret != 0:
+            raise_err('gpg key generation failed', err)
+        # Getting fingerprint of the generated key
+        ret, out, err = run_proc(
+            GPG, ['--batch', '--homedir', GPGDIR, '--list-keys'])
+        match = re.match(RE_GPG_SINGLE_RSA_KEY, out)
+        if not match:
+            raise_err('wrong gpg key list output', out)
+        keyfp = match.group(1)
+        # Exporting generated public key
+        ret, out, err = run_proc(
+            GPG, ['--batch', '--homedir', GPGDIR, '--armor', '--export', keyfp])
+        if ret != 0:
+            raise_err('gpg : public key export failed', err)
+        pubpath = path.join(RNPDIR, keyfp + '-pub.asc')
+        with open(pubpath, 'w+') as f:
+            f.write(out)
+        # Exporting generated secret key
+        ret, out, err = run_proc(
+            GPG, ['--batch', '--homedir', GPGDIR, '--armor', '--export-secret-key', keyfp])
+        if ret != 0:
+            raise_err('gpg : secret key export failed', err)
+        secpath = path.join(RNPDIR, keyfp + '-sec.asc')
+        with open(secpath, 'w+') as f:
+            f.write(out)
+        # Importing public key to rnp
+        ret, out, err = run_proc(
+            RNPK, ['--homedir', RNPDIR, '--import-key', pubpath])
+        if ret != 0:
+            raise_err('rnp : public key import failed', err)
+        # Importing secret key to rnp
+        ret, out, err = run_proc(
+            RNPK, ['--homedir', RNPDIR, '--import-key', secpath])
+        if ret != 0:
+            raise_err('rnp : secret key import failed', err)
+        # We do not check keyrings after the import - imported by RNP keys are not
+        # saved yet
 
-    return
+    def test_generate_with_rnp_import_to_gpg(self):
+        '''
+        Generate key with RNP and export it and then import to GnuPG
+        '''
+        # Open pipe for password
+        pipe = pswd_pipe(PASSWORD)
+        # Run key generation
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--pass-fd', str(pipe), '--userid', 'rsakey@rnp', '--generate-key'])
+        os.close(pipe)
+        if ret != 0: raise_err('key generation failed', err)
+        # Export key
+        ret, out, err = run_proc(RNPK, ['--homedir', RNPDIR, '--export-key', 'rsakey@rnp'])
+        if ret != 0: raise_err('key export failed', err)
+        pubpath = path.join(RNPDIR, 'rnpkey-pub.asc')
+        with open(pubpath, 'w+') as f:
+            f.write(out)
+        # Import key with GPG
+        ret, out, err = run_proc(GPG, ['--batch', '--homedir', GPGDIR, '--import', pubpath])
+        if ret != 0: raise_err('gpg : public key import failed', err)
+
+
+class Misc(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rnp_genkey_rsa(KEY_ENCRYPT)
+        rnp_genkey_rsa(KEY_SIGN_GPG)
+        gpg_import_pubring()
+        gpg_import_secring()
+
+    def tearDown(self):
+        clear_workfiles()
+
+    def test_encryption_no_mdc(self):
+        src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
+        # Generate random file of required size
+        random_text(src, 64000)
+        # Encrypt cleartext file with GPG
+        params = ['--homedir', GPGDIR, '-c', '-z', '0', '--disable-mdc', '--s2k-count', '65536', '--batch', '--passphrase', PASSWORD, '--output', dst, src]
+        ret, _, err = run_proc(GPG, params)
+        if ret != 0:
+            raise_err('gpg symmetric encryption failed', err)
+        # Decrypt encrypted file with RNP
+        rnp_decrypt_file(dst, dec)
+        compare_files(src, dec, 'rnp decrypted data differs')
+
+    def test_encryption_s2k(self):
+        src, dst, dec = reg_workfiles('cleartext', '.txt', '.gpg', '.rnp')
+        random_text(src, 64000)
+
+        ciphers = ['AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128',
+                'CAMELLIA192', 'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
+        hashes = ['SHA1', 'RIPEMD160', 'SHA256', 'SHA384', 'SHA512', 'SHA224']
+        s2kmodes = [0, 1, 3]
+
+        def rnp_encryption_s2k_gpg(cipher, hash_alg, s2k=None, iterations=None):
+            params = ['--homedir', GPGDIR, '-c', '--s2k-cipher-algo', cipher, '--s2k-digest-algo',
+                    hash_alg, '--batch', '--passphrase', PASSWORD, '--output', dst, src]
+
+            if s2k is not None:
+                params.insert(7, '--s2k-mode')
+                params.insert(8, str(s2k))
+
+                if iterations is not None:
+                    params.insert(9, '--s2k-count')
+                    params.insert(10, str(iterations))
+
+            ret, _, err = run_proc(GPG, params)
+            if ret != 0:
+                raise_err('gpg symmetric encryption failed', err)
+            rnp_decrypt_file(dst, dec)
+            compare_files(src, dec, 'rnp decrypted data differs')
+            remove_files(dst, dec)
+
+        for i in range(0, 80):
+            rnp_encryption_s2k_gpg(ciphers[i % len(ciphers)], hashes[
+                                i % len(hashes)], s2kmodes[i % len(s2kmodes)])
+
+    def test_armor(self):
+        src_beg, dst_beg, dst_mid, dst_fin = reg_workfiles('beg','.src','.dst', '.mid.dst', '.fin.dst')
+
+        for data_type in ['msg', 'pubkey', 'seckey', 'sign']:
+            random_text(src_beg, 1000)
+
+            run_proc(RNP, ['--enarmor', data_type, src_beg, '--output', dst_beg])
+            run_proc(RNP, ['--dearmor', dst_beg, '--output', dst_mid])
+            run_proc(RNP, ['--enarmor', data_type, dst_mid, '--output', dst_fin])
+
+            compare_files(dst_beg, dst_fin, "RNP armor/dearmor test failed")
+            compare_files(src_beg, dst_mid, "RNP armor/dearmor test failed")
+            remove_files(dst_beg, dst_mid, dst_fin)
+
+class Encryption(unittest.TestCase):
+    '''
+        Things to try later:
+        - different public key algorithms
+        - different hash algorithms where applicable
+        - cleartext signing/verification
+        - detached signing/verification
+
+        TODO:
+        Tests in this test case should be splitted into many algorithm-specific tests (potentially auto generated)
+        Reason being - if you have a problem with BLOWFISH size 1000000, you don't want to wait until everything else gets
+        tested before your failing BLOWFISH
+    '''
+    RNP_CIPHERS = ['AES', 'AES192', 'AES256', 'TWOFISH', 'CAMELLIA128', 'CAMELLIA192', 'CAMELLIA256', 'IDEA', '3DES', 'CAST5', 'BLOWFISH']
+    GPG_CIPHERS = ['cast5', 'idea', 'blowfish', 'twofish', 'aes128', 'aes192', 'aes256', 'camellia128', 'camellia192', 'camellia256', 'tripledes']
+    SIZES = [20, 1000, 5000, 20000, 150000, 1000000]
+
+    @classmethod
+    def setUpClass(cls):
+        # Generate keypair in RNP
+        rnp_genkey_rsa(KEY_ENCRYPT)
+        # Add some other keys to the keyring
+        rnp_genkey_rsa('dummy1@rnp', 1024)
+        rnp_genkey_rsa('dummy2@rnp', 1024)
+        gpg_import_pubring()
+        gpg_import_secring()
+
+    @classmethod
+    def tearDownClass(cls):
+        clear_keyrings()
+
+    def tearDown(self):
+        clear_workfiles()
+
+    def test_file_encryption__gpg_to_rnp(self):
+        for cipher,size in itertools.product(Encryption.RNP_CIPHERS, Encryption.SIZES):
+            gpg_to_rnp_encryption(cipher,size)
+        # Encrypt cleartext file with GPG and decrypt it with RNP, using different ciphers and file sizes
+
+    def test_file_encryption__rnp_to_gpg(self):
+        for size in Encryption.SIZES:
+            file_encryption_rnp_to_gpg(size)
+
+    def test_sym_encryption__gpg_to_rnp(self):
+        # Encrypt cleartext with GPG and decrypt with RNP
+        for cipher, size in itertools.product(Encryption.RNP_CIPHERS, Encryption.SIZES):
+            rnp_sym_encryption_gpg_to_rnp(cipher, size, 0, 1)
+            rnp_sym_encryption_gpg_to_rnp(cipher, size, 6, 1)
+            rnp_sym_encryption_gpg_to_rnp(cipher, size, 6, 2)
+            rnp_sym_encryption_gpg_to_rnp(cipher, size, 6, 3)
+
+    def test_sym_encryption__rnp_to_gpg(self):
+        # Encrypt cleartext with RNP and decrypt with GPG
+        for cipher, size in itertools.product(Encryption.GPG_CIPHERS, Encryption.SIZES):
+            rnp_sym_encryption_rnp_to_gpg(cipher, size, 0)
+            rnp_sym_encryption_rnp_to_gpg(cipher, size, 6, 'zip')
+            rnp_sym_encryption_rnp_to_gpg(cipher, size, 6, 'zlib')
+            rnp_sym_encryption_rnp_to_gpg(cipher, size, 6, 'bzip2')
+
+class Compression(unittest.TestCase):
+
+    def setUp(self):
+        # Compression is currently implemented only for encrypted messages
+        rnp_genkey_rsa(KEY_ENCRYPT)
+        rnp_genkey_rsa(KEY_SIGN_GPG)
+        gpg_import_pubring()
+        gpg_import_secring()
+
+    def tearDown(self):
+        clear_keyrings()
+
+    def test_rnp_compression(self):
+        levels = [0, 2, 4, 6, 9]
+        algosrnp = ['zip', 'zlib', 'bzip2']
+        algosgpg = [1, 2, 3]
+        sizes = [20, 1000, 5000, 20000, 150000, 1000000]
+
+        for size in sizes:
+            for algo in [0, 1, 2]:
+                for level in levels:
+                    gpg_to_rnp_encryption(
+                        'AES', size, level, algosgpg[algo])
+                    file_encryption_rnp_to_gpg(size, level, algosrnp[algo])
+                    rnp_signing_gpg_to_rnp(size, level, algosgpg[algo])
+
+class Sign(unittest.TestCase):
+    '''
+        Things to try later:
+        - different public key algorithms
+        - different hash algorithms where applicable
+        - cleartext signing/verification
+        - detached signing/verification
+    '''
+    # Message sizes to be tested
+    SIZES = [20, 1000, 5000, 20000, 150000, 1000000]
+
+    @classmethod
+    def setUpClass(cls):
+        # Generate keypair in RNP
+        rnp_genkey_rsa(KEY_SIGN_RNP)
+        rnp_genkey_rsa(KEY_SIGN_GPG)
+        gpg_import_pubring()
+        gpg_import_secring()
+
+    @classmethod
+    def tearDownClass(cls):
+        clear_keyrings()
+
+    # TODO: This script should generate one test case per message size.
+    #       Not sure how to do it yet
+    def test_rnp_to_gpg_default_key(self):
+        for size in Sign.SIZES:
+            rnp_signing_rnp_to_gpg(size)
+            rnp_detached_signing_rnp_to_gpg(size)
+            rnp_cleartext_signing_rnp_to_gpg(size)
+
+    def test_gpg_to_rnp_default_key(self):
+        for size in Sign.SIZES:
+            rnp_signing_gpg_to_rnp(size)
+            rnp_detached_signing_gpg_to_rnp(size)
+            rnp_cleartext_signing_gpg_to_rnp(size)
 
 if __name__ == '__main__':
-    try:
-        run_tests()
-    finally:
-        cleanup()
+    main = unittest.main
+    main.USAGE +=   ''.join([
+                    "\nRNP test client specific flags:\n",
+                    "  -w,\t\t Don't remove working directory\n",
+                    "  -d,\t\t Enable debug messages\n"])
+
+    CLEANUP = ("-w" in sys.argv)
+    if CLEANUP:
+        # -w must be removed as unittest doesn't expect it
+        sys.argv.remove('-w')
+
+    LVL = logging.INFO
+    if "-d" in sys.argv:
+        sys.argv.remove('-d')
+        LVL = logging.DEBUG
+
+    setup(LVL)
+    main()
+
+    if CLEANUP:
+        try:
+            if RMWORKDIR:
+                shutil.rmtree(WORKDIR)
+            else:
+                shutil.rmtree(RNPDIR)
+                shutil.rmtree(GPGDIR)
+        except:
+            pass


### PR DESCRIPTION
3 misc changes in 3  separated commits :

* Removes code duplication for hash interface

* Use 'unitests' python module for CLI tests
   
    Use unittest python module to do CLI tests
    This way we will be able to choose test to
    run
  
    This is done in order to be able to run single
    test during development process. Example:
    ```./src/tests/cli_tests.py -f  -v Keystore.test_generate_with_rnp_import_to_gpg```

    This patch removes '--debug' cmd line option.
    Instead '-v' and '-f' options should be used
    
    For more details on how to run the tests issue
    ./src/tests/cli_tests.py -h

* Refactors cli_performance tests in order to
  be able to run single test during development process
   
  For more info how to do it, run:
  ```./src/tests/cli_perf.py -h```

  Example: ```./src/tests/cli_perf.py large_file_armored_decryption```
