### PR TITLE
Initialize title variable in rnp_on_signatures.

### DIFF
--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -326,7 +326,7 @@ rnp_on_signatures(pgp_parse_handler_t *handler, pgp_signature_info_t *sigs, int 
     const pgp_key_t *key;
     pgp_pubkey_t *   sigkey;
     unsigned         from;
-    char *           title;
+    char *           title = "UNKNOWN signature";
     pgp_io_t *       io = handler->ctx->rnp->io;
 
     for (int i = 0; i < count; i++) {


### PR DESCRIPTION
Just a minor thing here that my compiler has been complaining about (refuses to build).