### PR TITLE
Cleanup in bn.c - automatic changes to cleanup interface

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -105,8 +105,8 @@ int
 pgp_decrypt_decode_mpi(rng_t *             rng,
                        uint8_t *           buf,
                        size_t              buflen,
-                       const BIGNUM *      g_to_k,
-                       const BIGNUM *      encmpi,
+                       const bignum_t *    g_to_k,
+                       const bignum_t *    encmpi,
                        const pgp_seckey_t *seckey)
 {
     uint8_t encmpibuf[RNP_BUFSIZ] = {0};

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -114,7 +114,7 @@ pgp_decrypt_decode_mpi(rng_t *             rng,
     int     n;
     size_t  encmpi_byte_len;
 
-    if (!BN_num_bytes(encmpi, &encmpi_byte_len)) {
+    if (!bn_num_bytes(encmpi, &encmpi_byte_len)) {
         RNP_LOG("Bad param: encmpi");
         return -1;
     }
@@ -126,7 +126,7 @@ pgp_decrypt_decode_mpi(rng_t *             rng,
     }
     switch (seckey->pubkey.alg) {
     case PGP_PKA_RSA:
-        BN_bn2bin(encmpi, encmpibuf);
+        bn_bn2bin(encmpi, encmpibuf);
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "encrypted", encmpibuf, 16);
         }
@@ -146,7 +146,7 @@ pgp_decrypt_decode_mpi(rng_t *             rng,
         }
         return n;
     case PGP_PKA_SM2:
-        BN_bn2bin(encmpi, encmpibuf);
+        bn_bn2bin(encmpi, encmpibuf);
 
         size_t       out_len = buflen;
         rnp_result_t err = pgp_sm2_decrypt(buf,
@@ -164,8 +164,8 @@ pgp_decrypt_decode_mpi(rng_t *             rng,
 
     case PGP_PKA_DSA:
     case PGP_PKA_ELGAMAL:
-        (void) BN_bn2bin(g_to_k, gkbuf);
-        (void) BN_bn2bin(encmpi, encmpibuf);
+        (void) bn_bn2bin(g_to_k, gkbuf);
+        (void) bn_bn2bin(encmpi, encmpibuf);
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "encrypted", encmpibuf, 16);
         }
@@ -188,7 +188,7 @@ pgp_decrypt_decode_mpi(rng_t *             rng,
     case PGP_PKA_ECDH: {
         pgp_fingerprint_t fingerprint;
         size_t            out_len = buflen;
-        if (BN_bn2bin(encmpi, encmpibuf)) {
+        if (bn_bn2bin(encmpi, encmpibuf)) {
             RNP_LOG("Can't find session key");
             return -1;
         }

--- a/src/lib/crypto.h
+++ b/src/lib/crypto.h
@@ -148,7 +148,7 @@ int  pgp_reader_push_hash(pgp_stream_t *, pgp_hash_t *);
 void pgp_reader_pop_hash(pgp_stream_t *);
 
 int pgp_decrypt_decode_mpi(
-  rng_t *, uint8_t *, size_t, const BIGNUM *, const BIGNUM *, const pgp_seckey_t *);
+  rng_t *, uint8_t *, size_t, const bignum_t *, const bignum_t *, const pgp_seckey_t *);
 
 /* Encrypt everything that's written */
 struct pgp_key_data;

--- a/src/lib/crypto/bn.c
+++ b/src/lib/crypto/bn.c
@@ -44,13 +44,13 @@
 /* these wrappers also check the arguments passed for sanity */
 
 PGPV_BIGNUM *
-PGPV_BN_bin2bn(const uint8_t *data, int len, PGPV_BIGNUM *ret)
+bn_bin2bn(const uint8_t *data, int len, PGPV_BIGNUM *ret)
 {
     if (data == NULL) {
-        return PGPV_BN_new();
+        return bn_new();
     }
     if (ret == NULL) {
-        ret = PGPV_BN_new();
+        ret = bn_new();
     }
 
     if (ret == NULL) {
@@ -62,7 +62,7 @@ PGPV_BN_bin2bn(const uint8_t *data, int len, PGPV_BIGNUM *ret)
 
 /* store in unsigned [big endian] format */
 int
-PGPV_BN_bn2bin(const PGPV_BIGNUM *a, unsigned char *b)
+bn_bn2bin(const PGPV_BIGNUM *a, unsigned char *b)
 {
     if (a == NULL || b == NULL) {
         return -1;
@@ -72,7 +72,7 @@ PGPV_BN_bn2bin(const PGPV_BIGNUM *a, unsigned char *b)
 }
 
 PGPV_BIGNUM *
-PGPV_BN_new(void)
+bn_new(void)
 {
     PGPV_BIGNUM *a;
 
@@ -85,7 +85,7 @@ PGPV_BN_new(void)
 }
 
 void
-PGPV_BN_free(PGPV_BIGNUM *a)
+bn_free(PGPV_BIGNUM *a)
 {
     if (a != NULL) {
         botan_mp_destroy(a->mp);
@@ -95,7 +95,7 @@ PGPV_BN_free(PGPV_BIGNUM *a)
 
 /* copy, b = a */
 int
-PGPV_BN_copy(PGPV_BIGNUM *to, const PGPV_BIGNUM *from)
+bn_copy(PGPV_BIGNUM *to, const PGPV_BIGNUM *from)
 {
     if (from == NULL || to == NULL) {
         return -1;
@@ -104,21 +104,21 @@ PGPV_BN_copy(PGPV_BIGNUM *to, const PGPV_BIGNUM *from)
 }
 
 PGPV_BIGNUM *
-PGPV_BN_dup(const PGPV_BIGNUM *a)
+bn_dup(const PGPV_BIGNUM *a)
 {
     PGPV_BIGNUM *ret;
 
     if (a == NULL) {
         return NULL;
     }
-    if ((ret = PGPV_BN_new()) != NULL) {
-        PGPV_BN_copy(ret, a);
+    if ((ret = bn_new()) != NULL) {
+        bn_copy(ret, a);
     }
     return ret;
 }
 
 void
-PGPV_BN_clear(PGPV_BIGNUM *a)
+bn_clear(PGPV_BIGNUM *a)
 {
     if (a) {
         botan_mp_clear(a->mp);
@@ -126,14 +126,14 @@ PGPV_BN_clear(PGPV_BIGNUM *a)
 }
 
 void
-PGPV_BN_clear_free(PGPV_BIGNUM *a)
+bn_clear_free(PGPV_BIGNUM *a)
 {
     /* Same as BN_free in Botan */
-    PGPV_BN_free(a);
+    bn_free(a);
 }
 
 bool
-BN_num_bits(const PGPV_BIGNUM *a, size_t *bits)
+bn_num_bits(const PGPV_BIGNUM *a, size_t *bits)
 {
     if (!a || botan_mp_num_bits(a->mp, bits)) {
         return false;
@@ -142,9 +142,9 @@ BN_num_bits(const PGPV_BIGNUM *a, size_t *bits)
 }
 
 bool
-BN_num_bytes(const PGPV_BIGNUM *a, size_t *bits)
+bn_num_bytes(const PGPV_BIGNUM *a, size_t *bits)
 {
-    if (BN_num_bits(a, bits)) {
+    if (bn_num_bits(a, bits)) {
         *bits = BITS_TO_BYTES(*bits);
         return true;
     }
@@ -152,7 +152,7 @@ BN_num_bytes(const PGPV_BIGNUM *a, size_t *bits)
 }
 
 int
-PGPV_BN_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
+bn_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 {
     int cmp_result;
 
@@ -165,7 +165,7 @@ PGPV_BN_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 }
 
 int
-PGPV_BN_print_fp(FILE *fp, const PGPV_BIGNUM *a)
+bn_print_fp(FILE *fp, const PGPV_BIGNUM *a)
 {
     int    ret;
     size_t num_bytes;
@@ -190,7 +190,7 @@ PGPV_BN_print_fp(FILE *fp, const PGPV_BIGNUM *a)
 }
 
 char *
-PGPV_BN_bn2hex(const PGPV_BIGNUM *a)
+bn_bn2hex(const PGPV_BIGNUM *a)
 {
     char *       out;
     size_t       out_len;
@@ -223,13 +223,13 @@ PGPV_BN_bn2hex(const PGPV_BIGNUM *a)
 
 /* hash a bignum, possibly padded - first length, then string itself */
 size_t
-BN_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash)
+bn_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash)
 {
     uint8_t *bn;
     size_t   len;
     size_t   padbyte;
 
-    if (!BN_num_bytes(bignum, &len) || (len > UINT32_MAX)) {
+    if (!bn_num_bytes(bignum, &len) || (len > UINT32_MAX)) {
         RNP_LOG("Wrong input");
         return 0;
     }
@@ -243,7 +243,7 @@ BN_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash)
         return 0;
     }
 
-    BN_bn2bin(bignum, bn + 1);
+    bn_bn2bin(bignum, bn + 1);
     bn[0] = 0x0;
     padbyte = !!(bn[1] & 0x80);
     len += padbyte;
@@ -256,7 +256,7 @@ BN_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash)
 }
 
 int
-PGPV_BN_is_zero(const PGPV_BIGNUM *n)
+bn_is_zero(const PGPV_BIGNUM *n)
 {
     if (n == NULL) {
         return -1;
@@ -265,7 +265,7 @@ PGPV_BN_is_zero(const PGPV_BIGNUM *n)
 }
 
 int
-PGPV_BN_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w)
+bn_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w)
 {
     if (a == NULL) {
         return -1;
@@ -275,7 +275,7 @@ PGPV_BN_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w)
 }
 
 int
-PGPV_BN_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P)
+bn_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P)
 {
     if (Y == NULL || G == NULL || X == NULL || P == NULL) {
         return -1;

--- a/src/lib/crypto/bn.c
+++ b/src/lib/crypto/bn.c
@@ -1,4 +1,4 @@
-/*-
+/*
  * Copyright (c) 2012 Alistair Crooks <agc@NetBSD.org>
  * All rights reserved.
  *
@@ -265,7 +265,7 @@ bn_is_zero(const bignum_t *n)
 }
 
 int
-bn_set_word(bignum_t *a, PGPV_BN_ULONG w)
+bn_set_word(bignum_t *a, uint32_t w)
 {
     if (a == NULL) {
         return -1;

--- a/src/lib/crypto/bn.c
+++ b/src/lib/crypto/bn.c
@@ -36,15 +36,15 @@
 
 /**************************************************************************/
 
-/* OpenSSL BIGNUM emulation layer */
+/* OpenSSL bignum_t emulation layer */
 
 /* essentiually, these are just wrappers around the botan functions */
 /* usually the order of args changes */
-/* the PGPV_BIGNUM API tends to have more const poisoning */
+/* the bignum_t API tends to have more const poisoning */
 /* these wrappers also check the arguments passed for sanity */
 
-PGPV_BIGNUM *
-bn_bin2bn(const uint8_t *data, int len, PGPV_BIGNUM *ret)
+bignum_t *
+bn_bin2bn(const uint8_t *data, int len, bignum_t *ret)
 {
     if (data == NULL) {
         return bn_new();
@@ -62,7 +62,7 @@ bn_bin2bn(const uint8_t *data, int len, PGPV_BIGNUM *ret)
 
 /* store in unsigned [big endian] format */
 int
-bn_bn2bin(const PGPV_BIGNUM *a, unsigned char *b)
+bn_bn2bin(const bignum_t *a, unsigned char *b)
 {
     if (a == NULL || b == NULL) {
         return -1;
@@ -71,10 +71,10 @@ bn_bn2bin(const PGPV_BIGNUM *a, unsigned char *b)
     return botan_mp_to_bin(a->mp, b);
 }
 
-PGPV_BIGNUM *
+bignum_t *
 bn_new(void)
 {
-    PGPV_BIGNUM *a;
+    bignum_t *a;
 
     a = calloc(1, sizeof(*a));
     if (a == NULL) {
@@ -85,7 +85,7 @@ bn_new(void)
 }
 
 void
-bn_free(PGPV_BIGNUM *a)
+bn_free(bignum_t *a)
 {
     if (a != NULL) {
         botan_mp_destroy(a->mp);
@@ -95,7 +95,7 @@ bn_free(PGPV_BIGNUM *a)
 
 /* copy, b = a */
 int
-bn_copy(PGPV_BIGNUM *to, const PGPV_BIGNUM *from)
+bn_copy(bignum_t *to, const bignum_t *from)
 {
     if (from == NULL || to == NULL) {
         return -1;
@@ -103,10 +103,10 @@ bn_copy(PGPV_BIGNUM *to, const PGPV_BIGNUM *from)
     return botan_mp_set_from_mp(to->mp, from->mp);
 }
 
-PGPV_BIGNUM *
-bn_dup(const PGPV_BIGNUM *a)
+bignum_t *
+bn_dup(const bignum_t *a)
 {
-    PGPV_BIGNUM *ret;
+    bignum_t *ret;
 
     if (a == NULL) {
         return NULL;
@@ -118,7 +118,7 @@ bn_dup(const PGPV_BIGNUM *a)
 }
 
 void
-bn_clear(PGPV_BIGNUM *a)
+bn_clear(bignum_t *a)
 {
     if (a) {
         botan_mp_clear(a->mp);
@@ -126,14 +126,14 @@ bn_clear(PGPV_BIGNUM *a)
 }
 
 void
-bn_clear_free(PGPV_BIGNUM *a)
+bn_clear_free(bignum_t *a)
 {
     /* Same as BN_free in Botan */
     bn_free(a);
 }
 
 bool
-bn_num_bits(const PGPV_BIGNUM *a, size_t *bits)
+bn_num_bits(const bignum_t *a, size_t *bits)
 {
     if (!a || botan_mp_num_bits(a->mp, bits)) {
         return false;
@@ -142,7 +142,7 @@ bn_num_bits(const PGPV_BIGNUM *a, size_t *bits)
 }
 
 bool
-bn_num_bytes(const PGPV_BIGNUM *a, size_t *bits)
+bn_num_bytes(const bignum_t *a, size_t *bits)
 {
     if (bn_num_bits(a, bits)) {
         *bits = BITS_TO_BYTES(*bits);
@@ -152,7 +152,7 @@ bn_num_bytes(const PGPV_BIGNUM *a, size_t *bits)
 }
 
 int
-bn_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
+bn_cmp(bignum_t *a, bignum_t *b)
 {
     int cmp_result;
 
@@ -165,7 +165,7 @@ bn_cmp(PGPV_BIGNUM *a, PGPV_BIGNUM *b)
 }
 
 int
-bn_print_fp(FILE *fp, const PGPV_BIGNUM *a)
+bn_print_fp(FILE *fp, const bignum_t *a)
 {
     int    ret;
     size_t num_bytes;
@@ -190,7 +190,7 @@ bn_print_fp(FILE *fp, const PGPV_BIGNUM *a)
 }
 
 char *
-bn_bn2hex(const PGPV_BIGNUM *a)
+bn_bn2hex(const bignum_t *a)
 {
     char *       out;
     size_t       out_len;
@@ -223,7 +223,7 @@ bn_bn2hex(const PGPV_BIGNUM *a)
 
 /* hash a bignum, possibly padded - first length, then string itself */
 size_t
-bn_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash)
+bn_hash(const bignum_t *bignum, pgp_hash_t *hash)
 {
     uint8_t *bn;
     size_t   len;
@@ -256,7 +256,7 @@ bn_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash)
 }
 
 int
-bn_is_zero(const PGPV_BIGNUM *n)
+bn_is_zero(const bignum_t *n)
 {
     if (n == NULL) {
         return -1;
@@ -265,7 +265,7 @@ bn_is_zero(const PGPV_BIGNUM *n)
 }
 
 int
-bn_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w)
+bn_set_word(bignum_t *a, PGPV_BN_ULONG w)
 {
     if (a == NULL) {
         return -1;
@@ -275,7 +275,7 @@ bn_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w)
 }
 
 int
-bn_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P)
+bn_mod_exp(bignum_t *Y, bignum_t *G, bignum_t *X, bignum_t *P)
 {
     if (Y == NULL || G == NULL || X == NULL || P == NULL) {
         return -1;

--- a/src/lib/crypto/bn.h
+++ b/src/lib/crypto/bn.h
@@ -35,13 +35,11 @@ typedef struct pgp_hash_t       pgp_hash_t;
 typedef uint32_t                PGPV_BN_ULONG;
 
 /*
- * PGPV_BIGNUM struct
+ * bignum_t struct
  */
-typedef struct PGPV_BIGNUM_st {
+typedef struct bignum_t_st {
     botan_mp_t mp;
-} PGPV_BIGNUM;
-
-#define BIGNUM PGPV_BIGNUM
+} bignum_t;
 
 #define MP_LT -1
 #define MP_EQ 0
@@ -57,38 +55,38 @@ typedef struct PGPV_BIGNUM_st {
 
 /*********************************/
 
-PGPV_BIGNUM *bn_new(void);
-PGPV_BIGNUM *bn_dup(const PGPV_BIGNUM * /*a*/);
-int          bn_copy(PGPV_BIGNUM * /*b*/, const PGPV_BIGNUM * /*a*/);
-char *bn_bn2hex(const PGPV_BIGNUM *a);
-void bn_init(PGPV_BIGNUM * /*a*/);
-void bn_free(PGPV_BIGNUM * /*a*/);
-void bn_clear(PGPV_BIGNUM * /*a*/);
-void bn_clear_free(PGPV_BIGNUM * /*a*/);
+bignum_t *bn_new(void);
+bignum_t *bn_dup(const bignum_t * /*a*/);
+int       bn_copy(bignum_t * /*b*/, const bignum_t * /*a*/);
+char *bn_bn2hex(const bignum_t *a);
+void bn_init(bignum_t * /*a*/);
+void bn_free(bignum_t * /*a*/);
+void bn_clear(bignum_t * /*a*/);
+void bn_clear_free(bignum_t * /*a*/);
 
-int bn_cmp(PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
+int bn_cmp(bignum_t * /*a*/, bignum_t * /*b*/);
 
-PGPV_BIGNUM *bn_bin2bn(const uint8_t * /*buf*/, int /*size*/, PGPV_BIGNUM * /*bn*/);
-int          bn_bn2bin(const PGPV_BIGNUM * /*a*/, unsigned char * /*b*/);
-int          bn_print_fp(FILE * /*fp*/, const PGPV_BIGNUM * /*a*/);
-int bn_is_zero(const PGPV_BIGNUM *n);
-int bn_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w);
-int bn_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P);
+bignum_t *bn_bin2bn(const uint8_t * /*buf*/, int /*size*/, bignum_t * /*bn*/);
+int       bn_bn2bin(const bignum_t * /*a*/, unsigned char * /*b*/);
+int       bn_print_fp(FILE * /*fp*/, const bignum_t * /*a*/);
+int bn_is_zero(const bignum_t *n);
+int bn_set_word(bignum_t *a, PGPV_BN_ULONG w);
+int bn_mod_exp(bignum_t *Y, bignum_t *G, bignum_t *X, bignum_t *P);
 
 /*
- * @param a Initialized PGPV_BIGNUM structure
+ * @param a Initialized bignum_t structure
  * @param bits [out] bitlength of a
  *
  * @returns true on success, otherwise false
  */
-bool bn_num_bits(const PGPV_BIGNUM *a, size_t *bits);
+bool bn_num_bits(const bignum_t *a, size_t *bits);
 /*
- * @param a Initialized PGPV_BIGNUM structure
+ * @param a Initialized bignum_t structure
  * @param bytes [out] byte length of a
  *
  * @returns true on success, otherwise false
  */
-bool bn_num_bytes(const PGPV_BIGNUM *a, size_t *bytes);
+bool bn_num_bytes(const bignum_t *a, size_t *bytes);
 
 /*
  * @brief Produces hash of any size bignum.
@@ -98,6 +96,6 @@ bool bn_num_bytes(const PGPV_BIGNUM *a, size_t *bytes);
  *
  * @returns size of hashed data, or 0 on error
  */
-size_t bn_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash);
+size_t bn_hash(const bignum_t *bignum, pgp_hash_t *hash);
 
 #endif

--- a/src/lib/crypto/bn.h
+++ b/src/lib/crypto/bn.h
@@ -30,27 +30,6 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#define USE_BN_INTERFACE
-
-#ifdef USE_BN_INTERFACE
-#define BIGNUM PGPV_BIGNUM
-#define BN_new PGPV_BN_new
-#define BN_dup PGPV_BN_dup
-#define BN_bin2bn PGPV_BN_bin2bn
-#define BN_copy PGPV_BN_copy
-#define BN_init PGPV_BN_init
-#define BN_free PGPV_BN_free
-#define BN_clear PGPV_BN_clear
-#define BN_clear_free PGPV_BN_clear_free
-#define BN_cmp PGPV_BN_cmp
-#define BN_bn2bin PGPV_BN_bn2bin
-#define BN_print_fp PGPV_BN_print_fp
-#define BN_bn2hex PGPV_BN_bn2hex
-#define BN_is_zero PGPV_BN_is_zero
-#define BN_set_word PGPV_BN_set_word
-#define BN_mod_exp PGPV_BN_mod_exp
-#endif /* USE_BN_INTERFACE */
-
 typedef struct botan_mp_struct *botan_mp_t;
 typedef struct pgp_hash_t       pgp_hash_t;
 typedef uint32_t                PGPV_BN_ULONG;
@@ -61,6 +40,8 @@ typedef uint32_t                PGPV_BN_ULONG;
 typedef struct PGPV_BIGNUM_st {
     botan_mp_t mp;
 } PGPV_BIGNUM;
+
+#define BIGNUM PGPV_BIGNUM
 
 #define MP_LT -1
 #define MP_EQ 0
@@ -76,23 +57,23 @@ typedef struct PGPV_BIGNUM_st {
 
 /*********************************/
 
-PGPV_BIGNUM *PGPV_BN_new(void);
-PGPV_BIGNUM *PGPV_BN_dup(const PGPV_BIGNUM * /*a*/);
-int          PGPV_BN_copy(PGPV_BIGNUM * /*b*/, const PGPV_BIGNUM * /*a*/);
-char *PGPV_BN_bn2hex(const PGPV_BIGNUM *a);
-void PGPV_BN_init(PGPV_BIGNUM * /*a*/);
-void PGPV_BN_free(PGPV_BIGNUM * /*a*/);
-void PGPV_BN_clear(PGPV_BIGNUM * /*a*/);
-void PGPV_BN_clear_free(PGPV_BIGNUM * /*a*/);
+PGPV_BIGNUM *bn_new(void);
+PGPV_BIGNUM *bn_dup(const PGPV_BIGNUM * /*a*/);
+int          bn_copy(PGPV_BIGNUM * /*b*/, const PGPV_BIGNUM * /*a*/);
+char *bn_bn2hex(const PGPV_BIGNUM *a);
+void bn_init(PGPV_BIGNUM * /*a*/);
+void bn_free(PGPV_BIGNUM * /*a*/);
+void bn_clear(PGPV_BIGNUM * /*a*/);
+void bn_clear_free(PGPV_BIGNUM * /*a*/);
 
-int PGPV_BN_cmp(PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
+int bn_cmp(PGPV_BIGNUM * /*a*/, PGPV_BIGNUM * /*b*/);
 
-PGPV_BIGNUM *PGPV_BN_bin2bn(const uint8_t * /*buf*/, int /*size*/, PGPV_BIGNUM * /*bn*/);
-int          PGPV_BN_bn2bin(const PGPV_BIGNUM * /*a*/, unsigned char * /*b*/);
-int          PGPV_BN_print_fp(FILE * /*fp*/, const PGPV_BIGNUM * /*a*/);
-int PGPV_BN_is_zero(const PGPV_BIGNUM *n);
-int PGPV_BN_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w);
-int PGPV_BN_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P);
+PGPV_BIGNUM *bn_bin2bn(const uint8_t * /*buf*/, int /*size*/, PGPV_BIGNUM * /*bn*/);
+int          bn_bn2bin(const PGPV_BIGNUM * /*a*/, unsigned char * /*b*/);
+int          bn_print_fp(FILE * /*fp*/, const PGPV_BIGNUM * /*a*/);
+int bn_is_zero(const PGPV_BIGNUM *n);
+int bn_set_word(PGPV_BIGNUM *a, PGPV_BN_ULONG w);
+int bn_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM *P);
 
 /*
  * @param a Initialized PGPV_BIGNUM structure
@@ -100,14 +81,14 @@ int PGPV_BN_mod_exp(PGPV_BIGNUM *Y, PGPV_BIGNUM *G, PGPV_BIGNUM *X, PGPV_BIGNUM 
  *
  * @returns true on success, otherwise false
  */
-bool BN_num_bits(const PGPV_BIGNUM *a, size_t *bits);
+bool bn_num_bits(const PGPV_BIGNUM *a, size_t *bits);
 /*
  * @param a Initialized PGPV_BIGNUM structure
  * @param bytes [out] byte length of a
  *
  * @returns true on success, otherwise false
  */
-bool BN_num_bytes(const PGPV_BIGNUM *a, size_t *bytes);
+bool bn_num_bytes(const PGPV_BIGNUM *a, size_t *bytes);
 
 /*
  * @brief Produces hash of any size bignum.
@@ -117,6 +98,6 @@ bool BN_num_bytes(const PGPV_BIGNUM *a, size_t *bytes);
  *
  * @returns size of hashed data, or 0 on error
  */
-size_t BN_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash);
+size_t bn_hash(const PGPV_BIGNUM *bignum, pgp_hash_t *hash);
 
 #endif

--- a/src/lib/crypto/bn.h
+++ b/src/lib/crypto/bn.h
@@ -32,7 +32,6 @@
 
 typedef struct botan_mp_struct *botan_mp_t;
 typedef struct pgp_hash_t       pgp_hash_t;
-typedef uint32_t                PGPV_BN_ULONG;
 
 /*
  * bignum_t struct
@@ -70,7 +69,7 @@ bignum_t *bn_bin2bn(const uint8_t * /*buf*/, int /*size*/, bignum_t * /*bn*/);
 int       bn_bn2bin(const bignum_t * /*a*/, unsigned char * /*b*/);
 int       bn_print_fp(FILE * /*fp*/, const bignum_t * /*a*/);
 int bn_is_zero(const bignum_t *n);
-int bn_set_word(bignum_t *a, PGPV_BN_ULONG w);
+int bn_set_word(bignum_t *a, uint32_t w);
 int bn_mod_exp(bignum_t *Y, bignum_t *G, bignum_t *X, bignum_t *P);
 
 /*

--- a/src/lib/crypto/dsa.c
+++ b/src/lib/crypto/dsa.c
@@ -85,8 +85,8 @@ DSA_SIG_new()
 {
     DSA_SIG *sig = calloc(1, sizeof(DSA_SIG));
     if (sig) {
-        sig->r = BN_new();
-        sig->s = BN_new();
+        sig->r = bn_new();
+        sig->s = bn_new();
     }
     return sig;
 }
@@ -95,8 +95,8 @@ void
 DSA_SIG_free(DSA_SIG *sig)
 {
     if (sig) {
-        BN_clear_free(sig->r);
-        BN_clear_free(sig->s);
+        bn_clear_free(sig->r);
+        bn_clear_free(sig->s);
         free(sig);
     }
 }
@@ -118,8 +118,8 @@ pgp_dsa_verify(const uint8_t *         hash,
     botan_mp_num_bytes(dsa->q->mp, &q_bytes);
 
     encoded_signature = calloc(2, q_bytes);
-    BN_bn2bin(sig->r, encoded_signature);
-    BN_bn2bin(sig->s, encoded_signature + q_bytes);
+    bn_bn2bin(sig->r, encoded_signature);
+    bn_bn2bin(sig->s, encoded_signature + q_bytes);
 
     botan_pk_op_verify_create(&verify_op, dsa_key, "Raw", 0);
     botan_pk_op_verify_update(verify_op, hash, hash_length);

--- a/src/lib/crypto/dsa.h
+++ b/src/lib/crypto/dsa.h
@@ -63,22 +63,22 @@
  * \see RFC4880 5.5.2
  */
 typedef struct {
-    BIGNUM *p; /* DSA prime p */
-    BIGNUM *q; /* DSA group order q */
-    BIGNUM *g; /* DSA group generator g */
-    BIGNUM *y; /* DSA public key value y (= g^x mod p
+    bignum_t *p; /* DSA prime p */
+    bignum_t *q; /* DSA group order q */
+    bignum_t *g; /* DSA group generator g */
+    bignum_t *y; /* DSA public key value y (= g^x mod p
                 * with x being the secret) */
 } pgp_dsa_pubkey_t;
 
 /** pgp_dsa_seckey_t */
 typedef struct pgp_dsa_seckey_t {
-    BIGNUM *x;
+    bignum_t *x;
 } pgp_dsa_seckey_t;
 
 /** Struct to hold params of a DSA signature */
 typedef struct pgp_dsa_sig_t {
-    BIGNUM *r; /* DSA value r */
-    BIGNUM *s; /* DSA value s */
+    bignum_t *r; /* DSA value r */
+    bignum_t *s; /* DSA value s */
 } pgp_dsa_sig_t;
 
 /*
@@ -86,8 +86,8 @@ typedef struct pgp_dsa_sig_t {
 * a pair of MPIs is used (DSA, ECDSA, EdDSA, ...)
 */
 typedef struct DSA_SIG_st {
-    BIGNUM *r;
-    BIGNUM *s;
+    bignum_t *r;
+    bignum_t *s;
 } DSA_SIG;
 
 /* DSA signature/verify */

--- a/src/lib/crypto/ec.c
+++ b/src/lib/crypto/ec.c
@@ -125,8 +125,8 @@ pgp_genkey_ec_uncompressed(rng_t *                rng,
     uint8_t         point_bytes[BITS_TO_BYTES(521) * 2 + 1] = {0};
     botan_privkey_t pr_key = NULL;
     botan_pubkey_t  pu_key = NULL;
-    BIGNUM *        public_x = NULL;
-    BIGNUM *        public_y = NULL;
+    bignum_t *      public_x = NULL;
+    bignum_t *      public_y = NULL;
     rnp_result_t    ret = RNP_ERROR_KEY_GENERATION;
 
     const ec_curve_desc_t *ec_desc = get_curve_desc(curve);

--- a/src/lib/crypto/ec.c
+++ b/src/lib/crypto/ec.c
@@ -149,9 +149,9 @@ pgp_genkey_ec_uncompressed(rng_t *                rng,
     }
 
     // Crash if seckey is null. It's clean and easy to debug design
-    public_x = BN_new();
-    public_y = BN_new();
-    seckey->key.ecc.x = BN_new();
+    public_x = bn_new();
+    public_y = bn_new();
+    seckey->key.ecc.x = bn_new();
 
     if (!public_x || !public_y || !seckey->key.ecc.x) {
         RNP_LOG("Allocation failed");
@@ -173,8 +173,8 @@ pgp_genkey_ec_uncompressed(rng_t *                rng,
 
     size_t x_bytes;
     size_t y_bytes;
-    (void) BN_num_bytes(public_x, &x_bytes); // Can't fail
-    (void) BN_num_bytes(public_y, &y_bytes);
+    (void) bn_num_bytes(public_x, &x_bytes); // Can't fail
+    (void) bn_num_bytes(public_y, &y_bytes);
 
     // Safety check
     if ((x_bytes > filed_byte_size) || (y_bytes > filed_byte_size)) {
@@ -193,10 +193,10 @@ pgp_genkey_ec_uncompressed(rng_t *                rng,
      *       which is important when converting to octet-string
      */
     point_bytes[0] = 0x04;
-    BN_bn2bin(public_x, &point_bytes[1 + filed_byte_size - x_bytes]);
-    BN_bn2bin(public_y, &point_bytes[1 + filed_byte_size + (filed_byte_size - y_bytes)]);
+    bn_bn2bin(public_x, &point_bytes[1 + filed_byte_size - x_bytes]);
+    bn_bn2bin(public_y, &point_bytes[1 + filed_byte_size + (filed_byte_size - y_bytes)]);
 
-    seckey->pubkey.key.ecc.point = BN_bin2bn(point_bytes, (2 * filed_byte_size) + 1, NULL);
+    seckey->pubkey.key.ecc.point = bn_bin2bn(point_bytes, (2 * filed_byte_size) + 1, NULL);
     if (!seckey->pubkey.key.ecc.point) {
         goto end;
     }
@@ -211,10 +211,10 @@ end:
         botan_pubkey_destroy(pu_key);
     }
     if (public_x != NULL) {
-        BN_free(public_x);
+        bn_free(public_x);
     }
     if (public_y != NULL) {
-        BN_free(public_y);
+        bn_free(public_y);
     }
     if (RNP_SUCCESS != ret) {
         RNP_LOG("EC key generation failed");

--- a/src/lib/crypto/ec.h
+++ b/src/lib/crypto/ec.h
@@ -62,18 +62,18 @@ typedef struct ec_curve_desc_t {
  */
 typedef struct {
     pgp_curve_t curve;
-    BIGNUM *    point; /* octet string encoded as MPI */
+    bignum_t *  point; /* octet string encoded as MPI */
 } pgp_ecc_pubkey_t;
 
 /** pgp_ecc_seckey_t */
 typedef struct {
-    BIGNUM *x;
+    bignum_t *x;
 } pgp_ecc_seckey_t;
 
 /** Struct to hold params of a ECDSA/EDDSA/SM2 signature */
 typedef struct pgp_ecc_sig_t {
-    BIGNUM *r;
-    BIGNUM *s;
+    bignum_t *r;
+    bignum_t *s;
 } pgp_ecc_sig_t;
 
 typedef struct pgp_output_t pgp_output_t;

--- a/src/lib/crypto/ecdh.c
+++ b/src/lib/crypto/ecdh.c
@@ -203,7 +203,7 @@ pgp_ecdh_encrypt_pkcs5(rng_t *                  rng,
                        size_t                   session_key_len,
                        uint8_t *                wrapped_key,
                        size_t *                 wrapped_key_len,
-                       BIGNUM *                 ephemeral_key,
+                       bignum_t *               ephemeral_key,
                        const pgp_ecdh_pubkey_t *pubkey,
                        const pgp_fingerprint_t *fingerprint)
 {
@@ -306,7 +306,7 @@ pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
                        size_t *                 session_key_len,
                        uint8_t *                wrapped_key,
                        size_t                   wrapped_key_len,
-                       const BIGNUM *           ephemeral_key,
+                       const bignum_t *         ephemeral_key,
                        const pgp_ecc_seckey_t * seckey,
                        const pgp_ecdh_pubkey_t *pubkey,
                        const pgp_fingerprint_t *fingerprint)

--- a/src/lib/crypto/ecdh.h
+++ b/src/lib/crypto/ecdh.h
@@ -92,7 +92,7 @@ rnp_result_t pgp_ecdh_encrypt_pkcs5(rng_t *                  rng,
                                     size_t                   session_key_len,
                                     uint8_t *                wrapped_key,
                                     size_t *                 wrapped_key_len,
-                                    BIGNUM *                 ephemeral_key,
+                                    bignum_t *               ephemeral_key,
                                     const pgp_ecdh_pubkey_t *pubkey,
                                     const pgp_fingerprint_t *fingerprint);
 
@@ -120,7 +120,7 @@ rnp_result_t pgp_ecdh_decrypt_pkcs5(uint8_t *                session_key,
                                     size_t *                 session_key_len,
                                     uint8_t *                wrapped_key,
                                     size_t                   wrapped_key_len,
-                                    const BIGNUM *           ephemeral_key,
+                                    const bignum_t *         ephemeral_key,
                                     const pgp_ecc_seckey_t * seckey,
                                     const pgp_ecdh_pubkey_t *pubkey,
                                     const pgp_fingerprint_t *fingerprint);

--- a/src/lib/crypto/ecdsa.c
+++ b/src/lib/crypto/ecdsa.c
@@ -82,8 +82,8 @@ pgp_ecdsa_sign_hash(rng_t *                 rng,
     }
 
     // Allocate memory and copy results
-    sign->r = BN_bin2bn(out_buf, curve_order, sign->r);
-    sign->s = BN_bin2bn(out_buf + curve_order, curve_order, sign->s);
+    sign->r = bn_bin2bn(out_buf, curve_order, sign->r);
+    sign->s = bn_bin2bn(out_buf + curve_order, curve_order, sign->s);
     if (!sign->r || !sign->s) {
         goto end;
     }
@@ -93,8 +93,8 @@ pgp_ecdsa_sign_hash(rng_t *                 rng,
 
 end:
     if (ret != RNP_SUCCESS) {
-        BN_clear_free(sign->r);
-        BN_clear_free(sign->s);
+        bn_clear_free(sign->r);
+        bn_clear_free(sign->s);
     }
     botan_privkey_destroy(key);
     botan_pk_op_sign_destroy(signer);
@@ -123,8 +123,8 @@ pgp_ecdsa_verify_hash(const pgp_ecc_sig_t *   sign,
         return RNP_ERROR_BAD_PARAMETERS;
     }
 
-    if (!BN_num_bytes(pubkey->point, &r_blen) || (r_blen > sizeof(point_bytes)) ||
-        BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
+    if (!bn_num_bytes(pubkey->point, &r_blen) || (r_blen > sizeof(point_bytes)) ||
+        bn_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
         RNP_LOG("Failed to load public key");
         ret = RNP_ERROR_BAD_PARAMETERS;
         goto end;
@@ -152,16 +152,16 @@ pgp_ecdsa_verify_hash(const pgp_ecc_sig_t *   sign,
         goto end;
     }
 
-    if (!BN_num_bytes(sign->r, &r_blen) || (r_blen > curve_order) ||
-        !BN_num_bytes(sign->s, &s_blen) || (s_blen > curve_order) ||
+    if (!bn_num_bytes(sign->r, &r_blen) || (r_blen > curve_order) ||
+        !bn_num_bytes(sign->s, &s_blen) || (s_blen > curve_order) ||
         (curve_order > MAX_CURVE_BYTELEN)) {
         ret = RNP_ERROR_BAD_PARAMETERS;
         goto end;
     }
 
     // Both can't fail
-    (void) BN_bn2bin(sign->r, &sign_buf[curve_order - r_blen]);
-    (void) BN_bn2bin(sign->s, &sign_buf[curve_order + curve_order - s_blen]);
+    (void) bn_bn2bin(sign->r, &sign_buf[curve_order - r_blen]);
+    (void) bn_bn2bin(sign->s, &sign_buf[curve_order + curve_order - s_blen]);
 
     ret = botan_pk_op_verify_finish(verifier, sign_buf, curve_order * 2) ?
             RNP_ERROR_SIGNATURE_INVALID :

--- a/src/lib/crypto/eddsa.c
+++ b/src/lib/crypto/eddsa.c
@@ -65,8 +65,8 @@ end:
 }
 
 int
-pgp_eddsa_verify_hash(const BIGNUM *          r,
-                      const BIGNUM *          s,
+pgp_eddsa_verify_hash(const bignum_t *        r,
+                      const bignum_t *        s,
                       const uint8_t *         hash,
                       size_t                  hash_len,
                       const pgp_ecc_pubkey_t *pubkey)
@@ -123,8 +123,8 @@ done:
 
 int
 pgp_eddsa_sign_hash(rng_t *                 rng,
-                    BIGNUM *                r,
-                    BIGNUM *                s,
+                    bignum_t *              r,
+                    bignum_t *              s,
                     const uint8_t *         hash,
                     size_t                  hash_len,
                     const pgp_ecc_seckey_t *seckey,

--- a/src/lib/crypto/eddsa.c
+++ b/src/lib/crypto/eddsa.c
@@ -50,12 +50,12 @@ pgp_genkey_eddsa(rng_t *rng, pgp_seckey_t *seckey, size_t curve_len)
     // First 32 bytesof key_bits are the EdDSA seed (private key)
     // Second 32 bytes are the EdDSA public key
 
-    seckey->key.ecc.x = BN_bin2bn(key_bits, 32, NULL);
+    seckey->key.ecc.x = bn_bin2bn(key_bits, 32, NULL);
     seckey->pubkey.key.ecc.curve = PGP_CURVE_ED25519;
 
     // Hack to insert the required 0x40 prefix on the public key
     key_bits[31] = 0x40;
-    seckey->pubkey.key.ecc.point = BN_bin2bn(key_bits + 31, 33, NULL);
+    seckey->pubkey.key.ecc.point = bn_bin2bn(key_bits + 31, 33, NULL);
 
     retval = true;
 
@@ -82,10 +82,10 @@ pgp_eddsa_verify_hash(const BIGNUM *          r,
         goto done;
 
     // Unexpected size for Ed25519 key
-    if (!BN_num_bytes(pubkey->point, &sz) || sz != 33)
+    if (!bn_num_bytes(pubkey->point, &sz) || sz != 33)
         goto done;
 
-    BN_bn2bin(pubkey->point, bn_buf);
+    bn_bn2bin(pubkey->point, bn_buf);
 
     /*
     * See draft-ietf-openpgp-rfc4880bis-01 section 13.3
@@ -104,14 +104,14 @@ pgp_eddsa_verify_hash(const BIGNUM *          r,
 
     memset(bn_buf, 0, sizeof(bn_buf));
     // Unexpected size for Ed25519 signature
-    if (!BN_num_bytes(r, &sz) || (sz > 32)) {
+    if (!bn_num_bytes(r, &sz) || (sz > 32)) {
         goto done;
     }
-    BN_bn2bin(r, &bn_buf[32 - sz]);
-    if (!BN_num_bytes(s, &sz) || (sz > 32)) {
+    bn_bn2bin(r, &bn_buf[32 - sz]);
+    if (!bn_num_bytes(s, &sz) || (sz > 32)) {
         goto done;
     }
-    BN_bn2bin(s, &bn_buf[32 + 32 - sz]);
+    bn_bn2bin(s, &bn_buf[32 + 32 - sz]);
 
     result = (botan_pk_op_verify_finish(verify_op, bn_buf, 64) == 0);
 
@@ -142,10 +142,10 @@ pgp_eddsa_sign_hash(rng_t *                 rng,
     }
 
     // Unexpected size for Ed25519 key
-    if (!BN_num_bytes(seckey->x, &sz) || (sz > 32))
+    if (!bn_num_bytes(seckey->x, &sz) || (sz > 32))
         goto done;
 
-    BN_bn2bin(seckey->x, bn_buf + (32 - sz));
+    bn_bn2bin(seckey->x, bn_buf + (32 - sz));
 
     if (botan_privkey_load_ed25519(&eddsa, bn_buf) != 0)
         goto done;
@@ -164,8 +164,8 @@ pgp_eddsa_sign_hash(rng_t *                 rng,
     if (sig_size != 64)
         goto done;
 
-    BN_bin2bn(bn_buf, 32, r);
-    BN_bin2bn(bn_buf + 32, 32, s);
+    bn_bin2bn(bn_buf, 32, r);
+    bn_bin2bn(bn_buf + 32, 32, s);
     result = 0;
 
 done:

--- a/src/lib/crypto/eddsa.h
+++ b/src/lib/crypto/eddsa.h
@@ -39,15 +39,15 @@
 */
 bool pgp_genkey_eddsa(rng_t *rng, pgp_seckey_t *seckey, size_t numbits);
 
-int pgp_eddsa_verify_hash(const BIGNUM *          r,
-                          const BIGNUM *          s,
+int pgp_eddsa_verify_hash(const bignum_t *        r,
+                          const bignum_t *        s,
                           const uint8_t *         hash,
                           size_t                  hash_len,
                           const pgp_ecc_pubkey_t *pubkey);
 
 int pgp_eddsa_sign_hash(rng_t *        rng,
-                        BIGNUM *       r,
-                        BIGNUM *       s,
+                        bignum_t *     r,
+                        bignum_t *     s,
                         const uint8_t *hash,
                         size_t         hash_len,
                         const pgp_ecc_seckey_t *,

--- a/src/lib/crypto/elgamal.h
+++ b/src/lib/crypto/elgamal.h
@@ -40,21 +40,21 @@
  * \see RFC4880 5.5.2
  */
 typedef struct {
-    BIGNUM *p; /* ElGamal prime p */
-    BIGNUM *g; /* ElGamal group generator g */
-    BIGNUM *y; /* ElGamal public key value y (= g^x mod p
+    bignum_t *p; /* ElGamal prime p */
+    bignum_t *g; /* ElGamal group generator g */
+    bignum_t *y; /* ElGamal public key value y (= g^x mod p
                 * with x being the secret) */
 } pgp_elgamal_pubkey_t;
 
 /** pgp_elgamal_seckey_t */
 typedef struct pgp_elgamal_seckey_t {
-    BIGNUM *x;
+    bignum_t *x;
 } pgp_elgamal_seckey_t;
 
 /** Struct to hold params of a Elgamal signature */
 typedef struct pgp_elgamal_sig_t {
-    BIGNUM *r;
-    BIGNUM *s;
+    bignum_t *r;
+    bignum_t *s;
 } pgp_elgamal_sig_t;
 
 /*

--- a/src/lib/crypto/rsa.c
+++ b/src/lib/crypto/rsa.c
@@ -283,12 +283,12 @@ pgp_genkey_rsa(rng_t *rng, pgp_seckey_t *seckey, size_t numbits)
     botan_privkey_t rsa_key = NULL;
     int             ret = 0, cmp;
 
-    seckey->pubkey.key.rsa.n = BN_new();
-    seckey->pubkey.key.rsa.e = BN_new();
-    seckey->key.rsa.p = BN_new();
-    seckey->key.rsa.q = BN_new();
-    seckey->key.rsa.d = BN_new();
-    seckey->key.rsa.u = BN_new();
+    seckey->pubkey.key.rsa.n = bn_new();
+    seckey->pubkey.key.rsa.e = bn_new();
+    seckey->key.rsa.p = bn_new();
+    seckey->key.rsa.q = bn_new();
+    seckey->key.rsa.d = bn_new();
+    seckey->key.rsa.u = bn_new();
 
     if (!seckey->pubkey.key.rsa.n || !seckey->pubkey.key.rsa.e || !seckey->key.rsa.p ||
         !seckey->key.rsa.q || !seckey->key.rsa.d || !seckey->key.rsa.u) {

--- a/src/lib/crypto/rsa.h
+++ b/src/lib/crypto/rsa.h
@@ -44,22 +44,22 @@ typedef struct pgp_rsa_seckey_t pgp_rsa_seckey_t;
  * \see RFC4880 5.5.2
  */
 typedef struct {
-    BIGNUM *n; /* RSA public modulus n */
-    BIGNUM *e; /* RSA public encryption exponent e */
+    bignum_t *n; /* RSA public modulus n */
+    bignum_t *e; /* RSA public encryption exponent e */
 } pgp_rsa_pubkey_t;
 
 /** Struct to hold params of an RSA signature */
 typedef struct pgp_rsa_sig_t {
-    BIGNUM *sig; /* the signature value (m^d % n) */
+    bignum_t *sig; /* the signature value (m^d % n) */
 } pgp_rsa_sig_t;
 
 /** Structure to hold data for one RSA secret key
  */
 typedef struct pgp_rsa_seckey_t {
-    BIGNUM *d;
-    BIGNUM *p;
-    BIGNUM *q;
-    BIGNUM *u;
+    bignum_t *d;
+    bignum_t *p;
+    bignum_t *q;
+    bignum_t *u;
 } pgp_rsa_seckey_t;
 
 /*

--- a/src/lib/crypto/sm2.c
+++ b/src/lib/crypto/sm2.c
@@ -80,8 +80,8 @@ pgp_sm2_sign_hash(rng_t *                 rng,
     }
 
     // Allocate memory and copy results
-    sign->r = BN_bin2bn(out_buf, sign_half_len, sign->r);
-    sign->s = BN_bin2bn(out_buf + sign_half_len, sign_half_len, sign->s);
+    sign->r = bn_bin2bn(out_buf, sign_half_len, sign->r);
+    sign->s = bn_bin2bn(out_buf + sign_half_len, sign_half_len, sign->s);
     if (!sign->r || !sign->s) {
         goto end;
     }
@@ -91,8 +91,8 @@ pgp_sm2_sign_hash(rng_t *                 rng,
 
 end:
     if (ret != RNP_SUCCESS) {
-        BN_clear_free(sign->r);
-        BN_clear_free(sign->s);
+        bn_clear_free(sign->r);
+        bn_clear_free(sign->s);
     }
     botan_privkey_destroy(key);
     botan_pk_op_sign_destroy(signer);
@@ -123,8 +123,8 @@ pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
 
     const size_t sign_half_len = BITS_TO_BYTES(curve->bitlen);
 
-    if (!BN_num_bytes(pubkey->point, &r_blen) || (r_blen > sizeof(point_bytes)) ||
-        BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
+    if (!bn_num_bytes(pubkey->point, &r_blen) || (r_blen > sizeof(point_bytes)) ||
+        bn_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
         RNP_LOG("Failed to load public key");
         goto end;
     }
@@ -148,14 +148,14 @@ pgp_sm2_verify_hash(const pgp_ecc_sig_t *   sign,
         goto end;
     }
 
-    if (!BN_num_bytes(sign->r, &r_blen) || (r_blen > sign_half_len) ||
-        !BN_num_bytes(sign->s, &s_blen) || (s_blen > sign_half_len) ||
+    if (!bn_num_bytes(sign->r, &r_blen) || (r_blen > sign_half_len) ||
+        !bn_num_bytes(sign->s, &s_blen) || (s_blen > sign_half_len) ||
         (sign_half_len > MAX_CURVE_BYTELEN)) {
         goto end;
     }
 
-    BN_bn2bin(sign->r, &sign_buf[sign_half_len - r_blen]);
-    BN_bn2bin(sign->s, &sign_buf[sign_half_len + sign_half_len - s_blen]);
+    bn_bn2bin(sign->r, &sign_buf[sign_half_len - r_blen]);
+    bn_bn2bin(sign->s, &sign_buf[sign_half_len + sign_half_len - s_blen]);
 
     ret = botan_pk_op_verify_finish(verifier, sign_buf, sign_half_len * 2) ?
             RNP_ERROR_SIGNATURE_INVALID :
@@ -211,8 +211,8 @@ pgp_sm2_encrypt(rng_t *                 rng,
         goto done;
     }
 
-    if (!BN_num_bytes(pubkey->point, &sz) || (sz > sizeof(point_bytes)) ||
-        BN_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
+    if (!bn_num_bytes(pubkey->point, &sz) || (sz > sizeof(point_bytes)) ||
+        bn_bn2bin(pubkey->point, point_bytes) || (point_bytes[0] != 0x04)) {
         RNP_LOG("Failed to load public key");
         goto done;
     }

--- a/src/lib/fingerprint.c
+++ b/src/lib/fingerprint.c
@@ -57,14 +57,14 @@ ssh_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
     hash_string(&hash, (const uint8_t *) (const void *) type, (unsigned) strlen(type));
     switch (key->alg) {
     case PGP_PKA_RSA:
-        (void) BN_hash(key->key.rsa.e, &hash);
-        (void) BN_hash(key->key.rsa.n, &hash);
+        (void) bn_hash(key->key.rsa.e, &hash);
+        (void) bn_hash(key->key.rsa.n, &hash);
         break;
     case PGP_PKA_DSA:
-        (void) BN_hash(key->key.dsa.p, &hash);
-        (void) BN_hash(key->key.dsa.q, &hash);
-        (void) BN_hash(key->key.dsa.g, &hash);
-        (void) BN_hash(key->key.dsa.y, &hash);
+        (void) bn_hash(key->key.dsa.p, &hash);
+        (void) bn_hash(key->key.dsa.q, &hash);
+        (void) bn_hash(key->key.dsa.g, &hash);
+        (void) bn_hash(key->key.dsa.y, &hash);
         break;
     default:
         pgp_hash_finish(&hash, fp->fingerprint);
@@ -93,8 +93,8 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
             RNP_LOG("bad md5 alloc");
             return RNP_ERROR_NOT_SUPPORTED;
         }
-        (void) BN_hash(key->key.rsa.n, &hash);
-        (void) BN_hash(key->key.rsa.e, &hash);
+        (void) bn_hash(key->key.rsa.n, &hash);
+        (void) bn_hash(key->key.rsa.e, &hash);
         fp->length = pgp_hash_finish(&hash, fp->fingerprint);
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "v2/v3 fingerprint", fp->fingerprint, fp->length);
@@ -151,11 +151,11 @@ pgp_keyid(uint8_t *keyid, const size_t idlen, const pgp_pubkey_t *key)
             return false;
         }
 
-        if (!BN_num_bytes(key->key.rsa.n, &n) || (n > sizeof(bn))) {
+        if (!bn_num_bytes(key->key.rsa.n, &n) || (n > sizeof(bn))) {
             RNP_LOG("Internal error: bignum too big");
             return false;
         }
-        BN_bn2bin(key->key.rsa.n, bn);
+        bn_bn2bin(key->key.rsa.n, bn);
         (void) memcpy(keyid, bn + n - idlen, idlen);
     } else {
         pgp_fingerprint_t finger;

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -152,7 +152,7 @@ static size_t
 mpi_length(const BIGNUM *bn)
 {
     size_t bsz;
-    if (!BN_num_bytes(bn, &bsz)) {
+    if (!bn_num_bytes(bn, &bsz)) {
         return 0;
     }
 
@@ -882,7 +882,7 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher, rng_t *
             goto done;
         }
 
-        sesskey->params.rsa.encrypted_m = BN_bin2bn(encmpibuf, n, NULL);
+        sesskey->params.rsa.encrypted_m = bn_bin2bn(encmpibuf, n, NULL);
 
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "encrypted mpi", encmpibuf, n);
@@ -904,7 +904,7 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher, rng_t *
             goto done;
         }
 
-        sesskey->params.sm2.encrypted_m = BN_bin2bn(encmpibuf, out_len, NULL);
+        sesskey->params.sm2.encrypted_m = bn_bin2bn(encmpibuf, out_len, NULL);
 
     } break;
 
@@ -918,7 +918,7 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher, rng_t *
             goto done;
         }
 
-        sesskey->params.ecdh.ephemeral_point = BN_new();
+        sesskey->params.ecdh.ephemeral_point = bn_new();
         if (!sesskey->params.ecdh.ephemeral_point) {
             goto done;
         }
@@ -955,8 +955,8 @@ pgp_create_pk_sesskey(const pgp_pubkey_t *pubkey, pgp_symm_alg_t cipher, rng_t *
             goto error;
         }
 
-        sesskey->params.elgamal.g_to_k = BN_bin2bn(g_to_k, n / 2, NULL);
-        sesskey->params.elgamal.encrypted_m = BN_bin2bn(encmpibuf, n / 2, NULL);
+        sesskey->params.elgamal.g_to_k = bn_bin2bn(g_to_k, n / 2, NULL);
+        sesskey->params.elgamal.encrypted_m = bn_bin2bn(encmpibuf, n / 2, NULL);
 
         if (rnp_get_debug(__FILE__)) {
             hexdump(stderr, "elgamal g^k", g_to_k, n / 2);

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -149,7 +149,7 @@ pgp_write_userid(const uint8_t *userid, pgp_output_t *output)
 \ingroup Core_MPI
 */
 static size_t
-mpi_length(const BIGNUM *bn)
+mpi_length(const bignum_t *bn)
 {
     size_t bsz;
     if (!bn_num_bytes(bn, &bsz)) {

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -424,7 +424,7 @@ formatstring(char *buffer, const uint8_t *s, size_t len)
 
 /* format a bignum, checking for "interesting" high bit values */
 static int
-formatbignum(char *buffer, BIGNUM *bn)
+formatbignum(char *buffer, bignum_t *bn)
 {
     size_t   len;
     uint8_t *cp;

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -430,7 +430,7 @@ formatbignum(char *buffer, BIGNUM *bn)
     uint8_t *cp;
     int      cc;
 
-    if (!BN_num_bytes(bn, &len)) {
+    if (!bn_num_bytes(bn, &len)) {
         RNP_LOG("Wrong input");
         return 0;
     }
@@ -440,7 +440,7 @@ formatbignum(char *buffer, BIGNUM *bn)
         return 0;
     }
 
-    (void) BN_bn2bin(bn, cp + 1);
+    (void) bn_bn2bin(bn, cp + 1);
     cp[0] = 0x0;
     cc =
       (cp[1] & 0x80) ? formatstring(buffer, cp, len + 1) : formatstring(buffer, &cp[1], len);

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -179,9 +179,9 @@ rsa_sign(rng_t *                 rng,
         RNP_LOG("Internal error");
         return false;
     }
-    bn = BN_bin2bn(sigbuf, sig_size, NULL);
+    bn = bn_bin2bn(sigbuf, sig_size, NULL);
     pgp_write_mpi(out, bn);
-    BN_free(bn);
+    bn_free(bn);
     return true;
 }
 
@@ -258,8 +258,8 @@ ecdsa_sign(rng_t *                 rng,
     bool ret = !!pgp_write_mpi(output, sig.r);
     ret &= !!pgp_write_mpi(output, sig.s);
 
-    BN_free(sig.r);
-    BN_free(sig.s);
+    bn_free(sig.r);
+    bn_free(sig.s);
     return ret;
 }
 
@@ -299,8 +299,8 @@ sm2_sign(rng_t *                 rng,
     bool ret = !!pgp_write_mpi(output, sig.r);
     ret &= !!pgp_write_mpi(output, sig.s);
 
-    BN_free(sig.r);
-    BN_free(sig.s);
+    bn_free(sig.r);
+    bn_free(sig.s);
     return ret;
 }
 
@@ -320,8 +320,8 @@ eddsa_sign(rng_t *                 rng,
     pgp_write(output, &hashbuf[0], 2);
 
     /* write signature to buf */
-    BIGNUM *r = BN_new();
-    BIGNUM *s = BN_new();
+    BIGNUM *r = bn_new();
+    BIGNUM *s = bn_new();
     if (!r || !s) {
         goto end;
     }
@@ -335,8 +335,8 @@ eddsa_sign(rng_t *                 rng,
     ret = true;
 
 end:
-    BN_free(r);
-    BN_free(s);
+    bn_free(r);
+    bn_free(s);
     return ret;
 }
 
@@ -362,16 +362,16 @@ rsa_verify(rng_t *                 rng,
     uint8_t sigbuf[RNP_BUFSIZ];
 
     /* RSA key can't be bigger than 65535 bits, so... */
-    if (!BN_num_bytes(pubrsa->n, &sz) || (sz > sizeof(sigbuf))) {
+    if (!bn_num_bytes(pubrsa->n, &sz) || (sz > sizeof(sigbuf))) {
         RNP_LOG("keysize too big");
         return false;
     }
 
-    if (!BN_num_bytes(sig->sig, &sig_blen) || (sig_blen > sizeof(sigbuf))) {
+    if (!bn_num_bytes(sig->sig, &sig_blen) || (sig_blen > sizeof(sigbuf))) {
         RNP_LOG("Signature too big");
         return false;
     }
-    BN_bn2bin(sig->sig, sigbuf);
+    bn_bn2bin(sig->sig, sigbuf);
 
     return pgp_rsa_pkcs1_verify_hash(
       rng, sigbuf, sig_blen, hash_alg, hash, hash_length, pubrsa);

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -155,11 +155,11 @@ rsa_sign(rng_t *                 rng,
          const pgp_rsa_seckey_t *secrsa,
          pgp_output_t *          out)
 {
-    unsigned hash_size;
-    int      sig_size = 0;
-    uint8_t  hashbuf[128];
-    uint8_t  sigbuf[RNP_BUFSIZ];
-    BIGNUM * bn;
+    unsigned  hash_size;
+    int       sig_size = 0;
+    uint8_t   hashbuf[128];
+    uint8_t   sigbuf[RNP_BUFSIZ];
+    bignum_t *bn;
 
     pgp_hash_alg_t hash_alg = pgp_hash_alg_type(hash);
 
@@ -320,8 +320,8 @@ eddsa_sign(rng_t *                 rng,
     pgp_write(output, &hashbuf[0], 2);
 
     /* write signature to buf */
-    BIGNUM *r = bn_new();
-    BIGNUM *s = bn_new();
+    bignum_t *r = bn_new();
+    bignum_t *s = bn_new();
     if (!r || !s) {
         goto end;
     }

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -515,26 +515,26 @@ typedef struct pgp_dyn_body_t {
 
 /** pgp_pk_sesskey_params_rsa_t */
 typedef struct {
-    BIGNUM *encrypted_m;
-    BIGNUM *m;
+    bignum_t *encrypted_m;
+    bignum_t *m;
 } pgp_pk_sesskey_params_rsa_t;
 
 /** pgp_pk_sesskey_params_elgamal_t */
 typedef struct {
-    BIGNUM *g_to_k;
-    BIGNUM *encrypted_m;
+    bignum_t *g_to_k;
+    bignum_t *encrypted_m;
 } pgp_pk_sesskey_params_elgamal_t;
 
 /** pgp_pk_sesskey_params_sm2_t */
 typedef struct {
-    BIGNUM *encrypted_m;
+    bignum_t *encrypted_m;
 } pgp_pk_sesskey_params_sm2_t;
 
 /** pgp_pk_sesskey_params_elgamal_t */
 typedef struct {
-    uint8_t  encrypted_m[48];  // wrapped_key
-    unsigned encrypted_m_size; // wrapped_key_size
-    BIGNUM * ephemeral_point;
+    uint8_t   encrypted_m[48];  // wrapped_key
+    unsigned  encrypted_m_size; // wrapped_key_size
+    bignum_t *ephemeral_point;
 } pgp_pk_sesskey_params_ecdh_t;
 
 /** pgp_pk_sesskey_params_t */

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -148,12 +148,12 @@ pgp_write_mpi(pgp_output_t *output, const BIGNUM *bn)
 {
     uint8_t buf[RNP_BUFSIZ];
     size_t  bsz;
-    if (!BN_num_bits(bn, &bsz) || (bsz > 65535)) {
+    if (!bn_num_bits(bn, &bsz) || (bsz > 65535)) {
         RNP_LOG("Wrong input");
         return false;
     }
 
-    return !BN_bn2bin(bn, buf) && pgp_write_scalar(output, bsz, 2) &&
+    return !bn_bn2bin(bn, buf) && pgp_write_scalar(output, bsz, 2) &&
            pgp_write(output, buf, BITS_TO_BYTES(bsz));
 }
 

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -144,7 +144,7 @@ pgp_write_scalar(pgp_output_t *output, unsigned n, unsigned len)
  */
 
 bool
-pgp_write_mpi(pgp_output_t *output, const BIGNUM *bn)
+pgp_write_mpi(pgp_output_t *output, const bignum_t *bn)
 {
     uint8_t buf[RNP_BUFSIZ];
     size_t  bsz;

--- a/src/lib/writer.h
+++ b/src/lib/writer.h
@@ -112,7 +112,7 @@ bool pgp_write(pgp_output_t *, const void *, size_t);
 bool pgp_write_length(pgp_output_t *, unsigned);
 bool pgp_write_ptag(pgp_output_t *, pgp_content_enum);
 bool pgp_write_scalar(pgp_output_t *, unsigned, unsigned);
-bool pgp_write_mpi(pgp_output_t *, const BIGNUM *);
+bool pgp_write_mpi(pgp_output_t *, const bignum_t *);
 
 void     pgp_writer_info_delete(pgp_writer_t *);
 unsigned pgp_writer_info_finalise(pgp_error_t **, pgp_writer_t *);

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -372,8 +372,8 @@ read_bignum(s_exp_t *s_exp, const char *name)
         return NULL;
     }
 
-    BIGNUM *res = PGPV_BN_bin2bn(
-      var->sub_elements[1].block.bytes, (int) var->sub_elements[1].block.len, NULL);
+    BIGNUM *res =
+      bn_bin2bn(var->sub_elements[1].block.bytes, (int) var->sub_elements[1].block.len, NULL);
     if (res == NULL) {
         char *buf = malloc((var->sub_elements[1].block.len * 3) + 1);
         if (buf == NULL) {
@@ -398,7 +398,7 @@ write_bignum(s_exp_t *s_exp, const char *name, BIGNUM *bn)
 
     bnbuf[0] = 0;
 
-    if (PGPV_BN_bn2bin(bn, bnbuf + 1) < 0) {
+    if (bn_bn2bin(bn, bnbuf + 1) < 0) {
         return false;
     }
 
@@ -412,11 +412,11 @@ write_bignum(s_exp_t *s_exp, const char *name, BIGNUM *bn)
 
     size_t sz;
     if (bnbuf[1] & 0x80) {
-        if (!BN_num_bytes(bn, &sz) || !add_block_to_sexp(sub_s_exp, bnbuf, sz + 1)) {
+        if (!bn_num_bytes(bn, &sz) || !add_block_to_sexp(sub_s_exp, bnbuf, sz + 1)) {
             return false;
         }
     } else {
-        if (!BN_num_bytes(bn, &sz) || !add_block_to_sexp(sub_s_exp, bnbuf + 1, sz)) {
+        if (!bn_num_bytes(bn, &sz) || !add_block_to_sexp(sub_s_exp, bnbuf + 1, sz)) {
             return false;
         }
     }
@@ -438,22 +438,22 @@ parse_pubkey(pgp_pubkey_t *pubkey, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
         pubkey->key.dsa.q = read_bignum(s_exp, "q");
         if (pubkey->key.dsa.q == NULL) {
-            PGPV_BN_free(pubkey->key.dsa.p);
+            bn_free(pubkey->key.dsa.p);
             return false;
         }
 
         pubkey->key.dsa.g = read_bignum(s_exp, "g");
         if (pubkey->key.dsa.g == NULL) {
-            PGPV_BN_free(pubkey->key.dsa.p);
-            PGPV_BN_free(pubkey->key.dsa.q);
+            bn_free(pubkey->key.dsa.p);
+            bn_free(pubkey->key.dsa.q);
             return false;
         }
 
         pubkey->key.dsa.y = read_bignum(s_exp, "y");
         if (pubkey->key.dsa.y == NULL) {
-            PGPV_BN_free(pubkey->key.dsa.p);
-            PGPV_BN_free(pubkey->key.dsa.q);
-            PGPV_BN_free(pubkey->key.dsa.g);
+            bn_free(pubkey->key.dsa.p);
+            bn_free(pubkey->key.dsa.q);
+            bn_free(pubkey->key.dsa.g);
             return false;
         }
 
@@ -467,7 +467,7 @@ parse_pubkey(pgp_pubkey_t *pubkey, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
         pubkey->key.rsa.e = read_bignum(s_exp, "e");
         if (pubkey->key.rsa.e == NULL) {
-            PGPV_BN_free(pubkey->key.rsa.n);
+            bn_free(pubkey->key.rsa.n);
             return false;
         }
 
@@ -481,14 +481,14 @@ parse_pubkey(pgp_pubkey_t *pubkey, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
         pubkey->key.elgamal.g = read_bignum(s_exp, "g");
         if (pubkey->key.elgamal.g == NULL) {
-            PGPV_BN_free(pubkey->key.elgamal.p);
+            bn_free(pubkey->key.elgamal.p);
             return false;
         }
 
         pubkey->key.elgamal.y = read_bignum(s_exp, "y");
         if (pubkey->key.elgamal.y == NULL) {
-            PGPV_BN_free(pubkey->key.elgamal.p);
-            PGPV_BN_free(pubkey->key.elgamal.g);
+            bn_free(pubkey->key.elgamal.p);
+            bn_free(pubkey->key.elgamal.g);
             return false;
         }
 
@@ -522,22 +522,22 @@ parse_seckey(pgp_seckey_t *seckey, s_exp_t *s_exp, pgp_pubkey_alg_t alg)
 
         seckey->key.rsa.p = read_bignum(s_exp, "p");
         if (seckey->key.rsa.p == NULL) {
-            PGPV_BN_free(seckey->key.rsa.d);
+            bn_free(seckey->key.rsa.d);
             return false;
         }
 
         seckey->key.rsa.q = read_bignum(s_exp, "q");
         if (seckey->key.rsa.q == NULL) {
-            PGPV_BN_free(seckey->key.rsa.d);
-            PGPV_BN_free(seckey->key.rsa.p);
+            bn_free(seckey->key.rsa.d);
+            bn_free(seckey->key.rsa.p);
             return false;
         }
 
         seckey->key.rsa.u = read_bignum(s_exp, "u");
         if (seckey->key.rsa.u == NULL) {
-            PGPV_BN_free(seckey->key.rsa.d);
-            PGPV_BN_free(seckey->key.rsa.p);
-            PGPV_BN_free(seckey->key.rsa.q);
+            bn_free(seckey->key.rsa.d);
+            bn_free(seckey->key.rsa.p);
+            bn_free(seckey->key.rsa.q);
             return false;
         }
 

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -359,7 +359,7 @@ lookup_variable(s_exp_t *s_exp, const char *name)
     return NULL;
 }
 
-static BIGNUM *
+static bignum_t *
 read_bignum(s_exp_t *s_exp, const char *name)
 {
     s_exp_t *var = lookup_variable(s_exp, name);
@@ -372,7 +372,7 @@ read_bignum(s_exp_t *s_exp, const char *name)
         return NULL;
     }
 
-    BIGNUM *res =
+    bignum_t *res =
       bn_bin2bn(var->sub_elements[1].block.bytes, (int) var->sub_elements[1].block.len, NULL);
     if (res == NULL) {
         char *buf = malloc((var->sub_elements[1].block.len * 3) + 1);
@@ -390,7 +390,7 @@ read_bignum(s_exp_t *s_exp, const char *name)
 }
 
 static bool
-write_bignum(s_exp_t *s_exp, const char *name, BIGNUM *bn)
+write_bignum(s_exp_t *s_exp, const char *name, bignum_t *bn)
 {
     uint8_t bnbuf[RNP_BUFSIZ];
 

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -136,7 +136,7 @@ getbignum(bufgap_t *bg, char *buf, const char *header)
     len = ntohl(len);
     (void) bufgap_seek(bg, sizeof(len), BGFromHere, BGByte);
     (void) bufgap_getbin(bg, buf, len);
-    bignum = BN_bin2bn((const uint8_t *) buf, (int) len, NULL);
+    bignum = bn_bin2bn((const uint8_t *) buf, (int) len, NULL);
     if (rnp_get_debug(__FILE__)) {
         hexdump(stderr, header, (const uint8_t *) (void *) buf, len);
     }

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -126,11 +126,11 @@ frombase64(char *dst, const char *src, size_t size, int flag)
 }
 
 /* get a bignum from the buffer gap */
-static BIGNUM *
+static bignum_t *
 getbignum(bufgap_t *bg, char *buf, const char *header)
 {
-    uint32_t len;
-    BIGNUM * bignum;
+    uint32_t  len;
+    bignum_t *bignum;
 
     (void) bufgap_getbin(bg, &len, sizeof(len));
     len = ntohl(len);
@@ -368,7 +368,7 @@ ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey)
 
     if (key->key.seckey.pubkey.alg == PGP_PKA_RSA) {
         /* openssh and openssl have p and q swapped */
-        BIGNUM *tmp = key->key.seckey.key.rsa.p;
+        bignum_t *tmp = key->key.seckey.key.rsa.p;
         key->key.seckey.key.rsa.p = key->key.seckey.key.rsa.q;
         key->key.seckey.key.rsa.q = tmp;
     }

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -829,7 +829,7 @@ rnp_key_store_get_next_key_by_name(
 
 // TODO: This looks very similar to bn_hash()
 static bool
-grip_hash_bignum(pgp_hash_t *hash, const BIGNUM *bignum)
+grip_hash_bignum(pgp_hash_t *hash, const bignum_t *bignum)
 {
     uint8_t *bn;
     size_t   len;

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -827,7 +827,7 @@ rnp_key_store_get_next_key_by_name(
     return get_key_by_name(io, keyring, name, n, key);
 }
 
-// TODO: This looks very similar to BN_hash()
+// TODO: This looks very similar to bn_hash()
 static bool
 grip_hash_bignum(pgp_hash_t *hash, const BIGNUM *bignum)
 {
@@ -835,12 +835,12 @@ grip_hash_bignum(pgp_hash_t *hash, const BIGNUM *bignum)
     size_t   len;
     int      padbyte;
 
-    if (BN_is_zero(bignum)) {
+    if (bn_is_zero(bignum)) {
         pgp_hash_add(hash, (const uint8_t *) &"\0", 1);
         return true;
     }
 
-    if (!BN_num_bytes(bignum, &len)) {
+    if (!bn_num_bytes(bignum, &len)) {
         RNP_LOG("Wrong input");
         return false;
     }
@@ -849,7 +849,7 @@ grip_hash_bignum(pgp_hash_t *hash, const BIGNUM *bignum)
         (void) fprintf(stderr, "grip_hash_bignum: bad bn alloc\n");
         return false;
     }
-    BN_bn2bin(bignum, bn + 1);
+    bn_bn2bin(bignum, bn + 1);
     bn[0] = 0x0;
     padbyte = (bn[1] & 0x80) ? 1 : 0;
     pgp_hash_add(hash, bn, (unsigned) (len + padbyte));

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -624,7 +624,7 @@ limited_read_time(time_t *dest, pgp_region_t *region, pgp_stream_t *stream)
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param **pgn        return the integer there - the BIGNUM is created by bn_bin2bn() and
+ * \param **pgn        return the integer there - the bignum_t is created by bn_bin2bn() and
  * probably needs to be freed
  *                 by the caller XXX right ben?
  * \param *ptag        Pointer to current packet's Packet Tag.
@@ -642,7 +642,7 @@ limited_read_time(time_t *dest, pgp_region_t *region, pgp_stream_t *stream)
  * \see RFC4880 3.2
  */
 static bool
-limread_mpi(BIGNUM **pbn, pgp_region_t *region, pgp_stream_t *stream)
+limread_mpi(bignum_t **pbn, pgp_region_t *region, pgp_stream_t *stream)
 {
     uint8_t buf[RNP_BUFSIZ] = "";
     /* an MPI has a 2 byte length part.
@@ -919,7 +919,7 @@ cmd_get_password_free(pgp_seckey_password_t *skp)
 \brief Free allocated memory
 */
 static void
-free_BN(BIGNUM **pp)
+free_BN(bignum_t **pp)
 {
     if (*pp != NULL) {
         bn_free(*pp);
@@ -2797,8 +2797,8 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
     uint8_t             c = 0x0;
     uint8_t             cs[2];
     unsigned            k;
-    BIGNUM *            g_to_k = NULL;
-    BIGNUM *            enc_m = NULL;
+    bignum_t *          g_to_k = NULL;
+    bignum_t *          enc_m = NULL;
     int                 n;
     uint8_t             unencoded_m_buf[1024];
 

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -624,7 +624,7 @@ limited_read_time(time_t *dest, pgp_region_t *region, pgp_stream_t *stream)
  *
  * This function makes sure to respect packet boundaries.
  *
- * \param **pgn        return the integer there - the BIGNUM is created by BN_bin2bn() and
+ * \param **pgn        return the integer there - the BIGNUM is created by bn_bin2bn() and
  * probably needs to be freed
  *                 by the caller XXX right ben?
  * \param *ptag        Pointer to current packet's Packet Tag.
@@ -689,7 +689,7 @@ limread_mpi(BIGNUM **pbn, pgp_region_t *region, pgp_stream_t *stream)
          * draft says. -- peter */
         return false;
     }
-    *pbn = BN_bin2bn(buf, (int) length, NULL);
+    *pbn = bn_bin2bn(buf, (int) length, NULL);
     return true;
 }
 
@@ -922,7 +922,7 @@ static void
 free_BN(BIGNUM **pp)
 {
     if (*pp != NULL) {
-        BN_free(*pp);
+        bn_free(*pp);
         *pp = NULL;
     }
 }
@@ -2115,7 +2115,7 @@ parse_v4_sig(pgp_region_t *region, pgp_stream_t *stream)
         }
         if (rnp_get_debug(__FILE__)) {
             (void) fprintf(stderr, "parse_v4_sig: RSA: sig is\n");
-            BN_print_fp(stderr, pkt.u.sig.info.sig.rsa.sig);
+            bn_print_fp(stderr, pkt.u.sig.info.sig.rsa.sig);
             (void) fprintf(stderr, "\n");
         }
         break;
@@ -2867,7 +2867,7 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
             return false;
         }
         g_to_k = pkt.u.pk_sesskey.params.ecdh.ephemeral_point;
-        enc_m = BN_bin2bn(pkt.u.pk_sesskey.params.ecdh.encrypted_m,
+        enc_m = bn_bin2bn(pkt.u.pk_sesskey.params.ecdh.encrypted_m,
                           pkt.u.pk_sesskey.params.ecdh.encrypted_m_size,
                           enc_m);
         break;

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -150,7 +150,7 @@ print_string_and_value(int indent, const char *name, const char *str, uint8_t va
 }
 
 static void
-print_bn(int indent, const char *name, const BIGNUM *bn)
+print_bn(int indent, const char *name, const bignum_t *bn)
 {
     print_indent(indent);
     printf("%s = ", name);

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -155,9 +155,9 @@ print_bn(int indent, const char *name, const BIGNUM *bn)
     print_indent(indent);
     printf("%s = ", name);
     if (bn) {
-        BN_print_fp(stdout, bn);
+        bn_print_fp(stdout, bn);
         size_t bsz = 0;
-        (void) BN_num_bits(bn, &bsz);
+        (void) bn_num_bits(bn, &bsz);
         printf(" (%zu bits)\n", bsz);
     } else {
         puts("(unset)");
@@ -302,10 +302,10 @@ key_bitlength(const pgp_pubkey_t *pubkey)
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
-        (void) BN_num_bytes(pubkey->key.rsa.n, &sz);
+        (void) bn_num_bytes(pubkey->key.rsa.n, &sz);
         return sz * 8;
     case PGP_PKA_DSA:
-        (void) BN_num_bytes(pubkey->key.dsa.q, &sz);
+        (void) bn_num_bytes(pubkey->key.dsa.q, &sz);
         switch (sz) {
         case 20:
             return 1024;
@@ -317,14 +317,14 @@ key_bitlength(const pgp_pubkey_t *pubkey)
             return 0;
         }
     case PGP_PKA_ELGAMAL:
-        (void) BN_num_bytes(pubkey->key.elgamal.y, &sz);
+        (void) bn_num_bytes(pubkey->key.elgamal.y, &sz);
         return sz * 8;
 
     case PGP_PKA_ECDH:
     case PGP_PKA_ECDSA:
     case PGP_PKA_EDDSA:
     case PGP_PKA_SM2: {
-        // BN_num_bytes returns value <= curve order
+        // bn_num_bytes returns value <= curve order
         const ec_curve_desc_t *curve = get_curve_desc(pubkey->key.ecc.curve);
         return curve ? curve->bitlen : 0;
     }
@@ -964,10 +964,10 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         cc += snprintf(&out[cc],
                        outsize - cc,
                        "p=%s\nq=%s\ng=%s\ny=%s\n",
-                       BN_bn2hex(key->key.pubkey.key.dsa.p),
-                       BN_bn2hex(key->key.pubkey.key.dsa.q),
-                       BN_bn2hex(key->key.pubkey.key.dsa.g),
-                       BN_bn2hex(key->key.pubkey.key.dsa.y));
+                       bn_bn2hex(key->key.pubkey.key.dsa.p),
+                       bn_bn2hex(key->key.pubkey.key.dsa.q),
+                       bn_bn2hex(key->key.pubkey.key.dsa.g),
+                       bn_bn2hex(key->key.pubkey.key.dsa.y));
         break;
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
@@ -975,12 +975,12 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         cc += snprintf(&out[cc],
                        outsize - cc,
                        "n=%s\ne=%s\n",
-                       BN_bn2hex(key->key.pubkey.key.rsa.n),
-                       BN_bn2hex(key->key.pubkey.key.rsa.e));
+                       bn_bn2hex(key->key.pubkey.key.rsa.n),
+                       bn_bn2hex(key->key.pubkey.key.rsa.e));
         break;
     case PGP_PKA_EDDSA:
         cc += snprintf(
-          &out[cc], outsize - cc, "point=%s\n", BN_bn2hex(key->key.pubkey.key.ecc.point));
+          &out[cc], outsize - cc, "point=%s\n", bn_bn2hex(key->key.pubkey.key.ecc.point));
         break;
     case PGP_PKA_ECDSA:
     case PGP_PKA_SM2:
@@ -991,7 +991,7 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
                            outsize - cc,
                            "curve=%s\npoint=%s\n",
                            curve->botan_name,
-                           BN_bn2hex(key->key.pubkey.key.ecc.point));
+                           bn_bn2hex(key->key.pubkey.key.ecc.point));
         }
         break;
     }
@@ -1000,9 +1000,9 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         cc += snprintf(&out[cc],
                        outsize - cc,
                        "p=%s\ng=%s\ny=%s\n",
-                       BN_bn2hex(key->key.pubkey.key.elgamal.p),
-                       BN_bn2hex(key->key.pubkey.key.elgamal.g),
-                       BN_bn2hex(key->key.pubkey.key.elgamal.y));
+                       bn_bn2hex(key->key.pubkey.key.elgamal.p),
+                       bn_bn2hex(key->key.pubkey.key.elgamal.g),
+                       bn_bn2hex(key->key.pubkey.key.elgamal.y));
         break;
     default:
         (void) fprintf(stderr, "pgp_print_pubkey: Unusual algorithm\n");

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -616,29 +616,29 @@ signed_validate_signature(pgp_source_t *src, pgp_signature_t *sig, pgp_pubkey_t 
 
     switch (sig->palg) {
     case PGP_PKA_DSA: {
-        pgp_dsa_sig_t dsa = {.r = BN_bin2bn(sig->material.dsa.r, sig->material.dsa.rlen, NULL),
+        pgp_dsa_sig_t dsa = {.r = bn_bin2bn(sig->material.dsa.r, sig->material.dsa.rlen, NULL),
                              .s =
-                               BN_bin2bn(sig->material.dsa.s, sig->material.dsa.slen, NULL)};
+                               bn_bin2bn(sig->material.dsa.s, sig->material.dsa.slen, NULL)};
         ret = pgp_dsa_verify(hval, len, &dsa, &key->key.dsa);
-        BN_free(dsa.r);
-        BN_free(dsa.s);
+        bn_free(dsa.r);
+        bn_free(dsa.s);
         break;
     }
     case PGP_PKA_EDDSA: {
-        BIGNUM *r = BN_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL);
-        BIGNUM *s = BN_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL);
+        BIGNUM *r = bn_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL);
+        BIGNUM *s = bn_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL);
         ret = pgp_eddsa_verify_hash(r, s, hval, len, &key->key.ecc);
-        BN_free(r);
-        BN_free(s);
+        bn_free(r);
+        bn_free(s);
         break;
     }
     case PGP_PKA_SM2: {
-        pgp_ecc_sig_t ecc = {.r = BN_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL),
+        pgp_ecc_sig_t ecc = {.r = bn_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL),
                              .s =
-                               BN_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL)};
+                               bn_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL)};
         ret = pgp_sm2_verify_hash(&ecc, hval, len, &key->key.ecc) == RNP_SUCCESS;
-        BN_free(ecc.r);
-        BN_free(ecc.s);
+        bn_free(ecc.r);
+        bn_free(ecc.s);
         break;
     }
     case PGP_PKA_RSA: {
@@ -652,12 +652,12 @@ signed_validate_signature(pgp_source_t *src, pgp_signature_t *sig, pgp_pubkey_t 
         break;
     }
     case PGP_PKA_ECDSA: {
-        pgp_ecc_sig_t ecc = {.r = BN_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL),
+        pgp_ecc_sig_t ecc = {.r = bn_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL),
                              .s =
-                               BN_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL)};
+                               bn_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL)};
         ret = pgp_ecdsa_verify_hash(&ecc, hval, len, &key->key.ecc) == RNP_SUCCESS;
-        BN_free(ecc.r);
-        BN_free(ecc.s);
+        bn_free(ecc.r);
+        bn_free(ecc.s);
         break;
     }
     default:
@@ -1212,7 +1212,7 @@ encrypted_try_key(pgp_source_t *        src,
             RNP_LOG("ECDH fingerprint calculation failed");
             return false;
         }
-        ecdh_p = BN_bin2bn(sesskey->params.ecdh.p, sesskey->params.ecdh.plen, NULL);
+        ecdh_p = bn_bin2bn(sesskey->params.ecdh.p, sesskey->params.ecdh.plen, NULL);
 
         err = pgp_ecdh_decrypt_pkcs5(decbuf,
                                      &declen,
@@ -1222,7 +1222,7 @@ encrypted_try_key(pgp_source_t *        src,
                                      &seckey->key.ecc,
                                      &seckey->pubkey.key.ecdh,
                                      &fingerprint);
-        BN_free(ecdh_p);
+        bn_free(ecdh_p);
 
         if (err != RNP_SUCCESS) {
             RNP_LOG("ECDH decryption error %u", err);

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -625,8 +625,8 @@ signed_validate_signature(pgp_source_t *src, pgp_signature_t *sig, pgp_pubkey_t 
         break;
     }
     case PGP_PKA_EDDSA: {
-        BIGNUM *r = bn_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL);
-        BIGNUM *s = bn_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL);
+        bignum_t *r = bn_bin2bn(sig->material.ecc.r, sig->material.ecc.rlen, NULL);
+        bignum_t *s = bn_bin2bn(sig->material.ecc.s, sig->material.ecc.slen, NULL);
         ret = pgp_eddsa_verify_hash(r, s, hval, len, &key->key.ecc);
         bn_free(r);
         bn_free(s);
@@ -1161,7 +1161,7 @@ encrypted_try_key(pgp_source_t *        src,
     pgp_symm_alg_t    salg;
     unsigned          checksum = 0;
     bool              res = false;
-    BIGNUM *          ecdh_p;
+    bignum_t *        ecdh_p;
 
     /* Decrypting session key value */
     switch (sesskey->alg) {

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -403,7 +403,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
     case PGP_PKA_ECDH: {
         pgp_fingerprint_t fingerprint;
         size_t            outlen = sizeof(pkey.params.ecdh.m);
-        BIGNUM *          p;
+        bignum_t *        p;
 
         if (!pgp_fingerprint(&fingerprint, pubkey)) {
             RNP_LOG("ECDH fingerprint calculation failed");

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -411,7 +411,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
             goto finish;
         }
 
-        if (!(p = BN_new())) {
+        if (!(p = bn_new())) {
             RNP_LOG("allocation failed");
             ret = RNP_ERROR_OUT_OF_MEMORY;
             goto finish;
@@ -428,16 +428,16 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
 
         if (ret != RNP_SUCCESS) {
             RNP_LOG("ECDH encryption failed %d", ret);
-            BN_free(p);
+            bn_free(p);
             goto finish;
         }
 
         pkey.params.ecdh.mlen = outlen;
-        (void) BN_num_bytes(
+        (void) bn_num_bytes(
           p,
           (size_t *) &pkey.params.ecdh.plen); // can't fail as pgp_ecdh_encrypt_pkcs5 succeded
-        (void) BN_bn2bin(p, pkey.params.ecdh.p);
-        BN_free(p);
+        (void) bn_bn2bin(p, pkey.params.ecdh.p);
+        bn_free(p);
     } break;
     case PGP_PKA_ELGAMAL:
     case PGP_PKA_ELGAMAL_ENCRYPT_OR_SIGN: {

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -165,19 +165,19 @@ pkcs1_rsa_test_success(void **state)
     printf("PT = 0x%s\n", tmp);
     free(tmp);
     printf("N = ");
-    BN_print_fp(stdout, pub_rsa->n);
+    bn_print_fp(stdout, pub_rsa->n);
     printf("\n");
     printf("E = ");
-    BN_print_fp(stdout, pub_rsa->e);
+    bn_print_fp(stdout, pub_rsa->e);
     printf("\n");
     printf("P = ");
-    BN_print_fp(stdout, sec_rsa->p);
+    bn_print_fp(stdout, sec_rsa->p);
     printf("\n");
     printf("Q = ");
-    BN_print_fp(stdout, sec_rsa->q);
+    bn_print_fp(stdout, sec_rsa->q);
     printf("\n");
     printf("D = ");
-    BN_print_fp(stdout, sec_rsa->d);
+    bn_print_fp(stdout, sec_rsa->d);
     printf("\n");
 #endif
 
@@ -218,8 +218,8 @@ rnp_test_eddsa(void **state)
     rnp_assert_true(rstate, pgp_generate_seckey(&key_desc, seckey));
 
     const uint8_t hash[32] = {0};
-    BIGNUM *      r = BN_new();
-    BIGNUM *      s = BN_new();
+    BIGNUM *      r = bn_new();
+    BIGNUM *      s = bn_new();
 
     rnp_assert_int_equal(
       rstate,
@@ -238,8 +238,8 @@ rnp_test_eddsa(void **state)
     rnp_assert_int_equal(
       rstate, pgp_eddsa_verify_hash(r, s, hash, sizeof(hash) - 1, &seckey->pubkey.key.ecc), 0);
 
-    BN_free(r);
-    BN_free(s);
+    bn_free(r);
+    bn_free(s);
     pgp_seckey_free(seckey);
     free(seckey);
 }
@@ -265,21 +265,21 @@ raw_elg_test_success(void **state)
     const uint8_t        plaintext[] = {0x01, 0x02, 0x03, 0x04, 0x17};
 
     // Allocate needed memory
-    pub_elg.p = BN_bin2bn(p512, sizeof(p512), NULL);
+    pub_elg.p = bn_bin2bn(p512, sizeof(p512), NULL);
     rnp_assert_non_null(rstate, pub_elg.p);
 
-    pub_elg.g = BN_new();
+    pub_elg.g = bn_new();
     rnp_assert_non_null(rstate, pub_elg.g);
 
-    sec_elg.x = BN_new();
+    sec_elg.x = bn_new();
     rnp_assert_non_null(rstate, sec_elg.x);
 
-    pub_elg.y = BN_new();
+    pub_elg.y = bn_new();
     rnp_assert_non_null(rstate, pub_elg.y);
 
-    BN_set_word(pub_elg.g, 3);
-    BN_set_word(sec_elg.x, 0xCAB5432);
-    BN_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p);
+    bn_set_word(pub_elg.g, 3);
+    bn_set_word(sec_elg.x, 0xCAB5432);
+    bn_mod_exp(pub_elg.y, pub_elg.g, sec_elg.x, pub_elg.p);
 
     // Encrypt
     unsigned ctext_size = pgp_elgamal_public_encrypt_pkcs1(
@@ -289,32 +289,32 @@ raw_elg_test_success(void **state)
     ctext_size /= 2;
 
 #if defined(DEBUG_PRINT)
-    BIGNUM *tmp = BN_new();
+    BIGNUM *tmp = bn_new();
 
     printf("\tP\t= ");
-    BN_print_fp(stdout, pub_elg.p);
+    bn_print_fp(stdout, pub_elg.p);
     printf("\n");
     printf("\tG\t= ");
-    BN_print_fp(stdout, pub_elg.g);
+    bn_print_fp(stdout, pub_elg.g);
     printf("\n");
     printf("\tY\t= ");
-    BN_print_fp(stdout, pub_elg.y);
+    bn_print_fp(stdout, pub_elg.y);
     printf("\n");
     printf("\tX\t= ");
-    BN_print_fp(stdout, sec_elg.x);
+    bn_print_fp(stdout, sec_elg.x);
     printf("\n");
 
-    BN_bin2bn(g_to_k, ctext_size, tmp);
+    bn_bin2bn(g_to_k, ctext_size, tmp);
     printf("\tGtk\t= ");
-    BN_print_fp(stdout, tmp);
+    bn_print_fp(stdout, tmp);
     printf("\n");
 
-    BN_bin2bn(encm, ctext_size, tmp);
+    bn_bin2bn(encm, ctext_size, tmp);
     printf("\tMM\t= ");
-    BN_print_fp(stdout, tmp);
+    bn_print_fp(stdout, tmp);
     printf("\n");
 
-    BN_clear_free(tmp);
+    bn_clear_free(tmp);
 #endif
 
     rnp_assert_int_not_equal(
@@ -329,10 +329,10 @@ raw_elg_test_success(void **state)
       test_value_equal("ElGamal decrypt", "0102030417", decryption_result, sizeof(plaintext)));
 
     // Free heap
-    BN_clear_free(pub_elg.p);
-    BN_clear_free(pub_elg.g);
-    BN_clear_free(sec_elg.x);
-    BN_clear_free(pub_elg.y);
+    bn_clear_free(pub_elg.p);
+    bn_clear_free(pub_elg.g);
+    bn_clear_free(sec_elg.x);
+    bn_clear_free(pub_elg.y);
 }
 
 void
@@ -389,8 +389,8 @@ ecdsa_signverify_success(void **state)
                              pgp_ecdsa_verify_hash(&sig, message, sizeof(message), pub_key1),
                              RNP_ERROR_SIGNATURE_INVALID);
 
-        BN_clear_free(sig.r);
-        BN_clear_free(sig.s);
+        bn_clear_free(sig.r);
+        bn_clear_free(sig.s);
         pgp_seckey_free(seckey1);
         free(seckey1);
         pgp_seckey_free(seckey2);
@@ -416,7 +416,7 @@ ecdh_roundtrip(void **state)
     size_t            result_len = sizeof(result);
     BIGNUM *          tmp_eph_key;
 
-    tmp_eph_key = BN_new();
+    tmp_eph_key = bn_new();
 
     rnp_assert_true(rstate, tmp_eph_key != NULL);
 
@@ -447,7 +447,7 @@ ecdh_roundtrip(void **state)
                              RNP_SUCCESS);
 
         size_t sz;
-        rnp_assert_true(rstate, BN_num_bytes(tmp_eph_key, &sz));
+        rnp_assert_true(rstate, bn_num_bytes(tmp_eph_key, &sz));
         rnp_assert_int_equal(rstate, sz, expected_result_byte_size);
 
         rnp_assert_int_equal(rstate,
@@ -466,7 +466,7 @@ ecdh_roundtrip(void **state)
         pgp_seckey_free(&ecdh_key1);
     }
 
-    BN_free(tmp_eph_key);
+    bn_free(tmp_eph_key);
 }
 
 void
@@ -481,7 +481,7 @@ ecdh_decryptionNegativeCases(void **state)
     size_t            result_len = sizeof(result);
     BIGNUM *          tmp_eph_key;
 
-    tmp_eph_key = BN_new();
+    tmp_eph_key = bn_new();
     rnp_assert_true(rstate, tmp_eph_key != NULL);
 
     const rnp_keygen_crypto_params_t key_desc = {.key_alg = PGP_PKA_ECDH,
@@ -509,7 +509,7 @@ ecdh_decryptionNegativeCases(void **state)
                                                 &ecdh_key1_fpr),
                          RNP_SUCCESS);
     size_t sz;
-    rnp_assert_true(rstate, BN_num_bytes(tmp_eph_key, &sz));
+    rnp_assert_true(rstate, bn_num_bytes(tmp_eph_key, &sz));
     rnp_assert_int_equal(rstate, sz, expected_result_byte_size);
 
     rnp_assert_int_equal(rstate,
@@ -595,7 +595,7 @@ ecdh_decryptionNegativeCases(void **state)
 
     // Change ephemeral key, so that it fails to decrypt
 
-    BN_clear(tmp_eph_key);
+    bn_clear(tmp_eph_key);
     rnp_assert_int_equal(rstate,
                          pgp_ecdh_decrypt_pkcs5(result,
                                                 &result_len,
@@ -611,7 +611,7 @@ ecdh_decryptionNegativeCases(void **state)
     rnp_assert_int_equal(rstate, memcmp(plaintext, result, result_len), 0);
     pgp_seckey_free(&ecdh_key1);
 
-    BN_free(tmp_eph_key);
+    bn_free(tmp_eph_key);
 }
 
 void

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -218,8 +218,8 @@ rnp_test_eddsa(void **state)
     rnp_assert_true(rstate, pgp_generate_seckey(&key_desc, seckey));
 
     const uint8_t hash[32] = {0};
-    BIGNUM *      r = bn_new();
-    BIGNUM *      s = bn_new();
+    bignum_t *    r = bn_new();
+    bignum_t *    s = bn_new();
 
     rnp_assert_int_equal(
       rstate,
@@ -289,7 +289,7 @@ raw_elg_test_success(void **state)
     ctext_size /= 2;
 
 #if defined(DEBUG_PRINT)
-    BIGNUM *tmp = bn_new();
+    bignum_t *tmp = bn_new();
 
     printf("\tP\t= ");
     bn_print_fp(stdout, pub_elg.p);
@@ -414,7 +414,7 @@ ecdh_roundtrip(void **state)
     size_t            plaintext_len = sizeof(plaintext);
     uint8_t           result[32] = {0};
     size_t            result_len = sizeof(result);
-    BIGNUM *          tmp_eph_key;
+    bignum_t *        tmp_eph_key;
 
     tmp_eph_key = bn_new();
 
@@ -479,7 +479,7 @@ ecdh_decryptionNegativeCases(void **state)
     size_t            plaintext_len = sizeof(plaintext);
     uint8_t           result[32] = {0};
     size_t            result_len = sizeof(result);
-    BIGNUM *          tmp_eph_key;
+    bignum_t *        tmp_eph_key;
 
     tmp_eph_key = bn_new();
     rnp_assert_true(rstate, tmp_eph_key != NULL);

--- a/src/tests/key-protect.c
+++ b/src/tests/key-protect.c
@@ -134,10 +134,10 @@ test_key_protect_load_pgp(void **state)
     assert_non_null(key->key.seckey.key.rsa.u);
 
     // save the secret MPIs for some later comparisons
-    BIGNUM *d = BN_dup(key->key.seckey.key.rsa.d);
-    BIGNUM *p = BN_dup(key->key.seckey.key.rsa.p);
-    BIGNUM *q = BN_dup(key->key.seckey.key.rsa.q);
-    BIGNUM *u = BN_dup(key->key.seckey.key.rsa.u);
+    BIGNUM *d = bn_dup(key->key.seckey.key.rsa.d);
+    BIGNUM *p = bn_dup(key->key.seckey.key.rsa.p);
+    BIGNUM *q = bn_dup(key->key.seckey.key.rsa.q);
+    BIGNUM *u = bn_dup(key->key.seckey.key.rsa.u);
 
     // confirm that packets[0] is no longer encrypted
     {
@@ -165,16 +165,16 @@ test_key_protect_load_pgp(void **state)
 
         // compare MPIs of the reloaded key, with the unlocked key from earlier
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.d));
+          0, bn_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.d));
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.p, reloaded_key->key.seckey.key.rsa.p));
+          0, bn_cmp(key->key.seckey.key.rsa.p, reloaded_key->key.seckey.key.rsa.p));
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.q, reloaded_key->key.seckey.key.rsa.q));
+          0, bn_cmp(key->key.seckey.key.rsa.q, reloaded_key->key.seckey.key.rsa.q));
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.u, reloaded_key->key.seckey.key.rsa.u));
+          0, bn_cmp(key->key.seckey.key.rsa.u, reloaded_key->key.seckey.key.rsa.u));
         // negative test to try to ensure the above is a valid test
         assert_int_not_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.p));
+          0, bn_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.p));
 
         // lock it
         assert_true(pgp_key_lock(reloaded_key));
@@ -192,13 +192,13 @@ test_key_protect_load_pgp(void **state)
         assert_false(pgp_key_is_locked(reloaded_key));
         // compare MPIs of the reloaded key, with the unlocked key from earlier
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.d));
+          0, bn_cmp(key->key.seckey.key.rsa.d, reloaded_key->key.seckey.key.rsa.d));
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.p, reloaded_key->key.seckey.key.rsa.p));
+          0, bn_cmp(key->key.seckey.key.rsa.p, reloaded_key->key.seckey.key.rsa.p));
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.q, reloaded_key->key.seckey.key.rsa.q));
+          0, bn_cmp(key->key.seckey.key.rsa.q, reloaded_key->key.seckey.key.rsa.q));
         assert_int_equal(
-          0, BN_cmp(key->key.seckey.key.rsa.u, reloaded_key->key.seckey.key.rsa.u));
+          0, bn_cmp(key->key.seckey.key.rsa.u, reloaded_key->key.seckey.key.rsa.u));
 
         rnp_key_store_free(ks);
     }
@@ -257,15 +257,15 @@ test_key_protect_load_pgp(void **state)
     assert_false(pgp_key_is_locked(key));
 
     // compare secret MPIs with those from earlier
-    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.d, d));
-    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.p, p));
-    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.q, q));
-    assert_int_equal(0, BN_cmp(key->key.seckey.key.rsa.u, u));
+    assert_int_equal(0, bn_cmp(key->key.seckey.key.rsa.d, d));
+    assert_int_equal(0, bn_cmp(key->key.seckey.key.rsa.p, p));
+    assert_int_equal(0, bn_cmp(key->key.seckey.key.rsa.q, q));
+    assert_int_equal(0, bn_cmp(key->key.seckey.key.rsa.u, u));
 
     // cleanup
     pgp_key_free(key);
-    BN_free(d);
-    BN_free(p);
-    BN_free(q);
-    BN_free(u);
+    bn_free(d);
+    bn_free(p);
+    bn_free(q);
+    bn_free(u);
 }

--- a/src/tests/key-protect.c
+++ b/src/tests/key-protect.c
@@ -134,10 +134,10 @@ test_key_protect_load_pgp(void **state)
     assert_non_null(key->key.seckey.key.rsa.u);
 
     // save the secret MPIs for some later comparisons
-    BIGNUM *d = bn_dup(key->key.seckey.key.rsa.d);
-    BIGNUM *p = bn_dup(key->key.seckey.key.rsa.p);
-    BIGNUM *q = bn_dup(key->key.seckey.key.rsa.q);
-    BIGNUM *u = bn_dup(key->key.seckey.key.rsa.u);
+    bignum_t *d = bn_dup(key->key.seckey.key.rsa.d);
+    bignum_t *p = bn_dup(key->key.seckey.key.rsa.p);
+    bignum_t *q = bn_dup(key->key.seckey.key.rsa.q);
+    bignum_t *u = bn_dup(key->key.seckey.key.rsa.u);
 
     // confirm that packets[0] is no longer encrypted
     {


### PR DESCRIPTION
Should be good now

*    Changes PGPV_BN_xxxx to bn_xxxx
*    Removes not needed defines
*    Changes structure called BIGNUM to bignum_t
*   All done with sed

Closes #543