### PR TITLE
Fix code to be compliant with -Wsign-compare

### DIFF
--- a/src/lib/crypto/ecdh.c
+++ b/src/lib/crypto/ecdh.c
@@ -186,7 +186,7 @@ end:
 bool
 set_ecdh_params(pgp_seckey_t *seckey, pgp_curve_t curve_id)
 {
-    for (int i = 0; i < ARRAY_SIZE(ecdh_params); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(ecdh_params); i++) {
         if (ecdh_params[i].curve == curve_id) {
             seckey->pubkey.key.ecdh.kdf_hash_alg = ecdh_params[i].hash;
             seckey->pubkey.key.ecdh.key_wrap_alg = ecdh_params[i].wrap_alg;

--- a/src/lib/crypto/ecdsa.c
+++ b/src/lib/crypto/ecdsa.c
@@ -127,7 +127,7 @@ pgp_ecdsa_verify_hash(const pgp_ecc_sig_t *   sign,
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if ((BN_num_bytes(pubkey->point) > sizeof(point_bytes)) ||
+    if ((BN_num_bytes(pubkey->point) > (int) sizeof(point_bytes)) ||
         BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
         RNP_LOG("Failed to load public key");
         goto end;
@@ -155,8 +155,8 @@ pgp_ecdsa_verify_hash(const pgp_ecc_sig_t *   sign,
         goto end;
     }
 
-    if ((BN_num_bytes(sign->r) > curve_order) || (BN_num_bytes(sign->s) > curve_order) ||
-        (curve_order > MAX_CURVE_BYTELEN)) {
+    if ((BN_num_bytes(sign->r) > (int) curve_order) ||
+        (BN_num_bytes(sign->s) > (int) curve_order) || (curve_order > MAX_CURVE_BYTELEN)) {
         goto end;
     }
 

--- a/src/lib/crypto/sm2.c
+++ b/src/lib/crypto/sm2.c
@@ -127,7 +127,7 @@ pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
 
     const size_t sign_half_len = BITS_TO_BYTES(curve->bitlen);
 
-    if ((BN_num_bytes(pubkey->point) > sizeof(point_bytes)) ||
+    if ((BN_num_bytes(pubkey->point) > (int) sizeof(point_bytes)) ||
         BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
         RNP_LOG("Failed to load public key");
         goto end;
@@ -152,8 +152,8 @@ pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
         goto end;
     }
 
-    if ((BN_num_bytes(sign->r) > sign_half_len) || (BN_num_bytes(sign->s) > sign_half_len) ||
-        (sign_half_len > MAX_CURVE_BYTELEN)) {
+    if ((BN_num_bytes(sign->r) > (int) sign_half_len) ||
+        (BN_num_bytes(sign->s) > (int) sign_half_len) || (sign_half_len > MAX_CURVE_BYTELEN)) {
         goto end;
     }
 
@@ -213,7 +213,7 @@ pgp_sm2_encrypt(uint8_t *               out,
         goto done;
     }
 
-    if ((BN_num_bytes(pubkey->point) > sizeof(point_bytes)) ||
+    if ((BN_num_bytes(pubkey->point) > (int) sizeof(point_bytes)) ||
         BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
         RNP_LOG("Failed to load public key");
         goto done;

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -254,7 +254,7 @@ static bool
 set_default_user_prefs(pgp_user_prefs_t *prefs)
 {
     if (!prefs->symm_algs) {
-        for (int i = 0; i < ARRAY_SIZE(DEFAULT_SYMMETRIC_ALGS); i++) {
+        for (size_t i = 0; i < ARRAY_SIZE(DEFAULT_SYMMETRIC_ALGS); i++) {
             EXPAND_ARRAY(prefs, symm_alg);
             if (!prefs->symm_algs) {
                 return false;
@@ -264,7 +264,7 @@ set_default_user_prefs(pgp_user_prefs_t *prefs)
         }
     }
     if (!prefs->hash_algs) {
-        for (int i = 0; i < ARRAY_SIZE(DEFAULT_HASH_ALGS); i++) {
+        for (size_t i = 0; i < ARRAY_SIZE(DEFAULT_HASH_ALGS); i++) {
             EXPAND_ARRAY(prefs, hash_alg);
             if (!prefs->hash_algs) {
                 return false;
@@ -274,7 +274,7 @@ set_default_user_prefs(pgp_user_prefs_t *prefs)
         }
     }
     if (!prefs->compress_algs) {
-        for (int i = 0; i < ARRAY_SIZE(DEFAULT_COMPRESS_ALGS); i++) {
+        for (size_t i = 0; i < ARRAY_SIZE(DEFAULT_COMPRESS_ALGS); i++) {
             EXPAND_ARRAY(prefs, compress_alg);
             if (!prefs->compress_algs) {
                 return false;

--- a/src/lib/hash.c
+++ b/src/lib/hash.c
@@ -80,9 +80,9 @@
 #include <stdio.h>
 
 static const struct hash_alg_map_t {
-    pgp_hash_alg_t  type;
-    const char      *name;
-    const char      *botan_name;
+    pgp_hash_alg_t type;
+    const char *   name;
+    const char *   botan_name;
 } hash_alg_map[] = {{PGP_HASH_MD5, "MD5", "MD5"},
                     {PGP_HASH_SHA1, "SHA1", "SHA-1"},
                     {PGP_HASH_RIPEMD, "RIPEMD160", "RIPEMD-160"},
@@ -134,7 +134,7 @@ pgp_str_to_hash_alg(const char *hash)
     if (hash == NULL) {
         return PGP_DEFAULT_HASH_ALGORITHM;
     }
-    for (int i = 0; i < ARRAY_SIZE(hash_alg_map); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(hash_alg_map); i++) {
         if (!rnp_strcasecmp(hash, hash_alg_map[i].name)) {
             return hash_alg_map[i].type;
         }

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -472,7 +472,7 @@ write_matching_packets(pgp_output_t *         output,
                        const pgp_content_enum tags[],
                        size_t                 tag_count)
 {
-    for (int i = 0; i < key->packetc; i++) {
+    for (unsigned i = 0; i < key->packetc; i++) {
         pgp_rawpacket_t *pkt = &key->packets[i];
 
         if (!packet_matches(pkt, tags, tag_count)) {

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -1166,7 +1166,7 @@ parse_locator(key_locator_t *locator, const char *identifier_type, const char *i
     switch (locator->type) {
     case PGP_KEY_SEARCH_USERID:
         if (snprintf(locator->id.userid, sizeof(locator->id.userid), "%s", identifier) >=
-            sizeof(locator->id.userid)) {
+            (int) sizeof(locator->id.userid)) {
             return RNP_ERROR_BAD_FORMAT;
         }
         break;

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -134,7 +134,7 @@ parse_format(const char *format, size_t format_len)
 static void
 destroy_s_exp(s_exp_t *s_exp)
 {
-    int i;
+    unsigned i;
 
     if (s_exp == NULL) {
         return;
@@ -162,7 +162,7 @@ add_block_to_sexp(s_exp_t *s_exp, uint8_t *bytes, size_t len)
 {
     sub_element_t *sub_element;
 
-    for (int i = 0; i < s_exp->sub_elementc; i++) {
+    for (unsigned i = 0; i < s_exp->sub_elementc; i++) {
         if (!s_exp->sub_elements[i].is_block) {
             continue;
         }
@@ -282,7 +282,7 @@ parse_sexp(s_exp_t *s_exp, const char **r_bytes, size_t *r_length)
         length -= (next - bytes);
         bytes = next;
 
-        if (len == LONG_MIN || len == LONG_MAX || len <= 0 || len >= length) {
+        if (len == LONG_MIN || len == LONG_MAX || len <= 0 || (size_t) len >= length) {
             fprintf(
               stderr,
               "len over/under flow or bigger than remaining bytes, len: %ld, length: %zu\n",
@@ -339,7 +339,7 @@ static s_exp_t *
 lookup_variable(s_exp_t *s_exp, const char *name)
 {
     size_t name_len = strlen(name);
-    for (int i = 0; i < s_exp->sub_elementc; i++) {
+    for (unsigned i = 0; i < s_exp->sub_elementc; i++) {
         if (s_exp->sub_elements[i].is_block) {
             continue;
         }
@@ -1107,13 +1107,11 @@ write_block(s_exp_block_t *block, pgp_memory_t *mem)
 static bool
 write_sexp(s_exp_t *s_exp, pgp_memory_t *mem)
 {
-    int i;
-
     if (!pgp_memory_add(mem, (const uint8_t *) "(", 1)) {
         return false;
     }
 
-    for (i = 0; i < s_exp->sub_elementc; i++) {
+    for (unsigned i = 0; i < s_exp->sub_elementc; i++) {
         if (s_exp->sub_elements[i].is_block) {
             if (!write_block(&s_exp->sub_elements[i].block, mem)) {
                 return false;

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -483,7 +483,8 @@ rnp_key_store_kbx_write_header(rnp_key_store_t *key_store, pgp_memory_t *m)
 static bool
 rnp_key_store_kbx_write_pgp(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *m)
 {
-    int          i, rc;
+    unsigned     i;
+    int          rc;
     size_t       start, key_start, uid_start;
     uint8_t *    p;
     uint8_t      checksum[20];
@@ -665,7 +666,7 @@ rnp_key_store_kbx_write_pgp(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *m)
 static bool
 rnp_key_store_kbx_write_x509(rnp_key_store_t *key_store, pgp_memory_t *m)
 {
-    for (int i = 0; i < key_store->blobc; i++) {
+    for (unsigned i = 0; i < key_store->blobc; i++) {
         if (key_store->blobs[i]->type == KBX_X509_BLOB) {
             if (!pgp_memory_add(m, key_store->blobs[i]->image, key_store->blobs[i]->length)) {
                 return false;
@@ -679,7 +680,7 @@ rnp_key_store_kbx_write_x509(rnp_key_store_t *key_store, pgp_memory_t *m)
 bool
 rnp_key_store_kbx_to_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_t *memory)
 {
-    int i;
+    unsigned i;
 
     pgp_memory_clear(memory);
 

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -225,7 +225,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
         {
             const pgp_data_t *data = &content->ss_skapref;
             pgp_user_prefs_t *prefs = &subsig->prefs;
-            for (int i = 0; i < data->len; i++) {
+            for (size_t i = 0; i < data->len; i++) {
                 EXPAND_ARRAY(prefs, symm_alg);
                 if (!subsig->prefs.symm_algs) {
                     PGP_ERROR(cbinfo->errors, PGP_E_FAIL, "Failed to expand array.");
@@ -241,7 +241,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
         {
             const pgp_data_t *data = &content->ss_hashpref;
             pgp_user_prefs_t *prefs = &subsig->prefs;
-            for (int i = 0; i < data->len; i++) {
+            for (size_t i = 0; i < data->len; i++) {
                 EXPAND_ARRAY(prefs, hash_alg);
                 if (!subsig->prefs.hash_algs) {
                     PGP_ERROR(cbinfo->errors, PGP_E_FAIL, "Failed to expand array.");
@@ -257,7 +257,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
         {
             const pgp_data_t *data = &content->ss_zpref;
             pgp_user_prefs_t *prefs = &subsig->prefs;
-            for (int i = 0; i < data->len; i++) {
+            for (size_t i = 0; i < data->len; i++) {
                 EXPAND_ARRAY(prefs, compress_alg);
                 if (!subsig->prefs.compress_algs) {
                     PGP_ERROR(cbinfo->errors, PGP_E_FAIL, "Failed to expand array.");
@@ -273,7 +273,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
         {
             const pgp_data_t *data = &content->ss_key_server_prefs;
             pgp_user_prefs_t *prefs = &subsig->prefs;
-            for (int i = 0; i < data->len; i++) {
+            for (size_t i = 0; i < data->len; i++) {
                 EXPAND_ARRAY(prefs, key_server_pref);
                 if (!subsig->prefs.key_server_prefs) {
                     PGP_ERROR(cbinfo->errors, PGP_E_FAIL, "Failed to expand array.");
@@ -462,7 +462,7 @@ rnp_key_store_pgp_write_to_mem(pgp_io_t *       io,
         }
         pgp_writer_push_armored(&output, type);
     }
-    for (int ikey = 0; ikey < key_store->keyc; ikey++) {
+    for (unsigned ikey = 0; ikey < key_store->keyc; ikey++) {
         key = &key_store->keys[ikey];
 
         if (key->format != GPG_KEY_STORE) {

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -273,7 +273,7 @@ rnp_key_store_write_to_file(pgp_io_t *io, rnp_key_store_t *key_store, const unsi
             }
         }
 
-        for (int i = 0; i < key_store->keyc; i++) {
+        for (unsigned i = 0; i < key_store->keyc; i++) {
             if (!rnp_key_store_get_key_grip(&key_store->keys[i].key.pubkey, grip)) {
                 return false;
             }
@@ -403,7 +403,7 @@ rnp_key_store_get_first_ring(rnp_key_store_t *ring, char *id, size_t len, int la
 void
 rnp_key_store_clear(rnp_key_store_t *keyring)
 {
-    int i;
+    unsigned i;
 
     if (keyring->keys != NULL) {
         for (i = 0; i < keyring->keyc; i++) {
@@ -600,9 +600,7 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
 bool
 rnp_key_store_remove_key(pgp_io_t *io, rnp_key_store_t *keyring, const pgp_key_t *key)
 {
-    int i;
-
-    for (i = 0; i < keyring->keyc; i++) {
+    for (unsigned i = 0; i < keyring->keyc; i++) {
         if (key == &keyring->keys[i]) {
             memmove(&keyring->keys[i],
                     &keyring->keys[i + 1],
@@ -681,7 +679,7 @@ rnp_key_store_get_key_by_grip(pgp_io_t *io, rnp_key_store_t *keyring, const uint
         fprintf(io->errs, "looking keyring %p\n", keyring);
     }
 
-    for (int i = 0; keyring && i < keyring->keyc; i++) {
+    for (unsigned i = 0; keyring && i < keyring->keyc; i++) {
         if (rnp_get_debug(__FILE__)) {
             hexdump(io->errs, "looking for grip", grip, PGP_FINGERPRINT_SIZE);
             hexdump(io->errs, "keyring grip", keyring->keys[i].grip, PGP_FINGERPRINT_SIZE);

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -498,15 +498,14 @@ format_uid_notice(char *                 buffer,
                   size_t                 size,
                   int                    flags)
 {
-    int i;
-    int n = 0;
+    unsigned n = 0;
 
     if (isrevoked(key, uid) >= 0)
         flags |= F_REVOKED;
 
     n += format_uid_line(buffer, key->uids[uid], size, flags);
 
-    for (i = 0; i < key->subsigc; i++) {
+    for (unsigned i = 0; i < key->subsigc; i++) {
         pgp_subsig_t *   subsig = &key->subsigs[i];
         const pgp_key_t *trustkey;
         unsigned         from = 0;

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -978,7 +978,7 @@ armored_data_reader(pgp_stream_t *stream,
 
     if (!stream->coalescing && stream->virtualc && stream->virtualoff < stream->virtualc) {
         n = read_partial_data(stream, dest_, length);
-        if ((n < 0) || (n == length)) {
+        if ((n < 0) || (n == (int) length)) {
             return n;
         } else {
             length -= n;

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -315,14 +315,13 @@ rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key)
 void
 rnp_cfg_free(rnp_cfg_t *cfg)
 {
-    int         i;
     const char *passwd = rnp_cfg_get(cfg, CFG_PASSWD);
 
     if (passwd) {
         pgp_forget((void *) passwd, strlen(passwd) + 1);
     }
 
-    for (i = 0; i < cfg->count; i++) {
+    for (unsigned i = 0; i < cfg->count; i++) {
         free(cfg->vals[i]);
         free(cfg->keys[i]);
     }

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -342,7 +342,7 @@ ecdsa_signverify_success(void **state)
     } curves[] = {
       {PGP_CURVE_NIST_P_256, 32}, {PGP_CURVE_NIST_P_384, 48}, {PGP_CURVE_NIST_P_521, 64}};
 
-    for (int i = 0; i < ARRAY_SIZE(curves); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(curves); i++) {
         // Generate test data. Mainly to make valgrind not to complain about unitialized data
         rnp_assert_true(rstate, get_random(message, sizeof(message)));
 
@@ -414,7 +414,7 @@ ecdh_roundtrip(void **state)
 
     rnp_assert_true(rstate, tmp_eph_key != NULL);
 
-    for (int i = 0; i < ARRAY_SIZE(curves); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(curves); i++) {
         const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_ECDH,
                                                      .hash_alg = PGP_HASH_SHA512,
                                                      .ecc = {.curve = curves[i].id}};

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -262,8 +262,8 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
     rnp_t       rnp;
     int         pipefd[2];
 
-    for (int i = 0; i < sizeof(hashAlg) / sizeof(hashAlg[0]); i++) {
-        for (int j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
+    for (size_t i = 0; i < sizeof(hashAlg) / sizeof(hashAlg[0]); i++) {
+        for (size_t j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
             /* Setting up rnp again and decrypting memory */
             printf("keystore: %s\n", keystores[j]);
             rnp_assert_ok(rstate, setup_rnp_common(&rnp, keystores[j], NULL, pipefd));
@@ -318,8 +318,8 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
     rnp_t       rnp;
     int         pipefd[2];
 
-    for (int i = 0; i < sizeof(userIds) / sizeof(userIds[0]); i++) {
-        for (int j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
+    for (size_t i = 0; i < sizeof(userIds) / sizeof(userIds[0]); i++) {
+        for (size_t j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
             /* Set the user id to be used*/
             snprintf(userId, sizeof(userId), "%s", userIds[i]);
 
@@ -552,7 +552,7 @@ ask_expert_details(rnp_t *ctx, rnp_cfg_t *ops, const char *rsp, size_t rsp_len)
         ret = false;
         goto end;
     }
-    for (int i = 0; i < rsp_len;) {
+    for (size_t i = 0; i < rsp_len;) {
         i += write(user_input_pipefd[1], rsp + i, rsp_len - i);
     }
     close(user_input_pipefd[1]);

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -183,7 +183,7 @@ main(int argc, char *argv[])
 
     /* Each test entry will invoke setup_test before running
      * and teardown_test after running. */
-    for (int i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+    for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
         tests[i].setup_func = setup_test;
         tests[i].teardown_func = teardown_test;
     }

--- a/src/tests/user-prefs.c
+++ b/src/tests/user-prefs.c
@@ -36,7 +36,7 @@ find_subsig(const pgp_key_t *key, const char *userid)
 {
     // find the userid index
     int uididx = -1;
-    for (int i = 0; i < key->uidc; i++) {
+    for (unsigned i = 0; i < key->uidc; i++) {
         if (memcmp(key->uids[i], userid, strlen(userid)) == 0) {
             uididx = i;
             break;
@@ -47,8 +47,8 @@ find_subsig(const pgp_key_t *key, const char *userid)
     }
     int subsigidx = -1;
     // find the subsig index
-    for (int i = 0; i < key->subsigc; i++) {
-        if (key->subsigs[i].uid == uididx) {
+    for (unsigned i = 0; i < key->subsigc; i++) {
+        if ((int) key->subsigs[i].uid == uididx) {
             subsigidx = i;
             break;
         }


### PR DESCRIPTION
As per discussion at https://github.com/riboseinc/rnp/pull/539#discussion_r152394006 I checked code with `-Wsign-compare`, and introduced required fixes.
This PR doesn't add changes to the streamed code to avoid merge problems since they were added in PR #539.

@dewyatt @ronaldtse @flowher  Probably we should add `-Wsign-compare` to default build options, or travis checks, what do you think?