### PR TITLE
ECDSA tests against GnuPG

### DIFF
--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -1277,7 +1277,7 @@ rnp_initialize_output(rnp_ctx_t *ctx, pgp_dest_t *dst, const char *out)
             return false;
         }
 
-        return init_file_dest(dst, newname) == RNP_SUCCESS;
+        return init_file_dest(dst, newname, false) == RNP_SUCCESS;
     } else {
         return init_stdout_dest(dst) == RNP_SUCCESS;
     }

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -109,11 +109,12 @@ struct rnp_op_encrypt_st {
 
 static rnp_result_t rnp_keyring_create(rnp_ffi_t ffi, rnp_keyring_t *ring, const char *format);
 static rnp_result_t rnp_keyring_destroy(rnp_keyring_t ring);
-static bool         parse_symm_alg(const char *name, pgp_symm_alg_t *value);
-static bool         parse_compress_alg(const char *name, pgp_compression_type_t *value);
-static bool         parse_hash_alg(const char *name, pgp_hash_alg_t *value);
-static bool
-key_provider_bounce(const pgp_key_request_ctx_t *ctx, pgp_key_t **key, void *userdata);
+static bool parse_symm_alg(const char *name, pgp_symm_alg_t *value);
+static bool parse_compress_alg(const char *name, pgp_compression_type_t *value);
+static bool parse_hash_alg(const char *name, pgp_hash_alg_t *value);
+static bool key_provider_bounce(const pgp_key_request_ctx_t *ctx,
+                                pgp_key_t **                 key,
+                                void *                       userdata);
 
 rnp_result_t
 rnp_ffi_create(rnp_ffi_t *ffi, const char *pub_format, const char *sec_format)
@@ -818,7 +819,7 @@ rnp_output_to_file(rnp_output_t *output, const char *path)
     if (!*output) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
-    rnp_result_t ret = init_file_dest(&(*output)->dst, path);
+    rnp_result_t ret = init_file_dest(&(*output)->dst, path, false);
     if (ret) {
         free(*output);
         *output = NULL;
@@ -1053,9 +1054,12 @@ rnp_op_encrypt_execute(rnp_op_encrypt_t op)
       .userdata = &(struct rnp_password_cb_data){.cb_fn = op->ffi->getpasscb,
                                                  .cb_data = op->ffi->getpasscb_ctx}};
     pgp_write_handler_t handler = {
-      .password_provider = &provider, .ctx = &op->rnpctx, .param = NULL,
-      .key_provider = &(pgp_key_provider_t){.callback = key_provider_bounce, .userdata = op->ffi},
-     };
+      .password_provider = &provider,
+      .ctx = &op->rnpctx,
+      .param = NULL,
+      .key_provider =
+        &(pgp_key_provider_t){.callback = key_provider_bounce, .userdata = op->ffi},
+    };
     rnp_result_t ret = rnp_encrypt_src(&handler, &op->input->src, &op->output->dst);
     op->output->keep = ret == RNP_SUCCESS;
     op->input = NULL;

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -176,7 +176,8 @@ rnp_key_store_load_from_file(pgp_io_t *       io,
     if (key_store->format == G10_KEY_STORE) {
         dir = opendir(key_store->path);
         if (dir == NULL) {
-            fprintf(io->errs, "Can't open G10 directory: %s\n", strerror(errno));
+            fprintf(
+              io->errs, "Can't open G10 directory %s: %s\n", key_store->path, strerror(errno));
             return false;
         }
 

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -570,7 +570,7 @@ file_dst_close(pgp_dest_t *dst, bool discard)
 }
 
 rnp_result_t
-init_file_dest(pgp_dest_t *dst, const char *path)
+init_file_dest(pgp_dest_t *dst, const char *path, bool overwrite)
 {
     int                    fd;
     int                    flags;
@@ -582,12 +582,13 @@ init_file_dest(pgp_dest_t *dst, const char *path)
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if (stat(path, &st) == 0) {
+    if (!overwrite && !stat(path, &st)) {
         RNP_LOG("file already exists: '%s'", path);
         return RNP_ERROR_WRITE;
     }
 
-    flags = O_WRONLY | O_CREAT | O_EXCL;
+    flags = O_WRONLY | O_CREAT;
+    flags |= overwrite ? O_TRUNC : O_EXCL;
 #ifdef O_BINARY
     flags |= O_BINARY;
 #endif

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -219,9 +219,10 @@ void dst_close(pgp_dest_t *dst, bool discard);
 /** @brief init file destination
  *  @param dst pre-allocated dest structure
  *  @param path path to the file
+ *  @param overwrite overwrite existing file
  *  @return RNP_SUCCESS or error code
  **/
-rnp_result_t init_file_dest(pgp_dest_t *dst, const char *path);
+rnp_result_t init_file_dest(pgp_dest_t *dst, const char *path, bool overwrite);
 
 /** @brief init stdout destination
  *  @param dst pre-allocated dest structure

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -65,7 +65,8 @@
 #define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
 #define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
 #define CFG_KEYSTORE_DISABLED \
-    "disable_keystore" /* indicates wether keystore must be initialized */
+    "disable_keystore"    /* indicates wether keystore must be initialized */
+#define CFG_FORCE "force" /* force command to succeed operation */
 
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -37,6 +37,7 @@ typedef enum {
     OPT_FORMAT,
     OPT_EXPERT,
     OPT_OUTPUT,
+    OPT_FORCE,
 
     /* debug */
     OPT_DEBUG

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -36,6 +36,7 @@ typedef enum {
     OPT_CIPHER,
     OPT_FORMAT,
     OPT_EXPERT,
+    OPT_OUTPUT,
 
     /* debug */
     OPT_DEBUG

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -979,13 +979,6 @@ class SignECDSA(Sign):
         self.rnp.password = self.gpg.password = PASSWORD
         self.rnp.userid = self.gpg.userid = 'ecdsatest@secure.gov'
 
-        # Workaround
-        tmp = Rnp(RNPDIR, RNP, RNPK)
-        cmd = SignECDSA.RNP_GENERATE_ECDSA_PATTERN.format(1)
-        tmp.password = PASSWORD
-        tmp.userid = 'bad@mail.com'
-        tmp.generte_key_batch(cmd)
-
     def test_sign_P256(self):
         cmd = SignECDSA.RNP_GENERATE_ECDSA_PATTERN.format(1)
         self._rnp_sign_verify(self.rnp, self.gpg, 1, cmd)

--- a/src/tests/gnupg.py
+++ b/src/tests/gnupg.py
@@ -1,0 +1,87 @@
+import logging
+import copy
+
+class GnuPG(object):
+    def __init__(self, homedir, gpg_path):
+        self.__gpg = gpg_path
+        self.__common_params = ['--homedir', homedir, '--yes']
+        self.__password = None
+        self.__userid = None
+
+    @property
+    def bin(self):
+        return self.__gpg
+
+    @property
+    def common_params(self):
+        import copy
+        return copy.copy(self.__common_params)
+
+    @property
+    def password(self):
+        return self.__password
+
+    @property
+    def userid(self):
+        return self.__userid
+
+    @userid.setter
+    def userid(self, val):
+        self.__userid = val
+
+    @password.setter
+    def password(self, val):
+        self.__password = val
+
+    def _run(self, cmd, batch_input = None):
+        import subprocess
+        logging.debug((' '.join(cmd)).strip())
+        process = subprocess.Popen(cmd,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        output, errout = process.communicate(input = batch_input)
+        retcode = process.poll()
+        logging.debug(errout.strip())
+        logging.debug(output.strip())
+        return retcode == 0
+
+    def generte_key_batch(self, batch_input):
+        params = ['--gen-key', '--expert', '--batch',
+                  '--pinentry-mode', 'loopback'] + self.common_params
+        if self.password:
+            params += ['--passphrase', self.password]
+        return self._run([self.__gpg] + params, batch_input)
+
+    def export_key(self, out_filename, secret=False):
+        params = ['--armor']
+        if secret:
+            params += ['--pinentry-mode', 'loopback', '--export-secret-key']
+            params += ['--passphrase', self.password]
+        else:
+           params = ['--export']
+
+        params = self.common_params + \
+            params + ['-o', out_filename, self.userid]
+        return self._run([self.__gpg] + params)
+
+    def import_key(self, filename, secret = False):
+        params = self.common_params
+        if secret:
+            params += ['--trust-model', 'always']
+            params += ['--batch']
+            params += ['--passphrase', self.password]
+        params += ['--import', filename]
+        return self._run([self.__gpg] + params)
+
+    def sign(self, out, input):
+        params = self.common_params
+        params += ['--passphrase', self.password]
+        params += ['--batch']
+        params += ['--pinentry-mode', 'loopback']
+        params += ['-o', out]
+        params += ['--sign', input]
+        return self._run([self.__gpg] + params)
+
+    def verify(self, input):
+        params = self.common_params
+        params += ['--verify', input]
+        return self._run([self.__gpg] + params)

--- a/src/tests/rnp.py
+++ b/src/tests/rnp.py
@@ -1,0 +1,99 @@
+from cli_common import (
+    pswd_pipe
+)
+
+import logging
+import copy
+
+class Rnp(object):
+    def __init__(self, homedir, rnp_path, rnpkey_path):
+        self.__gpg = rnp_path
+        self.__key_mgm_bin = rnpkey_path
+        self.__common_params = ['--homedir', homedir]
+        self.__password = None
+        self.__userid = None
+
+    @property
+    def key_mgm_bin(self):
+        return self.__key_mgm_bin
+
+    @property
+    def rnp_bin(self):
+        return self.__gpg
+
+    @property
+    def common_params(self):
+        import copy
+        return copy.copy(self.__common_params)
+
+    @property
+    def password(self):
+        return self.__password
+
+    @password.setter
+    def password(self, val):
+        self.__password = val
+
+    @property
+    def userid(self):
+        return self.__userid
+
+    @userid.setter
+    def userid(self, val):
+        self.__userid = val
+
+    def _run(self, cmd, batch_input = None):
+        import subprocess
+        logging.debug((' '.join(cmd)).strip())
+        process = subprocess.Popen(cmd,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
+        output, errout = process.communicate(input = batch_input)
+        retcode = process.poll()
+        logging.debug(errout.strip())
+        logging.debug(output.strip())
+        return retcode == 0
+
+    def generte_key_batch(self, batch_input):
+        pipe = pswd_pipe(self.__password)
+        params = self.common_params
+        params += ['--generate-key', '--expert']
+        params += ['--pass-fd', str(pipe)]
+        params += ['--userid', self.userid]
+        try:
+            ret = self._run([self.__key_mgm_bin] + params, batch_input)
+        finally:
+            import os
+            os.close(pipe)
+        return ret
+
+    def export_key(self, output, secure = False):
+        params = self.common_params
+        params += ["--output", output]
+        params += ["--userid", self.userid]
+        params += ["--force"]
+        params += ["--export-key", self.userid]
+        return self._run([self.key_mgm_bin] + params)
+
+    def import_key(self, filename):
+        params = self.common_params
+        params += ['--import-key', filename]
+        return self._run([self.key_mgm_bin] + params)
+
+    def sign(self, output, input):
+        pipe = pswd_pipe(self.password)
+        params = self.common_params
+        params += ['--pass-fd', str(pipe)]
+        params += ['--userid', self.userid]
+        params += ['--sign', input]
+        params += ['--output', output]
+        try:
+            ret = self._run([self.rnp_bin] + params)
+        finally:
+            import os
+            os.close(pipe)
+        return ret
+
+    def verify(self, input):
+        params = self.common_params
+        params += ['--verify', input]
+        return self._run([self.rnp_bin] + params)


### PR DESCRIPTION
Implements ECDSA tests against GnuPG
* Introduces two wrappers around rnp (rnp.py) and gpg (gnupg.py)
* Tests sign with either gpg or rnp and verify with the other one
* ``rnpkey`` got possibility to export key to file 

Closes #516 