### PR TITLE
AEAD-EAX encryption support

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -382,7 +382,7 @@ typedef enum {
     PGP_CIPHER_MODE_OCB = 3,
 } pgp_cipher_mode_t;
 
-typedef enum { PGP_AEAD_NONE = 0, PGP_AEAD_EAX = 1 } pgp_aead_alg_t;
+typedef enum { PGP_AEAD_NONE = 0, PGP_AEAD_EAX = 1, PGP_AEAD_OCB = 2 } pgp_aead_alg_t;
 
 /** s2k_usage_t
  */
@@ -471,7 +471,8 @@ typedef enum {
     PGP_SIG_SUBPKT_FEATURES = 30,           /* features */
     PGP_SIG_SUBPKT_SIGNATURE_TARGET = 31,   /* signature target */
     PGP_SIG_SUBPKT_EMBEDDED_SIGNATURE = 32, /* embedded signature */
-    PGP_SIG_SUBPKT_ISSUER_FPR = 33          /* issuer fingerprint */
+    PGP_SIG_SUBPKT_ISSUER_FPR = 33,         /* issuer fingerprint */
+    PGP_SIG_SUBPKT_PREFERRED_AEAD = 34      /* preferred AEAD algorithms */
 } pgp_sig_subpacket_type_t;
 
 /** Key Flags

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -363,6 +363,8 @@ typedef enum {
     PGP_CIPHER_MODE_OCB = 3,
 } pgp_cipher_mode_t;
 
+typedef enum { PGP_AEAD_NONE = 0, PGP_AEAD_EAX = 1 } pgp_aead_alg_t;
+
 /** s2k_usage_t
  */
 typedef enum {

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -110,6 +110,9 @@
 /* Authentication tag len for AEAD/EAX */
 #define PGP_AEAD_EAX_TAG_LEN 16
 
+/* Maximum AEAD tag length */
+#define PGP_AEAD_MAX_TAG_LEN 16
+
 /* Maximum authenticated data length for AEAD */
 #define PGP_AEAD_MAX_AD_LEN 32
 

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -98,6 +98,12 @@
 /* Size of the fingerprint */
 #define PGP_FINGERPRINT_SIZE 20
 
+/* Nonce (IV) len for AEAD/EAX */
+#define PGP_AEAD_EAX_NONCE_LEN 16
+
+/* Authentication tag len for AEAD/EAX */
+#define PGP_AEAD_EAX_TAG_LEN 16
+
 /** Old Packet Format Lengths.
  * Defines the meanings of the 2 bits for length type in the
  * old packet format.
@@ -483,7 +489,7 @@ typedef enum {
     PGP_C_UNKNOWN = 255
 } pgp_compression_type_t;
 
-enum { PGP_SE_IP_DATA_VERSION = 1, PGP_PKSK_V3 = 3, PGP_SKSK_V4 = 4 };
+enum { PGP_SE_IP_DATA_VERSION = 1, PGP_PKSK_V3 = 3, PGP_SKSK_V4 = 4, PGP_SKSK_V5 = 5 };
 
 /** Version.
  * OpenPGP has two different protocol versions: version 3 and version 4.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -162,31 +162,32 @@ enum {
  * \see RFC4880 5.2.3.1
  */
 typedef enum {
-    PGP_PTAG_CT_RESERVED = 0,       /* Reserved - a packet tag must
-                                     * not have this value */
-    PGP_PTAG_CT_PK_SESSION_KEY = 1, /* Public-Key Encrypted Session
-                                     * Key Packet */
-    PGP_PTAG_CT_SIGNATURE = 2,      /* Signature Packet */
-    PGP_PTAG_CT_SK_SESSION_KEY = 3, /* Symmetric-Key Encrypted Session
-                                     * Key Packet */
-    PGP_PTAG_CT_1_PASS_SIG = 4,     /* One-Pass Signature
-                                     * Packet */
-    PGP_PTAG_CT_SECRET_KEY = 5,     /* Secret Key Packet */
-    PGP_PTAG_CT_PUBLIC_KEY = 6,     /* Public Key Packet */
-    PGP_PTAG_CT_SECRET_SUBKEY = 7,  /* Secret Subkey Packet */
-    PGP_PTAG_CT_COMPRESSED = 8,     /* Compressed Data Packet */
-    PGP_PTAG_CT_SE_DATA = 9,        /* Symmetrically Encrypted Data Packet */
-    PGP_PTAG_CT_MARKER = 10,        /* Marker Packet */
-    PGP_PTAG_CT_LITDATA = 11,       /* Literal Data Packet */
-    PGP_PTAG_CT_TRUST = 12,         /* Trust Packet */
-    PGP_PTAG_CT_USER_ID = 13,       /* User ID Packet */
-    PGP_PTAG_CT_PUBLIC_SUBKEY = 14, /* Public Subkey Packet */
-    PGP_PTAG_CT_RESERVED2 = 15,     /* reserved */
-    PGP_PTAG_CT_RESERVED3 = 16,     /* reserved */
-    PGP_PTAG_CT_USER_ATTR = 17,     /* User Attribute Packet */
-    PGP_PTAG_CT_SE_IP_DATA = 18,    /* Sym. Encrypted and Integrity
-                                     * Protected Data Packet */
-    PGP_PTAG_CT_MDC = 19,           /* Modification Detection Code Packet */
+    PGP_PTAG_CT_RESERVED = 0,        /* Reserved - a packet tag must
+                                      * not have this value */
+    PGP_PTAG_CT_PK_SESSION_KEY = 1,  /* Public-Key Encrypted Session
+                                      * Key Packet */
+    PGP_PTAG_CT_SIGNATURE = 2,       /* Signature Packet */
+    PGP_PTAG_CT_SK_SESSION_KEY = 3,  /* Symmetric-Key Encrypted Session
+                                      * Key Packet */
+    PGP_PTAG_CT_1_PASS_SIG = 4,      /* One-Pass Signature
+                                      * Packet */
+    PGP_PTAG_CT_SECRET_KEY = 5,      /* Secret Key Packet */
+    PGP_PTAG_CT_PUBLIC_KEY = 6,      /* Public Key Packet */
+    PGP_PTAG_CT_SECRET_SUBKEY = 7,   /* Secret Subkey Packet */
+    PGP_PTAG_CT_COMPRESSED = 8,      /* Compressed Data Packet */
+    PGP_PTAG_CT_SE_DATA = 9,         /* Symmetrically Encrypted Data Packet */
+    PGP_PTAG_CT_MARKER = 10,         /* Marker Packet */
+    PGP_PTAG_CT_LITDATA = 11,        /* Literal Data Packet */
+    PGP_PTAG_CT_TRUST = 12,          /* Trust Packet */
+    PGP_PTAG_CT_USER_ID = 13,        /* User ID Packet */
+    PGP_PTAG_CT_PUBLIC_SUBKEY = 14,  /* Public Subkey Packet */
+    PGP_PTAG_CT_RESERVED2 = 15,      /* reserved */
+    PGP_PTAG_CT_RESERVED3 = 16,      /* reserved */
+    PGP_PTAG_CT_USER_ATTR = 17,      /* User Attribute Packet */
+    PGP_PTAG_CT_SE_IP_DATA = 18,     /* Sym. Encrypted and Integrity
+                                      * Protected Data Packet */
+    PGP_PTAG_CT_MDC = 19,            /* Modification Detection Code Packet */
+    PGP_PTAG_CT_AEAD_ENCRYPTED = 20, /* AEAD Encrypted Data Packet, RFC 4880bis */
 
     PGP_PARSER_PTAG = 0x100, /* Internal Use: The packet is the "Packet
                               * Tag" itself - used when callback sends

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -98,11 +98,20 @@
 /* Size of the fingerprint */
 #define PGP_FINGERPRINT_SIZE 20
 
+/* Maximum length of the packet header */
+#define PGP_MAX_HEADER_SIZE 6
+
 /* Nonce (IV) len for AEAD/EAX */
 #define PGP_AEAD_EAX_NONCE_LEN 16
 
+/* Maximum AEAD nonce length */
+#define PGP_AEAD_MAX_NONCE_LEN 16
+
 /* Authentication tag len for AEAD/EAX */
 #define PGP_AEAD_EAX_TAG_LEN 16
+
+/* Maximum authenticated data length for AEAD */
+#define PGP_AEAD_MAX_AD_LEN 32
 
 /** Old Packet Format Lengths.
  * Defines the meanings of the 2 bits for length type in the

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -115,6 +115,7 @@ typedef struct rnp_ctx_t {
     pgp_symm_alg_t  ealg;          /* encryption algorithm */
     int             zalg;          /* compression algorithm used */
     int             zlevel;        /* compression level */
+    pgp_aead_alg_t  aalg;          /* non-zero to use AEAD */
     bool            overwrite;     /* allow to overwrite output file if exists */
     bool            armor;         /* whether to use ASCII armor on output */
     list            recipients;    /* recipients of the encrypted message */

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -349,7 +349,7 @@ write_protected_seckey_body(pgp_output_t *output, pgp_seckey_t *seckey, const ch
     }
 
     // use the session key to encrypt
-    if (!pgp_cipher_start(
+    if (!pgp_cipher_cfb_start(
           &crypt, seckey->protection.symm_alg, sesskey, seckey->protection.iv)) {
         goto done;
     }
@@ -393,7 +393,7 @@ done:
     for (unsigned i = 0; i < writers_pushed; i++) {
         pgp_writer_pop(output);
     }
-    pgp_cipher_finish(&crypt);
+    pgp_cipher_cfb_finish(&crypt);
     return ret;
 }
 

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -537,6 +537,12 @@ pgp_cipher_aead_init(pgp_crypt_t *  crypt,
     return true;
 }
 
+size_t
+pgp_cipher_aead_granularity(pgp_crypt_t *crypt)
+{
+    return crypt->aead.granularity;
+}
+
 bool
 pgp_cipher_aead_set_ad(pgp_crypt_t *crypt, const uint8_t *ad, size_t len)
 {
@@ -609,6 +615,12 @@ pgp_cipher_aead_finish(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size
     }
 
     return true;
+}
+
+void
+pgp_cipher_aead_reset(pgp_crypt_t *crypt)
+{
+    botan_cipher_clear(crypt->aead.obj);
 }
 
 void

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -120,6 +120,13 @@ bool pgp_cipher_aead_init(pgp_crypt_t *  crypt,
                           const uint8_t *key,
                           bool           decrypt);
 
+/** @brief Return the AEAD cipher update granularity. Botan FFI will consume chunks which are
+ *         multiple of this value. See the description of pgp_cipher_aead_update()
+ *  @param crypt initialized AEAD crypto
+ *  @return Update granularity value in bytes
+ */
+size_t pgp_cipher_aead_granularity(pgp_crypt_t *crypt);
+
 /** @brief Set associated data
  *  @param crypt initialized AEAD crypto
  *  @param ad buffer with data. Cannot be NULL.
@@ -162,6 +169,11 @@ bool pgp_cipher_aead_update(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in,
  *               tag size.
  */
 bool pgp_cipher_aead_finish(pgp_crypt_t *crypt, uint8_t *out, const uint8_t *in, size_t len);
+
+/** @brief Reset the cipher state without the need of key re-scheduling
+ *  @param crypt Initialized AEAD crypto
+ */
+void pgp_cipher_aead_reset(pgp_crypt_t *crypt);
 
 /** @brief Destroy the cipher object, deallocating all the memory.
  *  @param crypt initialized AEAD crypto

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -589,16 +589,20 @@ typedef struct {
     unsigned       version;
     pgp_symm_alg_t alg;
     pgp_s2k_t      s2k;
-    uint8_t        enckey[PGP_MAX_KEY_SIZE + 1];
+    uint8_t        enckey[PGP_MAX_KEY_SIZE + PGP_AEAD_EAX_TAG_LEN + 1];
     unsigned       enckeylen;
+    /* v5 specific fields */
+    pgp_aead_alg_t aalg;
+    uint8_t        iv[PGP_MAX_BLOCK_SIZE];
+    unsigned       ivlen;
 } pgp_sk_sesskey_t;
 
 /** pgp_seckey_password_t */
 typedef struct {
     const pgp_seckey_t *seckey;
     char **             password; /* point somewhere that gets filled
-                                     * in to work around constness of
-                                     * content */
+                                   * in to work around constness of
+                                   * content */
 } pgp_seckey_password_t;
 
 /** pgp_get_seckey_t */

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -336,7 +336,11 @@ typedef struct pgp_sig_subpkt_t {
             const char *str;
             unsigned    len;
         } revocation_reason; /* 5.2.3.23.  Reason for Revocation */
-        bool feature_mdc;    /* 5.2.3.24.  Features */
+        struct {
+            bool mdc;
+            bool aead;
+            bool key_v5;
+        } features; /* 5.2.3.24.  Features */
         struct {
             pgp_pubkey_alg_t pkalg;
             pgp_hash_alg_t   halg;

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -141,6 +141,19 @@ void *      pgp_new(size_t);
         ((uint8_t *) (x))[3] = (uint8_t)((y) >> 0) & 0xff;  \
     } while (0)
 
+/* Store big-endian 64-bit value x in y */
+#define STORE64BE(x, y)                                     \
+    do {                                                    \
+        ((uint8_t *) (x))[0] = (uint8_t)((y) >> 56) & 0xff; \
+        ((uint8_t *) (x))[1] = (uint8_t)((y) >> 48) & 0xff; \
+        ((uint8_t *) (x))[2] = (uint8_t)((y) >> 40) & 0xff; \
+        ((uint8_t *) (x))[3] = (uint8_t)((y) >> 32) & 0xff; \
+        ((uint8_t *) (x))[4] = (uint8_t)((y) >> 24) & 0xff; \
+        ((uint8_t *) (x))[5] = (uint8_t)((y) >> 16) & 0xff; \
+        ((uint8_t *) (x))[6] = (uint8_t)((y) >> 8) & 0xff;  \
+        ((uint8_t *) (x))[7] = (uint8_t)((y) >> 0) & 0xff;  \
+    } while (0)
+
 /* Swap endianness of 32-bit value */
 #if defined(__GNUC__) || defined(__clang__)
 #define BSWAP32(x) __builtin_bswap32(x)

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -384,7 +384,7 @@ ssh2seckey(pgp_io_t *io, const char *f, pgp_key_t *key, pgp_pubkey_t *pubkey)
         return false;
     }
 
-    pgp_cipher_start(
+    pgp_cipher_cfb_start(
       &crypted, key->key.seckey.protection.symm_alg, sesskey, key->key.seckey.protection.iv);
     ssh_fingerprint(&key->fingerprint, pubkey);
     ssh_keyid(key->keyid, sizeof(key->keyid), pubkey);

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2636,10 +2636,10 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
             hexdump(stderr, "key", derived_key, keysize);
         }
 
-        if (!pgp_cipher_start(&decrypt,
-                              pkt.u.seckey.protection.symm_alg,
-                              derived_key,
-                              pkt.u.seckey.protection.iv)) {
+        if (!pgp_cipher_cfb_start(&decrypt,
+                                  pkt.u.seckey.protection.symm_alg,
+                                  derived_key,
+                                  pkt.u.seckey.protection.iv)) {
             return false;
         }
 
@@ -2978,7 +2978,7 @@ parse_pk_sesskey(pgp_region_t *region, pgp_stream_t *stream)
         (void) fprintf(stderr, "got pk session key via callback\n");
     }
 
-    if (!pgp_cipher_start(
+    if (!pgp_cipher_cfb_start(
           &stream->decrypt, pkt.u.pk_sesskey.symm_alg, pkt.u.pk_sesskey.key, NULL))
         return false;
 

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -1456,7 +1456,7 @@ pgp_reader_pop_decrypt(pgp_stream_t *stream)
     encrypted_t *encrypted;
 
     encrypted = pgp_reader_get_arg(pgp_readinfo(stream));
-    pgp_cipher_finish(encrypted->decrypt);
+    pgp_cipher_cfb_finish(encrypted->decrypt);
     free(encrypted);
     pgp_reader_pop(stream);
 }

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -128,7 +128,7 @@ bool
 src_read_eq(pgp_source_t *src, void *buf, size_t len)
 {
     ssize_t res = src_read(src, buf, len);
-    return res == (size_t) len;
+    return res == (ssize_t) len;
 }
 
 ssize_t

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -124,6 +124,13 @@ finish:
     return len;
 }
 
+bool
+src_read_eq(pgp_source_t *src, void *buf, size_t len)
+{
+    ssize_t res = src_read(src, buf, len);
+    return res == (size_t) len;
+}
+
 ssize_t
 src_peek(pgp_source_t *src, void *buf, size_t len)
 {

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -55,13 +55,13 @@ typedef enum {
 typedef struct pgp_source_t pgp_source_t;
 typedef struct pgp_dest_t   pgp_dest_t;
 
-typedef ssize_t pgp_source_read_func_t(pgp_source_t *src, void *buf, size_t len);
+typedef ssize_t      pgp_source_read_func_t(pgp_source_t *src, void *buf, size_t len);
 typedef rnp_result_t pgp_source_finish_func_t(pgp_source_t *src);
-typedef void pgp_source_close_func_t(pgp_source_t *src);
+typedef void         pgp_source_close_func_t(pgp_source_t *src);
 
 typedef rnp_result_t pgp_dest_write_func_t(pgp_dest_t *dst, const void *buf, size_t len);
 typedef rnp_result_t pgp_dest_finish_func_t(pgp_dest_t *src);
-typedef void pgp_dest_close_func_t(pgp_dest_t *dst, bool discard);
+typedef void         pgp_dest_close_func_t(pgp_dest_t *dst, bool discard);
 
 /* statically preallocated cache for sources */
 typedef struct pgp_source_cache_t {
@@ -106,11 +106,16 @@ bool init_src_common(pgp_source_t *src, size_t paramsize);
  **/
 ssize_t src_read(pgp_source_t *src, void *buf, size_t len);
 
+/** @brief shortcut to read exactly len bytes from source. See src_read for parameters.
+ *  @return true if len bytes were read or false otherwise (i.e. less then len were read or
+ *          read error occurred) */
+bool src_read_eq(pgp_source_t *src, void *buf, size_t len);
+
 /** @brief read up to len bytes and keep them in the cache/do not process
  *  Works only for streams with cache
  *  @param src source structure
  *  @param buf preallocated buffer which can store up to len bytes, or NULL if data should be
- *  discarded, just making sure that needed input is available in source
+ *             discarded, just making sure that needed input is available in source
  *  @param len number of bytes to read. Must be less then PGP_INPUT_CACHE_SIZE.
  *  @return number of bytes read or -1 in case of error
  **/
@@ -128,13 +133,13 @@ ssize_t src_skip(pgp_source_t *src, size_t len);
  *  @param src allocated and initialized source structure
  *  @return RNP_SUCCESS or error code. If source doesn't have finish handler then also
  * RNP_SUCCESS is returned
-*/
+ */
 rnp_result_t src_finish(pgp_source_t *src);
 
 /** @brief check whether there is no more input on source
  *  @param src allocated and initialized source structure
  *  @return true if there is no more input or false otherwise
-*/
+ */
 bool src_eof(pgp_source_t *src);
 
 /** @brief close the source and deallocate all internal resources if any

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -192,7 +192,7 @@ typedef struct pgp_dest_t {
     pgp_stream_type_t       type;
     rnp_result_t            werr; /* write function may set this to some error code */
 
-    int64_t  writeb;   /* number of bytes written */
+    size_t   writeb;   /* number of bytes written */
     void *   param;    /* source-specific additional data */
     bool     no_cache; /* disable write caching */
     uint8_t  cache[PGP_OUTPUT_CACHE_SIZE];

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -1020,6 +1020,7 @@ signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
     case PGP_SIG_SUBPKT_PREFERRED_SKA:
     case PGP_SIG_SUBPKT_PREFERRED_HASH:
     case PGP_SIG_SUBPKT_PREF_COMPRESS:
+    case PGP_SIG_SUBPKT_PREFERRED_AEAD:
         subpkt->fields.preferred.arr = subpkt->data;
         subpkt->fields.preferred.len = subpkt->len;
         break;
@@ -1086,7 +1087,9 @@ signature_parse_subpacket(pgp_sig_subpkt_t *subpkt)
         break;
     case PGP_SIG_SUBPKT_FEATURES:
         if ((oklen = subpkt->len >= 1)) {
-            subpkt->fields.feature_mdc = subpkt->data[0] & 0x01;
+            subpkt->fields.features.mdc = subpkt->data[0] & 0x01;
+            subpkt->fields.features.aead = subpkt->data[0] & 0x02;
+            subpkt->fields.features.key_v5 = subpkt->data[0] & 0x04;
         }
         break;
     case PGP_SIG_SUBPKT_SIGNATURE_TARGET:

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -145,6 +145,8 @@ rnp_result_t stream_read_packet_body(pgp_source_t *src, pgp_packet_body_t *body)
 
 bool stream_write_sk_sesskey(pgp_sk_sesskey_t *skey, pgp_dest_t *dst);
 
+size_t stream_sk_sesskey_len(pgp_sk_sesskey_t *skey);
+
 bool stream_write_pk_sesskey(pgp_pk_sesskey_pkt_t *pkey, pgp_dest_t *dst);
 
 bool stream_write_one_pass(pgp_one_pass_sig_t *onepass, pgp_dest_t *dst);

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -538,7 +538,7 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     }
 
     read = sizeof(param->cache) - PGP_AEAD_EAX_TAG_LEN;
-    if (read >= param->chunklen - param->chunkin) {
+    if ((size_t) read >= param->chunklen - param->chunkin) {
         read = param->chunklen - param->chunkin;
         chunkend = true;
     }

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -526,7 +526,7 @@ encrypted_src_read(pgp_source_t *src, void *buf, size_t len)
 
         if (parsemdc) {
             pgp_cipher_cfb_decrypt(&param->decrypt, mdcbuf, mdcbuf, MDC_V1_SIZE);
-            pgp_cipher_finish(&param->decrypt);
+            pgp_cipher_cfb_finish(&param->decrypt);
             pgp_hash_add(&param->mdc, mdcbuf, 2);
             pgp_hash_finish(&param->mdc, hash);
 
@@ -1110,7 +1110,7 @@ encrypted_decrypt_header(pgp_source_t *src, pgp_symm_alg_t alg, uint8_t *key)
     }
 
     /* having symmetric key in keybuf let's decrypt blocksize + 2 bytes and check them */
-    if (!pgp_cipher_start(&crypt, alg, key, NULL)) {
+    if (!pgp_cipher_cfb_start(&crypt, alg, key, NULL)) {
         RNP_LOG("failed to start cipher");
         return false;
     }
@@ -1126,7 +1126,7 @@ encrypted_decrypt_header(pgp_source_t *src, pgp_symm_alg_t alg, uint8_t *key)
             pgp_cipher_cfb_resync(&param->decrypt, enchdr + 2);
         } else {
             if (!pgp_hash_create(&param->mdc, PGP_HASH_SHA1)) {
-                pgp_cipher_finish(&crypt);
+                pgp_cipher_cfb_finish(&crypt);
                 RNP_LOG("cannot create sha1 hash");
                 return false;
             }
@@ -1283,12 +1283,12 @@ encrypted_try_password(pgp_source_t *src, const char *password)
 
         if (symkey->enckeylen > 0) {
             /* decrypting session key */
-            if (!pgp_cipher_start(&crypt, symkey->alg, keybuf, NULL)) {
+            if (!pgp_cipher_cfb_start(&crypt, symkey->alg, keybuf, NULL)) {
                 continue;
             }
 
             pgp_cipher_cfb_decrypt(&crypt, keybuf, symkey->enckey, symkey->enckeylen);
-            pgp_cipher_finish(&crypt);
+            pgp_cipher_cfb_finish(&crypt);
 
             keyavail = true;
             alg = (pgp_symm_alg_t) keybuf[0];

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -78,6 +78,7 @@ static const char *usage = "--help OR\n"
                            "\t[--armor] AND/OR\n"
                            "\t[--cipher=<ciphername>] AND/OR\n"
                            "\t[--zip, --zlib, --bzip, -z 0..9] AND/OR\n"
+                           "\t[--aead] AND/OR\n"
                            "\t[--coredumps] AND/OR\n"
                            "\t[--homedir=<homedir>] AND/OR\n"
                            "\t[--keyring=<keyring>] AND/OR\n"
@@ -129,6 +130,7 @@ enum optdefs {
     OPT_ZALG_BZIP,
     OPT_ZLEVEL,
     OPT_OVERWRITE,
+    OPT_AEAD,
 
     /* debug */
     OPT_DEBUG
@@ -198,6 +200,7 @@ static struct option options[] = {
   {"bzip", no_argument, NULL, OPT_ZALG_BZIP},
   {"bzip2", no_argument, NULL, OPT_ZALG_BZIP},
   {"overwrite", no_argument, NULL, OPT_OVERWRITE},
+  {"aead", no_argument, NULL, OPT_AEAD},
 
   {NULL, 0, NULL, 0},
 };
@@ -385,6 +388,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         ctx.ealg = pgp_str_to_cipher(rnp_cfg_getstr(cfg, CFG_CIPHER));
         ctx.zalg = rnp_cfg_getint(cfg, CFG_ZALG);
         ctx.zlevel = rnp_cfg_getint(cfg, CFG_ZLEVEL);
+        ctx.aalg = rnp_cfg_getint(cfg, CFG_AEAD);
         ret = rnp_protect_file(&ctx, f, rnp_cfg_getstr(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
     }
@@ -600,6 +604,9 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
         break;
     case OPT_ZALG_BZIP:
         rnp_cfg_setint(cfg, CFG_ZALG, PGP_C_BZIP2);
+        break;
+    case OPT_AEAD:
+        rnp_cfg_setint(cfg, CFG_AEAD, PGP_AEAD_EAX);
         break;
     case OPT_OVERWRITE:
         rnp_cfg_setbool(cfg, CFG_OVERWRITE, true);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -65,6 +65,7 @@
 #define CFG_EXPERT "expert"             /* expert key generation mode */
 #define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
 #define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
+#define CFG_AEAD "aead"                 /* if nonzero then AEAD enryption mode, int */
 #define CFG_KEYSTORE_DISABLED \
     "disable_keystore"    /* indicates wether keystore must be initialized */
 #define CFG_FORCE "force" /* force command to succeed operation */

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -103,7 +103,7 @@ cipher_test_success(void **state)
     uint8_t cfb_data[20] = {0};
     memset(iv, 0x42, sizeof(iv));
 
-    rnp_assert_int_equal(rstate, 1, pgp_cipher_start(&crypt, alg, key, iv));
+    rnp_assert_int_equal(rstate, 1, pgp_cipher_cfb_start(&crypt, alg, key, iv));
 
     rnp_assert_int_equal(
       rstate, 0, pgp_cipher_cfb_encrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data)));
@@ -114,9 +114,9 @@ cipher_test_success(void **state)
                                           "BFDAA57CB812189713A950AD9947887983021617",
                                           cfb_data,
                                           sizeof(cfb_data)));
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_finish(&crypt));
+    rnp_assert_int_equal(rstate, 0, pgp_cipher_cfb_finish(&crypt));
 
-    rnp_assert_int_equal(rstate, 1, pgp_cipher_start(&crypt, alg, key, iv));
+    rnp_assert_int_equal(rstate, 1, pgp_cipher_cfb_start(&crypt, alg, key, iv));
     rnp_assert_int_equal(
       rstate, 0, pgp_cipher_cfb_decrypt(&crypt, cfb_data, cfb_data, sizeof(cfb_data)));
     rnp_assert_int_equal(rstate,
@@ -125,7 +125,7 @@ cipher_test_success(void **state)
                                           "0000000000000000000000000000000000000000",
                                           cfb_data,
                                           sizeof(cfb_data)));
-    rnp_assert_int_equal(rstate, 0, pgp_cipher_finish(&crypt));
+    rnp_assert_int_equal(rstate, 0, pgp_cipher_cfb_finish(&crypt));
 }
 
 void


### PR DESCRIPTION
This PR implements AEAD-EAX encryption mode as defined in rfc4880bis-03.
It implements AEAD-EAX for SESK and AEAD encrypted data packet, but do not implement it for secret key encryption (this will be implemented separately, when key loading/saving will be moved to streams).
Also rfc4880-03 seems to introduce changes in AEAD format soon, once they will be published I'll reflect them to the rnp.

To enable AEAD encryption mode just add `--aead` to the encrypting command line.

Some changes are just strange behavior of clang-format, will re-check it.