### PR TITLE
Streamed processing improvements

### DIFF
--- a/src/lib/hash.h
+++ b/src/lib/hash.h
@@ -38,6 +38,7 @@
 #include <repgp/repgp_def.h>
 #include "types.h"
 #include "utils.h"
+#include "list.h"
 
 /**
  * Output size (in bytes) of biggest supported hash algo
@@ -77,16 +78,42 @@ void pgp_calc_mdc_hash(
 
 const char *pgp_show_hash_alg(uint8_t);
 
-/* -----------------------------------------------------------------------------
- * @brief   Returns output size of an digest algorithm
+/* @brief   Returns output size of an digest algorithm
  *
  * @param   [in] alg
  * @param   [out] output_length: must be not NULL
  *
  * @return  true if provided algorithm is supported and it's size was
  *          correctly retrieved, otherwise false
- *
--------------------------------------------------------------------------------- */
+ **/
 bool pgp_digest_length(pgp_hash_alg_t alg, size_t *output_length);
+
+/* @brief Add hash for the corresponding algorithm to the list
+ * @param hashes non-NULL pointer to the list structure
+ * @param alg hash algorithm
+ * @return true if hash was added successfully or already exists in the list.
+ *         false will be returned if memory allocation failed, or alg is not supported, or
+ *         on other error
+ **/
+bool pgp_hash_list_add(list *hashes, pgp_hash_alg_t alg);
+
+/* @brief Get hash structure for the corresponding algorithm
+ * @param hashes List of pgp_hash_t structures
+ * @param alg Hash algorithm
+ * @return pointer to the pgp_hash_t structure or NULL if list doesn't contain alg
+ **/
+const pgp_hash_t *pgp_hash_list_get(list hashes, pgp_hash_alg_t alg);
+
+/* @brief Update list of hashes with the data
+ * @param hashes List of pgp_hash_t structures
+ * @param buf buffer with data
+ * @param len number of bytes in the buffer
+ **/
+void pgp_hash_list_update(list hashes, const void *buf, size_t len);
+
+/* @brief Free the list of hashes and deallocate all internal structures
+ * @param hashes List of pgp_hash_t structures
+ **/
+void pgp_hash_list_free(list *hashes);
 
 #endif

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -57,6 +57,7 @@
 #include "defs.h"
 #include "errors.h"
 #include "memory.h"
+#include "list.h"
 #include "crypto/rsa.h"
 #include "crypto/dsa.h"
 #include "crypto/elgamal.h"
@@ -391,7 +392,7 @@ typedef struct pgp_signature_t {
     uint8_t  signer[PGP_KEY_ID_SIZE];
 
     /* v4 - only fields */
-    DYNARRAY(pgp_sig_subpkt_t, subpkt);
+    list     subpkts;
     unsigned hashed_subpkts;
 } pgp_signature_t;
 

--- a/src/librepgp/stream-armor.c
+++ b/src/librepgp/stream-armor.c
@@ -571,10 +571,10 @@ armor_parse_headers(pgp_source_t *src)
 rnp_result_t
 init_armored_src(pgp_source_t *src, pgp_source_t *readsrc)
 {
-    rnp_result_t                errcode = RNP_SUCCESS;
+    rnp_result_t                errcode = RNP_ERROR_GENERIC;
     pgp_source_armored_param_t *param;
 
-    if (!init_source_cache(src, sizeof(*param))) {
+    if (!init_src_common(src, sizeof(*param))) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
 
@@ -589,10 +589,6 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc)
     src->read = armored_src_read;
     src->close = armored_src_close;
     src->type = PGP_STREAM_ARMORED;
-    src->size = 0;
-    src->knownsize = 0;
-    src->readb = 0;
-    src->eof = 0;
 
     /* parsing armored header */
     if (!armor_parse_header(src)) {
@@ -614,7 +610,6 @@ init_armored_src(pgp_source_t *src, pgp_source_t *readsrc)
 
     /* now we are good to go with base64-encoded data */
     errcode = RNP_SUCCESS;
-    goto finish;
 
 finish:
     if (errcode != RNP_SUCCESS) {

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -299,7 +299,7 @@ bool
 init_src_common(pgp_source_t *src, size_t paramsize)
 {
     memset(src, 0, sizeof(*src));
-    
+
     if ((src->cache = calloc(1, sizeof(pgp_source_cache_t))) == NULL) {
         RNP_LOG("cache allocation failed");
         return false;
@@ -465,7 +465,7 @@ bool
 init_dst_common(pgp_dest_t *dst, size_t paramsize)
 {
     memset(dst, 0, sizeof(*dst));
-    
+
     if (paramsize > 0) {
         if ((dst->param = calloc(1, paramsize)) == NULL) {
             RNP_LOG("allocation failed");

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -87,8 +87,12 @@ typedef struct pgp_source_t {
 } pgp_source_t;
 
 /** @brief helper function to allocate memory for source's cache and param
+ *         Also fills src and param with zeroes
+ *  @param src pointer to the source structure
+ *  @param paramsize number of bytes required for src->param
+ *  @return true on success or false if memory allocation failed.
  **/
-bool init_source_cache(pgp_source_t *src, size_t paramsize);
+bool init_src_common(pgp_source_t *src, size_t paramsize);
 
 /** @brief read up to len bytes from the source
  *  While this function tries to read as much bytes as possible however it may return
@@ -186,6 +190,14 @@ typedef struct pgp_dest_t {
     uint8_t  cache[PGP_OUTPUT_CACHE_SIZE];
     unsigned clen; /* number of bytes in cache */
 } pgp_dest_t;
+
+/** @brief helper function to allocate memory for dest's param.
+ *         Initializes dst and param with zeroes as well.
+ *  @param dst dest structure
+ *  @param paramsize number of bytes required for dst->param
+ *  @return true on success, or false if memory allocation failed
+ **/
+bool init_dst_common(pgp_dest_t *dst, size_t paramsize);
 
 /** @brief write buffer to the destination
  *

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -534,7 +534,8 @@ init_encrypted_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *wr
 
     /* Configuring and writing sk-encrypted session key(s) */
     for (list_item *pi = list_front(handler->ctx->passwords); pi; pi = list_next(pi)) {
-        encrypted_add_password((rnp_symmetric_pass_info_t *)pi, dst, enckey, keylen, singlepass);
+        encrypted_add_password(
+          (rnp_symmetric_pass_info_t *) pi, dst, enckey, keylen, singlepass);
     }
 
     /* Initializing partial packet writer */


### PR DESCRIPTION
This PR includes some improvements over streamed code which I noticed but didn't include into the previous PR:
- added common initialization functions, removed duplicate zero-initializations
- replaced default RNP_SUCCES for return code (thanks to @dewyatt for noticing some time ago)
- shortcuted iteration over lists of items
- replaced DYNARRAY with list for signature subpackets
- added pgp_hash_list_* functions to use them later in streamed signing