### PR TITLE
Streamed signature verification

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -501,7 +501,8 @@ typedef enum pgp_op_t {
     PGP_OP_PROTECT = 5,     /* adding protection to a key */
     PGP_OP_UNPROTECT = 6,   /* removing protection from a (locked) key */
     PGP_OP_DECRYPT_SYM = 7, /* symmetric decryption */
-    PGP_OP_ENCRYPT_SYM = 8  /* symmetric encryption */
+    PGP_OP_ENCRYPT_SYM = 8, /* symmetric encryption */
+    PGP_OP_VERIFY = 9       /* signature verification */
 } pgp_op_t;
 
 /** Hashing Algorithm Numbers.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -418,6 +418,40 @@ typedef enum {
     PGP_SIG_3RD_PARTY = 0x50 /* Third-Party Confirmation signature */
 } pgp_sig_type_t;
 
+/** Signature Subpacket Type
+ * Signature subpackets contains additional information about the signature
+ *
+ * \see RFC4880 5.2.3.1-5.2.3.26
+ */
+
+typedef enum {
+    PGP_SIG_SUBPKT_CREATION_TIME = 2,       /* signature creation time */
+    PGP_SIG_SUBPKT_EXPIRATION_TIME = 3,     /* signature expiration time */
+    PGP_SIG_SUBPKT_EXPORT_CERT = 4,         /* exportable certification */
+    PGP_SIG_SUBPKT_TRUST = 5,               /* trust signature */
+    PGP_SIG_SUBPKT_REGEXP = 6,              /* regular expression */
+    PGP_SIG_SUBPKT_REVOCABLE = 7,           /* revocable */
+    PGP_SIG_SUBPKT_KEY_EXPIRY = 9,          /* key expiration time */
+    PGP_SIG_SUBPKT_RESERVED = 10,           /* reserved */
+    PGP_SIG_SUBPKT_PREFERRED_SKA = 11,      /* preferred symmetric algs */
+    PGP_SIG_SUBPKT_REVOCATION_KEY = 12,     /* revocation key */
+    PGP_SIG_SUBPKT_ISSUER_KEY_ID = 16,      /* issuer key ID */
+    PGP_SIG_SUBPKT_NOTATION_DATA = 20,      /* notation data */
+    PGP_SIG_SUBPKT_PREFERRED_HASH = 21,     /* preferred hash algs */
+    PGP_SIG_SUBPKT_PREF_COMPRESS = 22,      /* preferred compression algorithms */
+    PGP_SIG_SUBPKT_KEYSERV_PREFS = 23,      /* key server preferences */
+    PGP_SIG_SUBPKT_PREF_KEYSERV = 24,       /* preferred key Server */
+    PGP_SIG_SUBPKT_PRIMARY_USER_ID = 25,    /* primary user ID */
+    PGP_SIG_SUBPKT_POLICY_URI = 26,         /* policy URI */
+    PGP_SIG_SUBPKT_KEY_FLAGS = 27,          /* key flags */
+    PGP_SIG_SUBPKT_SIGNERS_USER_ID = 28,    /* signer's user ID */
+    PGP_SIG_SUBPKT_REVOCATION_REASON = 29,  /* reason for revocation */
+    PGP_SIG_SUBPKT_FEATURES = 30,           /* features */
+    PGP_SIG_SUBPKT_SIGNATURE_TARGET = 31,   /* signature target */
+    PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE = 32, /* embedded signature */
+    PGP_SIG_SUBPKT_ISSUER_FPR = 33          /* issuer fingerprint */
+} pgp_sig_subpacket_type_t;
+
 /** Key Flags
  *
  * \see RFC4880 5.2.3.21

--- a/include/rnp/rnp_sdk.h
+++ b/include/rnp/rnp_sdk.h
@@ -77,4 +77,6 @@ char *rnp_strlwr(char *s);
  */
 char *rnp_strip_eol(char *s);
 
+char *userid_to_id(const uint8_t *userid, char *id);
+
 #endif

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -95,21 +95,22 @@ typedef struct rnp_symmetric_pass_info_t {
 
 /* rnp operation context : contains additional data about the currently ongoing operation */
 typedef struct rnp_ctx_t {
-    rnp_t *        rnp;        /* rnp structure */
-    char *         filename;   /* name of the input file to store in literal data packet */
-    int64_t        filemtime;  /* file modification time to store in literal data packet */
-    int64_t        sigcreate;  /* signature creation time */
-    uint64_t       sigexpire;  /* signature expiration time */
-    pgp_hash_alg_t halg;       /* hash algorithm */
-    pgp_symm_alg_t ealg;       /* encryption algorithm */
-    int            zalg;       /* compression algorithm used */
-    int            zlevel;     /* compression level */
-    bool           overwrite;  /* allow to overwrite output file if exists */
-    bool           armor;      /* whether to use ASCII armor on output */
-    list           recipients; /* recipients of the encrypted message */
-    list           passwords;  /* list of rnp_symmetric_pass_info_t */
-    unsigned       armortype;  /* type of the armored message, used in enarmor command */
-    bool           discard;    /* discard the output */
+    rnp_t *        rnp;           /* rnp structure */
+    char *         filename;      /* name of the input file to store in literal data packet */
+    int64_t        filemtime;     /* file modification time to store in literal data packet */
+    int64_t        sigcreate;     /* signature creation time */
+    uint64_t       sigexpire;     /* signature expiration time */
+    pgp_hash_alg_t halg;          /* hash algorithm */
+    pgp_symm_alg_t ealg;          /* encryption algorithm */
+    int            zalg;          /* compression algorithm used */
+    int            zlevel;        /* compression level */
+    bool           overwrite;     /* allow to overwrite output file if exists */
+    bool           armor;         /* whether to use ASCII armor on output */
+    list           recipients;    /* recipients of the encrypted message */
+    list           passwords;     /* list of rnp_symmetric_pass_info_t */
+    unsigned       armortype;     /* type of the armored message, used in enarmor command */
+    bool           discard;       /* discard the output */
+    void *         on_signatures; /* handler for signed messages */
 } rnp_ctx_t;
 
 #endif // __RNP_TYPES__

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -109,6 +109,7 @@ typedef struct rnp_ctx_t {
     list           recipients; /* recipients of the encrypted message */
     list           passwords;  /* list of rnp_symmetric_pass_info_t */
     unsigned       armortype;  /* type of the armored message, used in enarmor command */
+    bool           discard;    /* discard the output */
 } rnp_ctx_t;
 
 #endif // __RNP_TYPES__

--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -1143,3 +1143,18 @@ rnp_strip_eol(char *s)
 
     return s;
 }
+
+/* small function to pretty print an 8-character raw userid */
+char *
+userid_to_id(const uint8_t *userid, char *id)
+{
+    static const char *hexes = "0123456789abcdef";
+    int                i;
+
+    for (i = 0; i < 8; i++) {
+        id[i * 2] = hexes[(unsigned) (userid[i] & 0xf0) >> 4];
+        id[(i * 2) + 1] = hexes[userid[i] & 0xf];
+    }
+    id[8 * 2] = 0x0;
+    return id;
+}

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1316,6 +1316,29 @@ rnp_parse_handler_dest(pgp_parse_handler_t *handler, pgp_dest_t *dst, const char
     return rnp_initialize_output(param->ctx, dst, param->out);
 }
 
+static bool
+rnp_parse_handler_src(pgp_parse_handler_t *handler, pgp_source_t *src)
+{
+    pgp_parse_handler_param_t *param = handler->param;
+    char srcname[PATH_MAX];
+    size_t len;
+    
+    if (!param) {
+        return false;
+    }
+
+    len = strlen(param->in);
+    if ((len > 4) && (!strncmp(param->in + len - 4, ".sig", 4) || !strncmp(param->in + len - 4, ".asc", 4))) {
+        strncpy(srcname, param->in, sizeof(srcname));
+        srcname[len - 4] = '\0';
+        if (init_file_src(src, srcname) == RNP_SUCCESS) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static void
 rnp_parse_handler_signatures(pgp_parse_handler_t * handler,
                              pgp_signature_info_t *sigs,
@@ -1449,6 +1472,7 @@ rnp_process_stream(rnp_ctx_t *ctx, const char *in, const char *out)
     handler->password_provider = &ctx->rnp->password_provider;
     handler->key_provider = &keyprov;
     handler->dest_provider = rnp_parse_handler_dest;
+    handler->src_provider = rnp_parse_handler_src;
     handler->on_signatures = rnp_parse_handler_signatures;
     handler->param = param;
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1308,6 +1308,10 @@ rnp_parse_handler_dest(pgp_parse_handler_t *handler, pgp_dest_t *dst, const char
         return false;
     }
 
+    if (param->ctx->discard) {
+        return init_null_dest(dst) == RNP_SUCCESS;
+    }
+
     /* add some logic to build param->out, based on handler->in and filename */
     return rnp_initialize_output(param->ctx, dst, param->out);
 }
@@ -1397,7 +1401,7 @@ rnp_parse_handler_signatures(pgp_parse_handler_t * handler,
 rnp_result_t
 rnp_process_stream(rnp_ctx_t *ctx, const char *in, const char *out)
 {
-    pgp_source_t               src;
+    pgp_source_t               src = {0};
     pgp_parse_handler_t *      handler = NULL;
     pgp_parse_handler_param_t *param = NULL;
     pgp_key_provider_t         keyprov;
@@ -1412,7 +1416,7 @@ rnp_process_stream(rnp_ctx_t *ctx, const char *in, const char *out)
         goto finish;
     }
 
-    /* destination provider param */
+    /* parsing handler param */
     if ((param = calloc(1, sizeof(*param))) == NULL) {
         result = RNP_ERROR_OUT_OF_MEMORY;
         goto finish;

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1320,15 +1320,16 @@ static bool
 rnp_parse_handler_src(pgp_parse_handler_t *handler, pgp_source_t *src)
 {
     pgp_parse_handler_param_t *param = handler->param;
-    char srcname[PATH_MAX];
-    size_t len;
-    
+    char                       srcname[PATH_MAX];
+    size_t                     len;
+
     if (!param) {
         return false;
     }
 
     len = strlen(param->in);
-    if ((len > 4) && (!strncmp(param->in + len - 4, ".sig", 4) || !strncmp(param->in + len - 4, ".asc", 4))) {
+    if ((len > 4) && (!strncmp(param->in + len - 4, ".sig", 4) ||
+                      !strncmp(param->in + len - 4, ".asc", 4))) {
         strncpy(srcname, param->in, sizeof(srcname));
         srcname[len - 4] = '\0';
         if (init_file_src(src, srcname) == RNP_SUCCESS) {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -272,6 +272,53 @@ typedef struct pgp_sig_t {
     pgp_hash_t *hash;         /* the hash filled in for the data so far */
 } pgp_sig_t;
 
+typedef struct pgp_sig_subpkt_t {
+    uint8_t  type;
+    unsigned len;
+    uint8_t *data;
+    unsigned critical : 1;
+    unsigned hashed : 1;
+    unsigned raw : 1;
+} pgp_sig_subpkt_t;
+
+typedef struct pgp_signature_t {
+    pgp_version_t version;
+    /* common v3 and v4 fields */
+    pgp_sig_type_t   sigtype;
+    pgp_pubkey_alg_t palg;
+    pgp_hash_alg_t   halg;
+    uint16_t         lbits;
+    uint8_t *        hashed_data;
+
+    /* signature material */
+    union {
+        struct {
+            uint8_t  m[PGP_MPINT_SIZE];
+            unsigned mlen;
+        } rsa;
+        struct {
+            uint8_t  r[PGP_MPINT_SIZE];
+            uint8_t  s[PGP_MPINT_SIZE];
+            unsigned rlen;
+            unsigned slen;
+        } dsa;
+        struct {
+            uint8_t  r[PGP_MPINT_SIZE];
+            uint8_t  s[PGP_MPINT_SIZE];
+            unsigned rlen;
+            unsigned slen;
+        } ecc;
+    } material;
+
+    /* v3 - only fields */
+    uint32_t creation_time;
+    uint8_t  signer[PGP_KEY_ID_SIZE];
+
+    /* v4 - only fields */
+    DYNARRAY(pgp_sig_subpkt_t, subpkt);
+    unsigned hashed_subpkts;
+} pgp_signature_t;
+
 /** The raw bytes of a signature subpacket */
 
 typedef struct pgp_ss_raw_t {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -363,8 +363,8 @@ typedef struct pgp_signature_t {
     /* signature material */
     union {
         struct {
-            uint8_t  m[PGP_MPINT_SIZE];
-            unsigned mlen;
+            uint8_t  s[PGP_MPINT_SIZE];
+            unsigned slen;
         } rsa;
         struct {
             uint8_t  r[PGP_MPINT_SIZE];
@@ -439,9 +439,9 @@ typedef enum {
 /** pgp_one_pass_sig_t */
 typedef struct {
     uint8_t          version;
-    pgp_sig_type_t   sig_type;
-    pgp_hash_alg_t   hash_alg;
-    pgp_pubkey_alg_t key_alg;
+    pgp_sig_type_t   type;
+    pgp_hash_alg_t   halg;
+    pgp_pubkey_alg_t palg;
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     unsigned         nested;
 } pgp_one_pass_sig_t;

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2308,17 +2308,17 @@ parse_one_pass(pgp_region_t *region, pgp_stream_t *stream)
     if (!limread(&c, 1, region, stream)) {
         return false;
     }
-    pkt.u.one_pass_sig.sig_type = (pgp_sig_type_t) c;
+    pkt.u.one_pass_sig.type = (pgp_sig_type_t) c;
 
     if (!limread(&c, 1, region, stream)) {
         return false;
     }
-    pkt.u.one_pass_sig.hash_alg = (pgp_hash_alg_t) c;
+    pkt.u.one_pass_sig.halg = (pgp_hash_alg_t) c;
 
     if (!limread(&c, 1, region, stream)) {
         return false;
     }
-    pkt.u.one_pass_sig.key_alg = (pgp_pubkey_alg_t) c;
+    pkt.u.one_pass_sig.palg = (pgp_pubkey_alg_t) c;
 
     if (!limread(pkt.u.one_pass_sig.keyid,
                  (unsigned) sizeof(pkt.u.one_pass_sig.keyid),
@@ -2333,7 +2333,7 @@ parse_one_pass(pgp_region_t *region, pgp_stream_t *stream)
     pkt.u.one_pass_sig.nested = !!c;
     CALLBACK(PGP_PTAG_CT_1_PASS_SIG, &stream->cbinfo, &pkt);
     /* XXX: we should, perhaps, let the app choose whether to hash or not */
-    parse_hash_init(stream, pkt.u.one_pass_sig.hash_alg, pkt.u.one_pass_sig.keyid);
+    parse_hash_init(stream, pkt.u.one_pass_sig.halg, pkt.u.one_pass_sig.keyid);
     return true;
 }
 

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -1309,16 +1309,16 @@ pgp_print_packet(pgp_cbdata_t *cbinfo, const pgp_packet_t *pkt)
         print_uint(print->indent, "Version", (unsigned) content->one_pass_sig.version);
         print_string_and_value(print->indent,
                                "Signature Type",
-                               pgp_show_sig_type(content->one_pass_sig.sig_type),
-                               content->one_pass_sig.sig_type);
+                               pgp_show_sig_type(content->one_pass_sig.type),
+                               content->one_pass_sig.type);
         print_string_and_value(print->indent,
                                "Hash Algorithm",
-                               pgp_show_hash_alg((uint8_t) content->one_pass_sig.hash_alg),
-                               (uint8_t) content->one_pass_sig.hash_alg);
+                               pgp_show_hash_alg((uint8_t) content->one_pass_sig.halg),
+                               (uint8_t) content->one_pass_sig.halg);
         print_string_and_value(print->indent,
                                "Public Key Algorithm",
-                               pgp_show_pka(content->one_pass_sig.key_alg),
-                               content->one_pass_sig.key_alg);
+                               pgp_show_pka(content->one_pass_sig.palg),
+                               content->one_pass_sig.palg);
         print_hexdump(print->indent,
                       "Signer ID",
                       content->one_pass_sig.keyid,

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -374,7 +374,7 @@ armored_src_read(pgp_source_t *src, void *buf, size_t len)
             *bptr++ = (*dptr << 2) | (*(dptr + 1) >> 4);
         }
 
-        uint8_t    crc_fin[5];
+        uint8_t crc_fin[5];
         /* Calculate CRC after reading whole input stream */
         pgp_hash_add(&param->crc_ctx, param->rest, bptr - param->rest);
         if (!pgp_hash_finish(&param->crc_ctx, crc_fin)) {
@@ -415,18 +415,16 @@ armored_src_close(pgp_source_t *src)
 {
     pgp_source_armored_param_t *param = src->param;
 
-    if (!param) {
-        return;
+    if (param) {
+        (void) pgp_hash_finish(&param->crc_ctx, NULL);
+        free(param->armorhdr);
+        free(param->version);
+        free(param->comment);
+        free(param->hash);
+        free(param->charset);
+        free(param);
+        param = NULL;
     }
-
-    (void) pgp_hash_finish(&param->crc_ctx, NULL);
-    free(param->armorhdr);
-    free(param->version);
-    free(param->comment);
-    free(param->hash);
-    free(param->charset);
-    free(param);
-    param = NULL;
 }
 
 /** @brief finds armor header position in the buffer, returning beginning of header or NULL.
@@ -670,7 +668,7 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc)
 
 finish:
     if (errcode != RNP_SUCCESS) {
-        armored_src_close(src);
+        src_close(src);
     }
     return errcode;
 }

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -332,7 +332,7 @@ armored_src_read(pgp_source_t *src, void *buf, size_t len)
             }
             /* reading armor trailing line */
             if (!armor_read_trailer(src)) {
-                RNP_LOG("armored_src_read: wrong armor trailer");
+                RNP_LOG("wrong armor trailer");
                 return -1;
             }
 

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -171,7 +171,7 @@ armor_read_trailer(pgp_source_t *src)
     strncpy(st + stlen + 3, "-----", 5);
     stlen += 8;
     read = src_peek(param->readsrc, str, stlen);
-    if ((read < stlen) || strncmp(str, st, stlen)) {
+    if ((read < (ssize_t) stlen) || strncmp(str, st, stlen)) {
         return false;
     }
     src_skip(param->readsrc, stlen);
@@ -390,7 +390,7 @@ find_armor_header(const char *buf, size_t len, size_t *hdrlen)
 {
     int st = -1;
 
-    for (int i = 0; i < len - 10; i++) {
+    for (unsigned i = 0; i < len - 10; i++) {
         if ((buf[i] == '-') && !strncmp(&buf[i + 1], "----", 4)) {
             st = i;
             break;
@@ -401,7 +401,7 @@ find_armor_header(const char *buf, size_t len, size_t *hdrlen)
         return NULL;
     }
 
-    for (int i = st + 5; i <= len - 5; i++) {
+    for (unsigned i = st + 5; i <= len - 5; i++) {
         if ((buf[i] == '-') && !strncmp(&buf[i + 1], "----", 4)) {
             *hdrlen = i + 5 - st;
             return &buf[st];
@@ -909,7 +909,7 @@ is_armored_source(pgp_source_t *src)
     ssize_t    read;
 
     read = src_peek(src, buf, sizeof(buf));
-    if (read < sizeof(armor_start)) {
+    if (read < (ssize_t) sizeof(armor_start)) {
         return false;
     }
 
@@ -928,7 +928,7 @@ rnp_dearmor_source(pgp_source_t *src, pgp_dest_t *dst)
     ssize_t           read;
 
     read = src_peek(src, readbuf, sizeof(clear_start));
-    if (read < sizeof(armor_start)) {
+    if (read < (ssize_t) sizeof(armor_start)) {
         RNP_LOG("can't read enough data from source");
         return RNP_ERROR_READ;
     }

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -642,6 +642,7 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc)
     src->close = armored_src_close;
     src->type = PGP_STREAM_ARMORED;
     src->size = 0;
+    src->knownsize = 0;
     src->readb = 0;
     src->eof = 0;
 

--- a/src/librepgp/stream-armor.h
+++ b/src/librepgp/stream-armor.h
@@ -76,4 +76,10 @@ rnp_result_t rnp_armor_source(pgp_source_t *src, pgp_dest_t *dst, pgp_armored_ms
  **/
 pgp_armored_msg_t rnp_armor_guess_type(pgp_source_t *src);
 
+/* @brief Check whether source could be an armored source
+ * @param src initialized source with some data
+ * @return true if source could be an armored data or false otherwise
+ **/
+bool is_armored_source(pgp_source_t *src);
+
 #endif

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -50,7 +50,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
     ssize_t             read;
     pgp_source_cache_t *cache = src->cache;
     bool                readahead = cache->readahead;
-    
+
     if (src->eof || (len == 0)) {
         return 0;
     }
@@ -130,7 +130,7 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
     ssize_t             read;
     pgp_source_cache_t *cache = src->cache;
     bool                readahead = cache->readahead;
-    
+
     if (!cache || (len > sizeof(cache->buf))) {
         return -1;
     }
@@ -221,6 +221,17 @@ src_finish(pgp_source_t *src)
     return res;
 }
 
+bool
+src_eof(pgp_source_t *src)
+{
+    uint8_t check;
+
+    if (src->eof) {
+        return true;
+    }
+
+    return src_peek(src, &check, 1) == 0;
+}
 
 void
 src_close(pgp_source_t *src)

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -56,7 +56,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
     }
 
     // Do not read more then available if source size is known
-    if (src->size > 0 && src->readb + len > src->size) {
+    if (src->knownsize && (src->readb + len > src->size)) {
         len = src->size - src->readb;
         left = len;
         readahead = false;
@@ -65,7 +65,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
     // Check whether we have cache and there is data inside
     if (cache && (cache->len > cache->pos)) {
         read = cache->len - cache->pos;
-        if (read >= len) {
+        if ((size_t) read >= len) {
             memcpy(buf, &cache->buf[cache->pos], len);
             cache->pos += len;
             goto finish;
@@ -101,7 +101,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
                 goto finish;
             } else if (read < 0) {
                 return -1;
-            } else if (read < left) {
+            } else if ((size_t) read < left) {
                 memcpy(buf, &cache->buf[0], read);
                 left -= read;
                 buf = (uint8_t *) buf + read;
@@ -117,7 +117,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
 finish:
     src->readb += len;
 
-    if (src->knownsize && src->readb == src->size) {
+    if (src->knownsize && (src->readb == src->size)) {
         src->eof = 1;
     }
 
@@ -140,7 +140,7 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
     }
 
     // Do not read more then available if source size is known
-    if (src->size > 0 && src->readb + len > src->size) {
+    if (src->knownsize && (src->readb + len > src->size)) {
         len = src->size - src->readb;
         readahead = false;
     }

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -189,6 +189,18 @@ src_skip(pgp_source_t *src, size_t len)
     }
 }
 
+rnp_result_t
+src_finish(pgp_source_t *src)
+{
+    rnp_result_t res = RNP_SUCCESS;
+    if (src->finish) {
+        res = src->finish(src);
+    }
+
+    return res;
+}
+
+
 void
 src_close(pgp_source_t *src)
 {
@@ -281,6 +293,7 @@ init_file_src(pgp_source_t *src, const char *path)
     param->fd = fd;
     src->read = file_src_read;
     src->close = file_src_close;
+    src->finish = NULL;
     src->type = PGP_STREAM_FILE;
     src->size = st.st_size;
     src->readb = 0;
@@ -302,6 +315,7 @@ init_stdin_src(pgp_source_t *src)
     param->fd = 0;
     src->read = file_src_read;
     src->close = file_src_close;
+    src->finish = NULL;
     src->type = PGP_STREAM_STDIN;
     src->size = 0;
     src->readb = 0;

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -70,10 +70,10 @@ typedef struct pgp_source_cache_t {
 } pgp_source_cache_t;
 
 typedef struct pgp_source_t {
-    pgp_source_read_func_t * read;
-    pgp_source_close_func_t *close;
+    pgp_source_read_func_t *  read;
+    pgp_source_close_func_t * close;
     pgp_source_finish_func_t *finish;
-    pgp_stream_type_t        type;
+    pgp_stream_type_t         type;
 
     uint64_t size;  /* size of the data if available, see knownsize */
     uint64_t readb; /* number of bytes read from the stream via src_read. Do not confuse with
@@ -81,7 +81,7 @@ typedef struct pgp_source_t {
     pgp_source_cache_t *cache; /* cache if used */
     void *              param; /* source-specific additional data */
 
-    unsigned eof : 1; /* end of data as reported by read and empty cache */
+    unsigned eof : 1;       /* end of data as reported by read and empty cache */
     unsigned knownsize : 1; /* whether size of the data is known */
 } pgp_source_t;
 
@@ -117,11 +117,19 @@ ssize_t src_peek(pgp_source_t *src, void *buf, size_t len);
  **/
 ssize_t src_skip(pgp_source_t *src, size_t len);
 
-/** @brief notify source that all reading is done, so final data processing may be started, i.e. signature reading and verification and so on. Do not misuse with src_close.
+/** @brief notify source that all reading is done, so final data processing may be started,
+ * i.e. signature reading and verification and so on. Do not misuse with src_close.
  *  @param src allocated and initialized source structure
- *  @return RNP_SUCCESS or error code. If source doesn't have finish handler then also RNP_SUCCESS is returned
+ *  @return RNP_SUCCESS or error code. If source doesn't have finish handler then also
+ * RNP_SUCCESS is returned
 */
 rnp_result_t src_finish(pgp_source_t *src);
+
+/** @brief check whether there is no more input on source
+ *  @param src allocated and initialized source structure
+ *  @return true if there is no more input or false otherwise
+*/
+bool src_eof(pgp_source_t *src);
 
 /** @brief close the source and deallocate all internal resources if any
  **/

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -37,6 +37,7 @@
 #define PGP_OUTPUT_CACHE_SIZE 32768
 
 typedef enum {
+    PGP_STREAM_NULL,
     PGP_STREAM_FILE,
     PGP_STREAM_MEMORY,
     PGP_STREAM_STDIN,
@@ -162,10 +163,11 @@ typedef struct pgp_dest_t {
     pgp_stream_type_t      type;
     rnp_result_t           werr; /* write function may set this to some error code */
 
-    int64_t  writeb; /* number of bytes written */
-    void *   param;  /* source-specific additional data */
+    int64_t  writeb;   /* number of bytes written */
+    void *   param;    /* source-specific additional data */
+    bool     no_cache; /* disable write caching */
     uint8_t  cache[PGP_OUTPUT_CACHE_SIZE];
-    unsigned clen;
+    unsigned clen; /* number of bytes in cache */
 } pgp_dest_t;
 
 /** @brief write buffer to the destination
@@ -198,10 +200,24 @@ rnp_result_t init_file_dest(pgp_dest_t *dst, const char *path);
  **/
 rnp_result_t init_stdout_dest(pgp_dest_t *dst);
 
-/** @brief init memory source
+/** @brief init memory destination
+ *  @param dst pre-allocated dest structure
+ *  @param maxalloc maximum amount of memory to allocate
+ *  @return RNP_SUCCESS or error code
+ **/
+rnp_result_t init_mem_dest(pgp_dest_t *dst, unsigned maxalloc);
+
+/** @brief get the pointer to the memory where data is written.
+ *  Do not retain the result, it may change betweeen calls due to realloc
+ *  @param dst pre-allocated and initialized memory dest
+ *  @return pointer to the memory area or NULL if memory was not allocated
+ **/
+void *mem_dest_get_memory(pgp_dest_t *dst);
+
+/** @brief init null destination which silently discards all the output
  *  @param dst pre-allocated dest structure
  *  @return RNP_SUCCESS or error code
  **/
-rnp_result_t init_mem_dest(pgp_dest_t *dst);
+rnp_result_t init_null_dest(pgp_dest_t *dst);
 
 #endif

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -56,6 +56,7 @@ typedef struct pgp_dest_t   pgp_dest_t;
 
 typedef ssize_t pgp_source_read_func_t(pgp_source_t *src, void *buf, size_t len);
 typedef void pgp_source_close_func_t(pgp_source_t *src);
+typedef rnp_result_t pgp_source_finish_func_t(pgp_source_t *src);
 
 typedef rnp_result_t pgp_dest_write_func_t(pgp_dest_t *dst, const void *buf, size_t len);
 typedef void pgp_dest_close_func_t(pgp_dest_t *dst, bool discard);
@@ -70,6 +71,7 @@ typedef struct pgp_source_cache_t {
 typedef struct pgp_source_t {
     pgp_source_read_func_t * read;
     pgp_source_close_func_t *close;
+    pgp_source_finish_func_t *finish;
     pgp_stream_type_t        type;
 
     uint64_t size;  /* size of the data if available, 0 otherwise */
@@ -112,6 +114,12 @@ ssize_t src_peek(pgp_source_t *src, void *buf, size_t len);
  *  @return number of bytes skipped or -1 in case of error
  **/
 ssize_t src_skip(pgp_source_t *src, size_t len);
+
+/** @brief notify source that all reading is done, so final data processing may be started, i.e. signature reading and verification and so on. Do not misuse with src_close.
+ *  @param src allocated and initialized source structure
+ *  @return RNP_SUCCESS or error code. If source doesn't have finish handler then also RNP_SUCCESS is returned
+*/
+rnp_result_t src_finish(pgp_source_t *src);
 
 /** @brief close the source and deallocate all internal resources if any
  **/

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -133,8 +133,25 @@ rnp_result_t src_finish(pgp_source_t *src);
 bool src_eof(pgp_source_t *src);
 
 /** @brief close the source and deallocate all internal resources if any
- **/
+ */
 void src_close(pgp_source_t *src);
+
+/** @brief skip end of line on the source (\r\n or \n, depending on input)
+ *  @param src allocated and initialized source
+ *  @return true if eol was found and skipped or false otherwise
+ */
+bool src_skip_eol(pgp_source_t *src);
+
+/** @brief peek the line on the source
+ *  @param src allocated and initialized source with data
+ *  @param buf preallocated buffer to store the result. Result include NULL character and
+ *             doesn't include the end of line sequence.
+ *  @param len maximum length of data to store in buf, including terminating NULL
+ *  @return number of bytes in the string, without the NULL character, on success.
+ *          -1 is returned if there were eof, read error or eol was not found within the len.
+ *          Supported eol sequences are \r\n and \n
+ */
+ssize_t src_peek_line(pgp_source_t *src, char *buf, size_t len);
 
 /** @brief init file source
  *  @param src pre-allocated source structure

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -934,7 +934,7 @@ signature_parse_subpackets(pgp_signature_t *sig, uint8_t *buf, size_t len, bool 
             return false;
         }
 
-        memchr(&subpkt, 0, sizeof(subpkt));
+        memset(&subpkt, 0, sizeof(subpkt));
 
         if ((subpkt.data = malloc(splen - 1)) == NULL) {
             RNP_LOG("subpacket data allocation failed");

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -1009,7 +1009,7 @@ signature_read_v4(pgp_source_t *src, pgp_signature_t *sig, size_t len)
     sig->hashed_data[0] = sig->version;
     memcpy(sig->hashed_data + 1, buf, 5);
 
-    if (src_read(src, sig->hashed_data + 6, splen) != splen) {
+    if (src_read(src, sig->hashed_data + 6, splen) != (ssize_t) splen) {
         RNP_LOG("read of hashed subpackets failed");
         return RNP_ERROR_READ;
     }
@@ -1040,7 +1040,7 @@ signature_read_v4(pgp_source_t *src, pgp_signature_t *sig, size_t len)
         return RNP_ERROR_OUT_OF_MEMORY;
     }
 
-    if (src_read(src, spbuf, splen) != splen) {
+    if (src_read(src, spbuf, splen) != (ssize_t) splen) {
         RNP_LOG("read of unhashed subpackets failed");
         return RNP_ERROR_READ;
     }
@@ -1194,7 +1194,7 @@ signature_get_subpkt(pgp_signature_t *sig, pgp_sig_subpacket_type_t type)
         return NULL;
     }
 
-    for (int i = 0; i < sig->subpktc; i++) {
+    for (unsigned i = 0; i < sig->subpktc; i++) {
         if (sig->subpkts[i].type == type) {
             /* no reason to return non-parsed subpacket */
             if (sig->subpkts[i].parsed) {
@@ -1280,7 +1280,7 @@ void
 free_signature(pgp_signature_t *sig)
 {
     free(sig->hashed_data);
-    for (int i = 0; i < sig->subpktc; i++) {
+    for (unsigned i = 0; i < sig->subpktc; i++) {
         free(sig->subpkts[i].data);
     }
     FREE_ARRAY(sig, subpkt);

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -61,7 +61,7 @@ int get_packet_type(uint8_t ptag);
 
 /** @brief Read packet length for fixed-size (say, small) packet. Returns -1 on error.
  *  Will also read packet tag byte. We do not allow partial length here as well as large
- *packets (so ignoring possible ssize_t overflow)
+ *  packets (so ignoring possible ssize_t overflow)
  *
  *  @param src source to read length from
  *  @return length of the packet or -1 if there is read error or packet length is ill-formed
@@ -126,8 +126,16 @@ bool stream_write_sk_sesskey(pgp_sk_sesskey_t *skey, pgp_dest_t *dst);
 
 bool stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *pkey, pgp_dest_t *dst);
 
+bool stream_write_one_pass(pgp_one_pass_sig_t *onepass, pgp_dest_t *dst);
+
+bool stream_write_signature(pgp_signature_t *sig, pgp_dest_t *dst);
+
 rnp_result_t stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey);
 
 rnp_result_t stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_pkt_t *pkey);
+
+rnp_result_t stream_parse_one_pass(pgp_source_t *src, pgp_one_pass_sig_t *onepass);
+
+rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
 
 #endif

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -61,7 +61,7 @@ int get_packet_type(uint8_t ptag);
 
 /** @brief Peek length of the packet header. Returns -1 on error.
  *  @param src source to read length from
- *  @return number of bytes in packet header or -1 if there is a read error or packet length 
+ *  @return number of bytes in packet header or -1 if there is a read error or packet length
  *          is ill-formed
  **/
 ssize_t stream_pkt_hdr_len(pgp_source_t *src);
@@ -144,5 +144,13 @@ rnp_result_t stream_parse_pk_sesskey(pgp_source_t *src, pgp_pk_sesskey_pkt_t *pk
 rnp_result_t stream_parse_one_pass(pgp_source_t *src, pgp_one_pass_sig_t *onepass);
 
 rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
+
+bool signature_matches_onepass(pgp_signature_t *sig, pgp_one_pass_sig_t *onepass);
+pgp_sig_subpkt_t *signature_get_subpkt(pgp_signature_t *sig, pgp_sig_subpacket_type_t type);
+bool signature_get_keyfp(pgp_signature_t *sig, uint8_t *fp);
+bool signature_get_keyid(pgp_signature_t *sig, uint8_t *id);
+uint32_t signature_get_creation(pgp_signature_t *sig);
+uint32_t signature_get_expiration(pgp_signature_t *sig);
+void free_signature(pgp_signature_t *sig);
 
 #endif

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -59,6 +59,13 @@ size_t write_packet_len(uint8_t *buf, size_t len);
  **/
 int get_packet_type(uint8_t ptag);
 
+/** @brief Peek length of the packet header. Returns -1 on error.
+ *  @param src source to read length from
+ *  @return number of bytes in packet header or -1 if there is a read error or packet length 
+ *          is ill-formed
+ **/
+ssize_t stream_pkt_hdr_len(pgp_source_t *src);
+
 /** @brief Read packet length for fixed-size (say, small) packet. Returns -1 on error.
  *  Will also read packet tag byte. We do not allow partial length here as well as large
  *  packets (so ignoring possible ssize_t overflow)

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -1948,7 +1948,7 @@ init_packet_sequence(pgp_processing_ctx_t *ctx, pgp_source_t *src)
             return RNP_ERROR_BAD_FORMAT;
         }
 
-        memchr(&psrc, 0, sizeof(psrc));
+        memset(&psrc, 0, sizeof(psrc));
 
         switch (type) {
         case PGP_PTAG_CT_PK_SESSION_KEY:

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -40,14 +40,17 @@ typedef struct pgp_signature_info_t pgp_signature_info_t;
 typedef bool pgp_destination_func_t(pgp_parse_handler_t *handler,
                                     pgp_dest_t *         dst,
                                     const char *         filename);
+typedef bool pgp_source_func_t(pgp_parse_handler_t *handler, pgp_source_t *src);
 typedef void pgp_signatures_func_t(pgp_parse_handler_t * handler,
                                    pgp_signature_info_t *sigs,
                                    int                   count);
 
+/* handler used to return needed information during pgp source processing */
 typedef struct pgp_parse_handler_t {
     pgp_password_provider_t *password_provider;
     pgp_key_provider_t *     key_provider;
     pgp_destination_func_t * dest_provider;
+    pgp_source_func_t *      src_provider;
     pgp_signatures_func_t *  on_signatures;
 
     void *param;

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -47,13 +47,17 @@ typedef void pgp_signatures_func_t(pgp_parse_handler_t * handler,
 
 /* handler used to return needed information during pgp source processing */
 typedef struct pgp_parse_handler_t {
-    pgp_password_provider_t *password_provider;
-    pgp_key_provider_t *     key_provider;
-    pgp_destination_func_t * dest_provider;
-    pgp_source_func_t *      src_provider;
-    pgp_signatures_func_t *  on_signatures;
+    pgp_password_provider_t *password_provider; /* if NULL then default will be used */
+    pgp_key_provider_t *     key_provider; /* must be set when key is required, i.e. during
+                                              signing/verification/public key encryption and
+                                              deryption */
+    pgp_destination_func_t *dest_provider; /* called when destination stream is required */
+    pgp_source_func_t *     src_provider;  /* required to provider source during the detached
+                                              signature verification */
+    pgp_signatures_func_t *on_signatures;  /* for signature verification results */
 
-    void *param;
+    rnp_ctx_t *ctx;   /* operation context */
+    void *     param; /* additional parameters */
 } pgp_parse_handler_t;
 
 /* information about the signature */

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -35,18 +35,33 @@
 #include <rnp/rnp.h>
 #include "stream-common.h"
 
-typedef struct pgp_parse_handler_t pgp_parse_handler_t;
+typedef struct pgp_parse_handler_t  pgp_parse_handler_t;
+typedef struct pgp_signature_info_t pgp_signature_info_t;
 typedef bool pgp_destination_func_t(pgp_parse_handler_t *handler,
                                     pgp_dest_t *         dst,
                                     const char *         filename);
+typedef void pgp_signatures_func_t(pgp_parse_handler_t * handler,
+                                   pgp_signature_info_t *sigs,
+                                   int                   count);
 
 typedef struct pgp_parse_handler_t {
     pgp_password_provider_t *password_provider;
     pgp_key_provider_t *     key_provider;
     pgp_destination_func_t * dest_provider;
+    pgp_signatures_func_t *  on_signatures;
 
     void *param;
 } pgp_parse_handler_t;
+
+/* information about the signature */
+typedef struct pgp_signature_info_t {
+    pgp_signature_t *sig;       /* signature, or NULL if there were parsing error */
+    pgp_pubkey_t *   signer;    /* signer's public key if found */
+    bool             valid;     /* signature is cryptographically valid (but may be expired) */
+    bool             unknown;   /* signature is unknown - parsing error, wrong version, etc */
+    bool             no_signer; /* no signer's public key available */
+    bool             expired;   /* signature is expired */
+} pgp_signature_info_t;
 
 /* @brief Process the OpenPGP source: file, memory, stdin
  * Function will parse input data, provided by any source conforming to pgp_source_t,

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -347,7 +347,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
     memcpy(&enckey[1], key, keylen);
 
     /* Calculate checksum */
-    for (int i = 1; i <= keylen; i++) {
+    for (unsigned i = 1; i <= keylen; i++) {
         checksum += enckey[i];
     }
     enckey[keylen + 1] = (checksum >> 8) & 0xff;

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -414,9 +414,8 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         break;
     }
     case CMD_VERIFY:
-        ctx.discard = true;
-        ret = rnp_process_stream(&ctx, f, NULL) == RNP_SUCCESS;
-        break;
+        ctx.discard = !rnp_cfg_get(cfg, CFG_OUTFILE);
+    /* FALLTHROUGH */
     case CMD_VERIFY_CAT:
         ret = rnp_process_stream(&ctx, f, rnp_cfg_get(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -245,7 +245,7 @@ def rnp_verify_detached(sig, signer=None):
     if not match:
         raise_err('wrong rnp detached verification output', err)
     if signer and (not match.group(1).strip() == signer.strip()):
-        raise_err('rnp detached verification failed, wrong signer'.format()
+        raise_err('rnp detached verification failed, wrong signer'.format())
 
 
 def rnp_verify_cleartext(src, signer=None):

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -84,10 +84,11 @@ r'gpg: Signature made .*' \
 r'gpg: Good signature from "(.*)".*'
 
 RE_RNP_GOOD_SIGNATURE = r'(?s)^.*' \
-r'Good signature for .* made .*' \
+r'Good signature made .*' \
 r'using .* key .*' \
 r'signature .*' \
-r'uid\s+(.*)\s*$'
+r'uid\s+(.*)\s*' \
+r'Signature\(s\) verified successfully.*$'
 
 def check_packets(fname, regexp):
     ret, output, err = run_proc(GPG, ['--list-packets', fname])
@@ -244,7 +245,7 @@ def rnp_verify_detached(sig, signer=None):
     if not match:
         raise_err('wrong rnp detached verification output', err)
     if signer and (not match.group(1).strip() == signer.strip()):
-        raise_err('rnp detached verification failed, wrong signer')
+        raise_err('rnp detached verification failed, wrong signer'.format()
 
 
 def rnp_verify_cleartext(src, signer=None):


### PR DESCRIPTION
This PR adds streamed approach for signature verification (signing will be done later, as separate PR).

### New features:
- signed source type (it is called 'signed', however it is for verification purpose)
- cleartext signed source type (kinda subtype of signed source)
- detached signatures processing (as part of the signed source)
- minor very rare bug in cleartext signature verification, which I will fix later

### Following events were added to the handler:
- on_signatures event to handle verification results by callee
- src_provider to provide source for detached signature.

### Some notes:
- method process_pgp_source was divided to some submethods for readability
- moved to list instead of DYNARRAY, seems to be much easier and nicer in handling
- some code partially duplicates old codebase and types - this is just because old code will be removed once streamed processing will be 100% finished

### Questions:
- while all logic fits to the single pgp_process_source call, detached signatures processing is slightly different since it requires additional source. Should we separate it to the pgp_process_detached() call or on_source event handler is good enough?
- currently we display signature verification status on the librnp level, however logically all messages which are presented to user (not counting error log) should go on 'user' level, i.e. CLI. What do you think about it?
