### PR TITLE
Remove duplicate signature subpkt handling

### DIFF
--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -175,21 +175,6 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
     case PGP_PTAG_SS_KEY_EXPIRY:
         key->key.pubkey.duration = pkt->u.ss_time;
         break;
-    case PGP_PTAG_SS_ISSUER_KEY_ID:
-        SUBSIG_REQUIRED_BEFORE("ss issuer key id");
-        memcpy(&subsig->sig.info.signer_id, pkt->u.ss_issuer, sizeof(pkt->u.ss_issuer));
-        subsig->sig.info.signer_id_set = 1;
-        break;
-    case PGP_PTAG_SS_CREATION_TIME:
-        SUBSIG_REQUIRED_BEFORE("ss creation time");
-        subsig->sig.info.birthtime = pkt->u.ss_time;
-        subsig->sig.info.birthtime_set = 1;
-        break;
-    case PGP_PTAG_SS_EXPIRATION_TIME:
-        SUBSIG_REQUIRED_BEFORE("ss expiration time");
-        subsig->sig.info.duration = pkt->u.ss_time;
-        subsig->sig.info.duration_set = 1;
-        break;
     case PGP_PTAG_SS_PRIMARY_USER_ID:
         key->uid0 = key->uidc - 1;
         key->uid0_set = 1;

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -163,6 +163,8 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_load_v3_keyring_pgp),
       cmocka_unit_test(test_load_v4_keyring_pgp),
       cmocka_unit_test(test_load_keyring_and_count_pgp),
+      cmocka_unit_test(test_load_check_bitfields_and_times),
+      cmocka_unit_test(test_load_check_bitfields_and_times_v3),
       cmocka_unit_test(pgp_compress_roundtrip),
       cmocka_unit_test(test_key_unlock_pgp),
       cmocka_unit_test(test_key_protect_load_pgp),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -89,6 +89,10 @@ void test_load_v4_keyring_pgp(void **state);
 
 void test_load_keyring_and_count_pgp(void **state);
 
+void test_load_check_bitfields_and_times(void **state);
+
+void test_load_check_bitfields_and_times_v3(void **state);
+
 void pgp_compress_roundtrip(void **state);
 
 void test_key_unlock_pgp(void **state);


### PR DESCRIPTION
It looks like we inherited this from netpgp. The PGP packet parsing library already handles these particular subpackets, so the keyring loading code should not duplicate that. (We copy this stuff when handling `PGP_PTAG_CT_SIGNATURE_FOOTER`)

Also adds a couple of tests that are focused on this somewhat.