### PR TITLE
Rename 'birthtime' and 'duration' to more applicable names

### DIFF
--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -230,7 +230,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
     }
     /* populate pgp key structure */
     seckey->pubkey.version = PGP_V4;
-    seckey->pubkey.birthtime = time(NULL);
+    seckey->pubkey.creation = time(NULL);
     seckey->pubkey.alg = crypto->key_alg;
     rng_t *rng = crypto->rng;
 
@@ -250,7 +250,7 @@ pgp_generate_seckey(const rnp_keygen_crypto_params_t *crypto, pgp_seckey_t *seck
         break;
     case PGP_PKA_ECDH:
         if (!set_ecdh_params(seckey, crypto->ecc.curve)) {
-            RNP_LOG("Unsupoorted curve [ID=%d]", crypto->ecc.curve);
+            RNP_LOG("Unsupported curve [ID=%d]", crypto->ecc.curve);
             goto end;
         }
     /* FALLTHROUGH */

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -226,7 +226,7 @@ static bool
 write_pubkey_body(const pgp_pubkey_t *key, pgp_output_t *output)
 {
     if (!(pgp_write_scalar(output, (unsigned) key->version, 1) &&
-          pgp_write_scalar(output, (unsigned) key->birthtime, 4))) {
+          pgp_write_scalar(output, (unsigned) key->creation, 4))) {
         return false;
     }
 

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -238,7 +238,7 @@ ptimestr(char *dest, size_t size, time_t t)
 static void
 format_json_key(FILE *fp, json_object *obj, const int psigs)
 {
-    int64_t birthtime;
+    int64_t creation;
     int64_t duration;
     time_t  now;
     char    tbuf[32];
@@ -277,8 +277,8 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
     }
 
     if (json_object_object_get_ex(obj, "creation time", &tmp)) {
-        birthtime = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
-        p(fp, " ", ptimestr(tbuf, sizeof(tbuf), birthtime), NULL);
+        creation = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
+        p(fp, " ", ptimestr(tbuf, sizeof(tbuf), creation), NULL);
 
         if (json_object_object_get_ex(obj, "usage", &tmp)) {
             p(fp, " [", NULL);
@@ -298,8 +298,8 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
                 now = time(NULL);
                 p(fp,
                   " ",
-                  (birthtime + duration < now) ? "[EXPIRED " : "[EXPIRES ",
-                  ptimestr(tbuf, sizeof(tbuf), birthtime + duration),
+                  (creation + duration < now) ? "[EXPIRED " : "[EXPIRES ",
+                  ptimestr(tbuf, sizeof(tbuf), creation + duration),
                   "]",
                   NULL);
             }

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -239,7 +239,7 @@ static void
 format_json_key(FILE *fp, json_object *obj, const int psigs)
 {
     int64_t creation;
-    int64_t duration;
+    int64_t expiration;
     time_t  now;
     char    tbuf[32];
 
@@ -292,14 +292,14 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
             p(fp, "]", NULL);
         }
 
-        if (json_object_object_get_ex(obj, "duration", &tmp)) {
-            duration = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
-            if (duration > 0) {
+        if (json_object_object_get_ex(obj, "expiration", &tmp)) {
+            expiration = (int64_t) strtoll(json_object_get_string(tmp), NULL, 10);
+            if (expiration > 0) {
                 now = time(NULL);
                 p(fp,
                   " ",
-                  (creation + duration < now) ? "[EXPIRED " : "[EXPIRES ",
-                  ptimestr(tbuf, sizeof(tbuf), creation + duration),
+                  (creation + expiration < now) ? "[EXPIRED " : "[EXPIRES ",
+                  ptimestr(tbuf, sizeof(tbuf), creation + expiration),
                   "]",
                   NULL);
             }

--- a/src/lib/signature.c
+++ b/src/lib/signature.c
@@ -418,7 +418,7 @@ hash_add_trailer(pgp_hash_t *hash, const pgp_sig_t *sig, const uint8_t *raw_pack
         pgp_hash_add_int(hash, (unsigned) sig->info.v4_hashlen, 4);
     } else {
         pgp_hash_add_int(hash, (unsigned) sig->info.type, 1);
-        pgp_hash_add_int(hash, (unsigned) sig->info.birthtime, 4);
+        pgp_hash_add_int(hash, (unsigned) sig->info.creation, 4);
     }
 }
 

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -150,7 +150,7 @@ typedef struct {
 typedef struct pgp_pubkey_t {
     pgp_version_t version; /* version of the key (v3, v4...) */
     time_t        creation;
-    time_t        duration; /* v4 duration time (not always set, see SS_KEY_EXPIRY) */
+    time_t        expiration; /* v4 expiration time (not always set, see SS_KEY_EXPIRY) */
     /* validity period of the key in days since
      * creation.  A value of 0 has a special meaning
      * indicating this key does not expire.  Only used with
@@ -233,7 +233,7 @@ typedef struct pgp_sig_info_t {
     /* **Note**: the following 3 fields are only valid if
      * their corresponding bitfields are 1 (see below). */
     time_t  creation;                   /* creation time of the signature */
-    time_t  duration;                   /* number of seconds it's valid for */
+    time_t  expiration;                 /* number of seconds it's valid for */
     uint8_t signer_id[PGP_KEY_ID_SIZE]; /* Eight-octet key ID
                                          * of signer */
     pgp_pubkey_alg_t key_alg;           /* public key algorithm number */
@@ -252,8 +252,8 @@ typedef struct pgp_sig_info_t {
      *   creation_set
      *   - v3 sig pkts have an explicit creation time field
      *   - v4 sig pkts MAY specify the creation time via a sigsubpkt
-     *   duration_set
-     *   - v3 sig pkts have no duration/expiration
+     *   expiration_set
+     *   - v3 sig pkts have no expiration
      *   - v4 sig pkts MAY have an expiration via a sigsubpkt
      *   signer_id_set
      *   - v3 sig pkts have an explicit signer id field
@@ -261,7 +261,7 @@ typedef struct pgp_sig_info_t {
      */
     unsigned creation_set : 1;
     unsigned signer_id_set : 1;
-    unsigned duration_set : 1;
+    unsigned expiration_set : 1;
 } pgp_sig_info_t;
 
 /** Struct used when parsing a signature */

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -149,13 +149,13 @@ typedef struct {
 /** Structure to hold a pgp public key */
 typedef struct pgp_pubkey_t {
     pgp_version_t version; /* version of the key (v3, v4...) */
-    time_t        birthtime;
-    time_t        duration; /* v4 duration (not always set, see SS_KEY_EXPIRY) */
+    time_t        creation;
+    time_t        duration; /* v4 duration time (not always set, see SS_KEY_EXPIRY) */
     /* validity period of the key in days since
      * creation.  A value of 0 has a special meaning
      * indicating this key does not expire.  Only used with
      * v3 keys.  */
-    unsigned         days_valid; /* v3 duration */
+    unsigned         days_valid; /* v3 validity time */
     pgp_pubkey_alg_t alg;        /* Public Key Algorithm type */
     union {
         pgp_dsa_pubkey_t     dsa;     /* A DSA public key */
@@ -232,7 +232,7 @@ typedef struct pgp_sig_info_t {
 
     /* **Note**: the following 3 fields are only valid if
      * their corresponding bitfields are 1 (see below). */
-    time_t  birthtime;                  /* creation time of the signature */
+    time_t  creation;                   /* creation time of the signature */
     time_t  duration;                   /* number of seconds it's valid for */
     uint8_t signer_id[PGP_KEY_ID_SIZE]; /* Eight-octet key ID
                                          * of signer */
@@ -249,7 +249,7 @@ typedef struct pgp_sig_info_t {
     uint8_t *v4_hashed;
 
     /* These are here because:
-     *   birthtime_set
+     *   creation_set
      *   - v3 sig pkts have an explicit creation time field
      *   - v4 sig pkts MAY specify the creation time via a sigsubpkt
      *   duration_set
@@ -259,7 +259,7 @@ typedef struct pgp_sig_info_t {
      *   - v3 sig pkts have an explicit signer id field
      *   - v4 sig pkts MAY specify the signer id via a sigsubpkt
      */
-    unsigned birthtime_set : 1;
+    unsigned creation_set : 1;
     unsigned signer_id_set : 1;
     unsigned duration_set : 1;
 } pgp_sig_info_t;

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -568,7 +568,7 @@ rnp_key_store_kbx_write_pgp(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *m)
     }
 
     for (i = 0; i < key->subsigc; i++) {
-        if (!pu32(m, key->subsigs[i].sig.info.duration)) {
+        if (!pu32(m, key->subsigs[i].sig.info.expiration)) {
             return false;
         }
     }

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -171,7 +171,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
         subsig->trustamount = pkt->u.ss_trust.amount;
         break;
     case PGP_PTAG_SS_KEY_EXPIRY:
-        key->key.pubkey.duration = pkt->u.ss_time;
+        key->key.pubkey.expiration = pkt->u.ss_time;
         break;
     case PGP_PTAG_SS_PRIMARY_USER_ID:
         if (content->ss_primary_userid) {

--- a/src/librekey/key_store_ssh.c
+++ b/src/librekey/key_store_ssh.c
@@ -257,7 +257,7 @@ ssh2pubkey(pgp_io_t *io, const char *f, pgp_key_t *key)
     memset(key, 0x0, sizeof(*key));
     pubkey = &key->key.seckey.pubkey;
     pubkey->version = PGP_V4;
-    pubkey->birthtime = 0;
+    pubkey->creation = 0;
     /* get key type */
     ok = true;
     switch (pubkey->alg = findstr(pkatypes, buf)) {

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -1291,7 +1291,7 @@ parse_pubkey_data(pgp_pubkey_t *key, pgp_region_t *region, pgp_stream_t *stream)
                     key->version);
         return false;
     }
-    if (!limited_read_time(&key->birthtime, region, stream)) {
+    if (!limited_read_time(&key->creation, region, stream)) {
         return false;
     }
 
@@ -1559,10 +1559,10 @@ parse_v3_sig(pgp_region_t *region, pgp_stream_t *stream)
     pkt.u.sig.info.type = (pgp_sig_type_t) c;
     /* XXX: check signature type */
 
-    if (!limited_read_time(&pkt.u.sig.info.birthtime, region, stream)) {
+    if (!limited_read_time(&pkt.u.sig.info.creation, region, stream)) {
         return false;
     }
-    pkt.u.sig.info.birthtime_set = 1;
+    pkt.u.sig.info.creation_set = 1;
 
     if (!limread(pkt.u.sig.info.signer_id, PGP_KEY_ID_SIZE, region, stream)) {
         return false;
@@ -1714,8 +1714,8 @@ parse_one_sig_subpacket(pgp_sig_t *sig, pgp_region_t *region, pgp_stream_t *stre
         if (!limited_read_time(&pkt.u.ss_time, &subregion, stream))
             return false;
         if (pkt.tag == PGP_PTAG_SS_CREATION_TIME) {
-            sig->info.birthtime = pkt.u.ss_time;
-            sig->info.birthtime_set = 1;
+            sig->info.creation = pkt.u.ss_time;
+            sig->info.creation_set = 1;
         }
         if (pkt.tag == PGP_PTAG_SS_EXPIRATION_TIME) {
             sig->info.duration = pkt.u.ss_time;

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -1718,8 +1718,8 @@ parse_one_sig_subpacket(pgp_sig_t *sig, pgp_region_t *region, pgp_stream_t *stre
             sig->info.creation_set = 1;
         }
         if (pkt.tag == PGP_PTAG_SS_EXPIRATION_TIME) {
-            sig->info.duration = pkt.u.ss_time;
-            sig->info.duration_set = 1;
+            sig->info.expiration = pkt.u.ss_time;
+            sig->info.expiration_set = 1;
         }
         break;
 

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -76,9 +76,9 @@ __RCSID("$NetBSD: packet-print.c,v 1.42 2012/02/22 06:29:40 agc Exp $");
 
 #define PTIMESTR_LEN 10
 
-#define PUBKEY_DOES_EXPIRE(pk) ((pk)->duration > 0)
+#define PUBKEY_DOES_EXPIRE(pk) ((pk)->expiration > 0)
 
-#define PUBKEY_HAS_EXPIRED(pk, t) (((pk)->creation + (pk)->duration) < (t))
+#define PUBKEY_HAS_EXPIRED(pk, t) (((pk)->creation + (pk)->expiration) < (t))
 
 #define SIGNATURE_PADDING "          "
 
@@ -192,13 +192,13 @@ print_utf8_string(int indent, const char *name, const uint8_t *str)
 }
 
 static void
-print_duration(int indent, const char *name, time_t t)
+print_expiration(int indent, const char *name, time_t t)
 {
     int mins, hours, days, years;
 
     print_indent(indent);
     printf("%s: ", name);
-    printf("duration %" PRItime "d seconds", (long long) t);
+    printf("expiration %" PRItime "d seconds", (long long) t);
 
     mins = (int) (t / 60);
     hours = mins / 60;
@@ -426,7 +426,7 @@ format_pubkey_expiration_notice(char *              buffer,
         return false;
 
     /* Write the expiration time. */
-    ptimestr(buffer, buffer_end - buffer, pubkey->creation + pubkey->duration);
+    ptimestr(buffer, buffer_end - buffer, pubkey->creation + pubkey->expiration);
     buffer += PTIMESTR_LEN;
     if (buffer >= buffer_end)
         return false;
@@ -721,7 +721,7 @@ repgp_sprint_json(pgp_io_t *                    io,
                            json_object_new_string(rnp_strhexdump(
                              fp, key->fingerprint.fingerprint, key->fingerprint.length, "")));
     json_object_object_add(keyjson, "creation time", json_object_new_int(pubkey->creation));
-    json_object_object_add(keyjson, "duration", json_object_new_int(pubkey->duration));
+    json_object_object_add(keyjson, "expiration", json_object_new_int(pubkey->expiration));
     json_object_object_add(keyjson, "key flags", json_object_new_int(key->key_flags));
     json_object *usage_arr = json_object_new_array();
     format_key_usage_json(usage_arr, key->key_flags);
@@ -811,7 +811,7 @@ pgp_hkp_sprint_key(pgp_io_t *                    io,
                       sizeof(uidbuf) - n,
                       "uid:%lld:%lld:%s\n",
                       (long long) pubkey->creation,
-                      (long long) pubkey->duration,
+                      (long long) pubkey->expiration,
                       key->uids[i]);
         for (j = 0; j < key->subsigc; j++) {
             if (psigs) {
@@ -838,7 +838,7 @@ pgp_hkp_sprint_key(pgp_io_t *                    io,
                            rnp_strhexdump(
                              keyid, key->subsigs[j].sig.info.signer_id, PGP_KEY_ID_SIZE, ""),
                            (long long) (key->subsigs[j].sig.info.creation),
-                           (long long) pubkey->duration);
+                           (long long) pubkey->expiration);
             } else {
                 n +=
                   snprintf(&uidbuf[n],
@@ -867,7 +867,7 @@ pgp_hkp_sprint_key(pgp_io_t *                    io,
                          pubkey->alg,
                          key_bitlength(pubkey),
                          (long long) pubkey->creation,
-                         (long long) pubkey->duration,
+                         (long long) pubkey->expiration,
                          uidbuf);
             *buf = buffer;
         }
@@ -1244,9 +1244,9 @@ pgp_print_packet(pgp_cbdata_t *cbinfo, const pgp_packet_t *pkt)
         if (content->sig.info.creation_set) {
             print_time(print->indent, "Signature Creation Time", content->sig.info.creation);
         }
-        if (content->sig.info.duration_set) {
+        if (content->sig.info.expiration_set) {
             print_uint(
-              print->indent, "Signature Duration", (unsigned) content->sig.info.duration);
+              print->indent, "Signature Expiration", (unsigned) content->sig.info.expiration);
         }
 
         print_string_and_value(print->indent,
@@ -1359,13 +1359,13 @@ pgp_print_packet(pgp_cbdata_t *cbinfo, const pgp_packet_t *pkt)
 
     case PGP_PTAG_SS_EXPIRATION_TIME:
         start_subpacket(&print->indent, pkt->tag);
-        print_duration(print->indent, "Signature Expiration Time", content->ss_time);
+        print_expiration(print->indent, "Signature Expiration Time", content->ss_time);
         end_subpacket(&print->indent);
         break;
 
     case PGP_PTAG_SS_KEY_EXPIRY:
         start_subpacket(&print->indent, pkt->tag);
-        print_duration(print->indent, "Key Expiration Time", content->ss_time);
+        print_expiration(print->indent, "Key Expiration Time", content->ss_time);
         end_subpacket(&print->indent);
         break;
 
@@ -1587,9 +1587,9 @@ pgp_print_packet(pgp_cbdata_t *cbinfo, const pgp_packet_t *pkt)
         if (content->sig.info.creation_set) {
             print_time(print->indent, "Signature Creation Time", content->sig.info.creation);
         }
-        if (content->sig.info.duration_set) {
+        if (content->sig.info.expiration_set) {
             print_uint(
-              print->indent, "Signature Duration", (unsigned) content->sig.info.duration);
+              print->indent, "Signature Expiration", (unsigned) content->sig.info.expiration);
         }
         print_string_and_value(print->indent,
                                "Signature Type",

--- a/src/librepgp/validate.c
+++ b/src/librepgp/validate.c
@@ -437,7 +437,7 @@ validate_result_status(const char *f, pgp_validation_t *val)
     char   buf[128];
 
     now = time(NULL);
-    if (now < val->birthtime) {
+    if (now < val->creation) {
         /* signature is not valid yet! */
         if (f) {
             (void) fprintf(stderr, "\"%s\": ", f);
@@ -446,13 +446,13 @@ validate_result_status(const char *f, pgp_validation_t *val)
         }
         (void) fprintf(stderr,
                        "signature not valid until %.24s (%s)\n",
-                       ctime(&val->birthtime),
-                       fmtsecs((int64_t)(val->birthtime - now), buf, sizeof(buf)));
+                       ctime(&val->creation),
+                       fmtsecs((int64_t)(val->creation - now), buf, sizeof(buf)));
         return false;
     }
-    if (val->duration != 0 && now > val->birthtime + val->duration) {
+    if (val->duration != 0 && now > val->creation + val->duration) {
         /* signature has expired */
-        t = val->duration + val->birthtime;
+        t = val->duration + val->creation;
         if (f) {
             (void) fprintf(stderr, "\"%s\": ", f);
         } else {

--- a/src/librepgp/validate.c
+++ b/src/librepgp/validate.c
@@ -450,9 +450,9 @@ validate_result_status(const char *f, pgp_validation_t *val)
                        fmtsecs((int64_t)(val->creation - now), buf, sizeof(buf)));
         return false;
     }
-    if (val->duration != 0 && now > val->creation + val->duration) {
+    if (val->expiration != 0 && now > val->creation + val->expiration) {
         /* signature has expired */
-        t = val->duration + val->creation;
+        t = val->expiration + val->creation;
         if (f) {
             (void) fprintf(stderr, "\"%s\": ", f);
         } else {

--- a/src/librepgp/validate.h
+++ b/src/librepgp/validate.h
@@ -61,7 +61,7 @@ typedef struct pgp_validation_t {
     unsigned        unknownc;
     pgp_sig_info_t *unknown_sigs;
     time_t          creation;
-    time_t          duration;
+    time_t          expiration;
     rnp_ctx_t *     rnp_ctx;
 } pgp_validation_t;
 

--- a/src/librepgp/validate.h
+++ b/src/librepgp/validate.h
@@ -60,7 +60,7 @@ typedef struct pgp_validation_t {
     pgp_sig_info_t *invalid_sigs;
     unsigned        unknownc;
     pgp_sig_info_t *unknown_sigs;
-    time_t          birthtime;
+    time_t          creation;
     time_t          duration;
     rnp_ctx_t *     rnp_ctx;
 } pgp_validation_t;

--- a/src/rnp/rnp.1
+++ b/src/rnp/rnp.1
@@ -56,7 +56,7 @@
 .Op Fl Fl pass\-fd Ns = Ns Ar fd
 .Op Fl Fl from Ns = Ns Ar sig-valid-from
 .Op Fl Fl num\-tries Ns = Ns Ar attempts
-.Op Fl Fl duration Ns = Ns Ar sig-valid-duration
+.Op Fl Fl expiration Ns = Ns Ar sig-valid-expiration
 .Op options
 .Ar file ...
 .Nm
@@ -302,7 +302,7 @@ until a specific point in time.
 The time can be specified either in
 .Dv YYYY-MM-DD
 format, or as the number of seconds since the epoch.
-.It Fl Fl duration Ns = Ns Ar signature-valid-to
+.It Fl Fl expiration Ns = Ns Ar signature-valid-to
 This option allows the signer to specify a time as the
 end point for validity of the signature.
 In this way it is possible to prevent files from being verified

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -120,7 +120,7 @@ enum optdefs {
     OPT_PASSWD,
     OPT_SSHKEYFILE,
     OPT_MAX_MEM_ALLOC,
-    OPT_DURATION,
+    OPT_EXPIRATION,
     OPT_CREATION,
     OPT_CIPHER,
     OPT_NUMTRIES,
@@ -187,8 +187,8 @@ static struct option options[] = {
   {"max-mem", required_argument, NULL, OPT_MAX_MEM_ALLOC},
   {"max-alloc", required_argument, NULL, OPT_MAX_MEM_ALLOC},
   {"creation", required_argument, NULL, OPT_CREATION},
-  {"duration", required_argument, NULL, OPT_DURATION},
-  {"expiry", required_argument, NULL, OPT_DURATION},
+  {"expiration", required_argument, NULL, OPT_EXPIRATION},
+  {"expiry", required_argument, NULL, OPT_EXPIRATION},
   {"cipher", required_argument, NULL, OPT_CIPHER},
   {"num-tries", required_argument, NULL, OPT_NUMTRIES},
   {"numtries", required_argument, NULL, OPT_NUMTRIES},
@@ -363,7 +363,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         ctx.zalg = rnp_cfg_getint(cfg, CFG_ZALG);
         ctx.zlevel = rnp_cfg_getint(cfg, CFG_ZLEVEL);
         ctx.sigcreate = get_creation(rnp_cfg_get(cfg, CFG_CREATION));
-        ctx.sigexpire = get_duration(rnp_cfg_get(cfg, CFG_DURATION));
+        ctx.sigexpire = get_expiration(rnp_cfg_get(cfg, CFG_EXPIRATION));
         ctx.clearsign = cmd == CMD_CLEARSIGN;
         ctx.detached = rnp_cfg_getbool(cfg, CFG_DETACHED);
 
@@ -581,8 +581,8 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
     case OPT_MAX_MEM_ALLOC:
         rnp_cfg_set(cfg, CFG_MAXALLOC, arg);
         break;
-    case OPT_DURATION:
-        rnp_cfg_set(cfg, CFG_DURATION, arg);
+    case OPT_EXPIRATION:
+        rnp_cfg_set(cfg, CFG_EXPIRATION, arg);
         break;
     case OPT_CREATION:
         rnp_cfg_set(cfg, CFG_CREATION, arg);

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -121,7 +121,7 @@ enum optdefs {
     OPT_SSHKEYFILE,
     OPT_MAX_MEM_ALLOC,
     OPT_DURATION,
-    OPT_BIRTHTIME,
+    OPT_CREATION,
     OPT_CIPHER,
     OPT_NUMTRIES,
     OPT_ZALG_ZIP,
@@ -186,10 +186,7 @@ static struct option options[] = {
   {"maxmemalloc", required_argument, NULL, OPT_MAX_MEM_ALLOC},
   {"max-mem", required_argument, NULL, OPT_MAX_MEM_ALLOC},
   {"max-alloc", required_argument, NULL, OPT_MAX_MEM_ALLOC},
-  {"from", required_argument, NULL, OPT_BIRTHTIME},
-  {"birth", required_argument, NULL, OPT_BIRTHTIME},
-  {"birthtime", required_argument, NULL, OPT_BIRTHTIME},
-  {"creation", required_argument, NULL, OPT_BIRTHTIME},
+  {"creation", required_argument, NULL, OPT_CREATION},
   {"duration", required_argument, NULL, OPT_DURATION},
   {"expiry", required_argument, NULL, OPT_DURATION},
   {"cipher", required_argument, NULL, OPT_CIPHER},
@@ -365,7 +362,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
 
         ctx.zalg = rnp_cfg_getint(cfg, CFG_ZALG);
         ctx.zlevel = rnp_cfg_getint(cfg, CFG_ZLEVEL);
-        ctx.sigcreate = get_birthtime(rnp_cfg_get(cfg, CFG_BIRTHTIME));
+        ctx.sigcreate = get_creation(rnp_cfg_get(cfg, CFG_CREATION));
         ctx.sigexpire = get_duration(rnp_cfg_get(cfg, CFG_DURATION));
         ctx.clearsign = cmd == CMD_CLEARSIGN;
         ctx.detached = rnp_cfg_getbool(cfg, CFG_DETACHED);
@@ -587,8 +584,8 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
     case OPT_DURATION:
         rnp_cfg_set(cfg, CFG_DURATION, arg);
         break;
-    case OPT_BIRTHTIME:
-        rnp_cfg_set(cfg, CFG_BIRTHTIME, arg);
+    case OPT_CREATION:
+        rnp_cfg_set(cfg, CFG_CREATION, arg);
         break;
     case OPT_CIPHER:
         rnp_cfg_set(cfg, CFG_CIPHER, arg);

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -697,20 +697,20 @@ grabdate(const char *s, int64_t *t)
 }
 
 /**
- * @brief Get signature validity duration time from the user input
+ * @brief Get signature validity expiration time from the user input
  *
- * Signature duration may be specified in different formats:
+ * Signature expiration may be specified in different formats:
  * - 10d : 10 days (you can use [h]ours, d[ays], [w]eeks, [m]onthes)
  * - 2017-07-12 : as the exact date when signature becomes invalid
  * - 60000 : number of seconds
  *
  * @param s [in] NULL-terminated string with the date
  * @param t [out] On successfull return result will be placed here
- * @return duration time in seconds
+ * @return expiration time in seconds
  */
 
 uint64_t
-get_duration(const char *s)
+get_expiration(const char *s)
 {
     uint64_t now;
     int64_t  t;

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -752,7 +752,7 @@ get_duration(const char *s)
  */
 
 int64_t
-get_birthtime(const char *s)
+get_creation(const char *s)
 {
     int64_t t;
 

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -53,7 +53,7 @@
 #define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
 #define CFG_DURATION "duration"         /* signature validity duration */
-#define CFG_BIRTHTIME "birthtime"       /* signature validity start */
+#define CFG_CREATION "creation"       /* signature validity start */
 #define CFG_CIPHER "cipher"             /* symmetric encryption algorithm as string */
 #define CFG_HASH "hash"                 /* hash algorithm used, string like 'SHA1'*/
 #define CFG_IO_OUTS "outs"              /* output stream */
@@ -118,6 +118,6 @@ int rnp_cfg_get_pswdtries(rnp_cfg_t *cfg);
 
 /* rnp CLI helper functions */
 uint64_t get_duration(const char *s);
-int64_t get_birthtime(const char *s);
+int64_t get_creation(const char *s);
 
 #endif

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -52,7 +52,7 @@
 #define CFG_PASSWD "password" /* password as command-line constant */
 #define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
-#define CFG_DURATION "duration"         /* signature validity duration */
+#define CFG_EXPIRATION "expiration"     /* signature expiration time */
 #define CFG_CREATION "creation"       /* signature validity start */
 #define CFG_CIPHER "cipher"             /* symmetric encryption algorithm as string */
 #define CFG_HASH "hash"                 /* hash algorithm used, string like 'SHA1'*/
@@ -117,7 +117,7 @@ void rnp_cfg_get_defkey(rnp_cfg_t *cfg, rnp_params_t *params);
 int rnp_cfg_get_pswdtries(rnp_cfg_t *cfg);
 
 /* rnp CLI helper functions */
-uint64_t get_duration(const char *s);
+uint64_t get_expiration(const char *s);
 int64_t get_creation(const char *s);
 
 #endif

--- a/src/tests/key-add-userid.c
+++ b/src/tests/key-add-userid.c
@@ -110,7 +110,7 @@ test_key_add_userid(void **state)
     assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 2], "added1"));
     assert_int_equal(key->uidc - 2, key->subsigs[key->subsigc - 2].uid);
     assert_int_equal(0xAB, key->subsigs[key->subsigc - 2].key_flags);
-    assert_int_equal(123456789, key->key.pubkey.duration);
+    assert_int_equal(123456789, key->key.pubkey.expiration);
     // added2
     assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 1], "added2"));
     assert_int_equal(key->uidc - 1, key->subsigs[key->subsigc - 1].uid);
@@ -142,7 +142,7 @@ test_key_add_userid(void **state)
     assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 2], "added1"));
     assert_int_equal(key->uidc - 2, key->subsigs[key->subsigc - 2].uid);
     assert_int_equal(0xAB, key->subsigs[key->subsigc - 2].key_flags);
-    assert_int_equal(123456789, key->key.pubkey.duration);
+    assert_int_equal(123456789, key->key.pubkey.expiration);
     // added2
     assert_int_equal(0, strcmp((char *) key->uids[key->uidc - 1], "added2"));
     assert_int_equal(key->uidc - 1, key->subsigs[key->subsigc - 1].uid);

--- a/src/tests/load-pgp.c
+++ b/src/tests/load-pgp.c
@@ -246,11 +246,11 @@ test_load_check_bitfields_and_times(void **state)
         assert_int_equal(ss->sig.info.creation_set, 1);
         assert_int_equal(ss->sig.info.creation, expected_creation_times[i]);
         // check SS_EXPIRATION_TIME
-        assert_int_equal(ss->sig.info.duration_set, 0);
-        assert_int_equal(ss->sig.info.duration, 0);
+        assert_int_equal(ss->sig.info.expiration_set, 0);
+        assert_int_equal(ss->sig.info.expiration, 0);
     }
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 0);
+    assert_int_equal(key->key.pubkey.expiration, 0);
 
     // find
     from = 0;
@@ -269,10 +269,10 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.creation, 1500569820);
     assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
-    assert_int_equal(key->subsigs[0].sig.info.duration, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration_set, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration, 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 0);
+    assert_int_equal(key->key.pubkey.expiration, 0);
 
     // find
     from = 0;
@@ -291,10 +291,10 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.creation, 1500569851);
     assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
-    assert_int_equal(key->subsigs[0].sig.info.duration, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration_set, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration, 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 123 * 24 * 60 * 60 /* 123 days */);
+    assert_int_equal(key->key.pubkey.expiration, 123 * 24 * 60 * 60 /* 123 days */);
 
     // find
     from = 0;
@@ -313,10 +313,10 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.creation, 1500569896);
     assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
-    assert_int_equal(key->subsigs[0].sig.info.duration, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration_set, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration, 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 0);
+    assert_int_equal(key->key.pubkey.expiration, 0);
 
     // find
     from = 0;
@@ -338,11 +338,11 @@ test_load_check_bitfields_and_times(void **state)
         assert_int_equal(ss->sig.info.creation_set, 1);
         assert_int_equal(ss->sig.info.creation, expected_creation_times[i]);
         // check SS_EXPIRATION_TIME
-        assert_int_equal(ss->sig.info.duration_set, 0);
-        assert_int_equal(ss->sig.info.duration, 0);
+        assert_int_equal(ss->sig.info.expiration_set, 0);
+        assert_int_equal(ss->sig.info.expiration, 0);
     }
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 2076663808);
+    assert_int_equal(key->key.pubkey.expiration, 2076663808);
 
     // find
     from = 0;
@@ -361,10 +361,10 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.creation, 1500569946);
     assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
-    assert_int_equal(key->subsigs[0].sig.info.duration, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration_set, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration, 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 2076663808);
+    assert_int_equal(key->key.pubkey.expiration, 2076663808);
 
     // find
     from = 0;
@@ -383,10 +383,10 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.creation, 1500570165);
     assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
-    assert_int_equal(key->subsigs[0].sig.info.duration, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration_set, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration, 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->key.pubkey.duration, 0);
+    assert_int_equal(key->key.pubkey.expiration, 0);
 
     // cleanup
     rnp_key_store_free(key_store);
@@ -429,10 +429,10 @@ test_load_check_bitfields_and_times_v3(void **state)
     assert_int_equal(key->subsigs[0].sig.info.creation, 1005209227);
     assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check signature expiration time (V3 sigs have none)
-    assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
-    assert_int_equal(key->subsigs[0].sig.info.duration, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration_set, 0);
+    assert_int_equal(key->subsigs[0].sig.info.expiration, 0);
     // check key expiration
-    assert_int_equal(key->key.pubkey.duration, 0); // only for V4 keys
+    assert_int_equal(key->key.pubkey.expiration, 0); // only for V4 keys
     assert_int_equal(key->key.pubkey.days_valid, 0);
 
     // cleanup

--- a/src/tests/load-pgp.c
+++ b/src/tests/load-pgp.c
@@ -243,8 +243,8 @@ test_load_check_bitfields_and_times(void **state)
         assert_int_equal(ss->sig.info.signer_id_set, 1);
         assert_int_equal(memcmp(keyid, ss->sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
         // check SS_CREATION_TIME
-        assert_int_equal(ss->sig.info.birthtime_set, 1);
-        assert_int_equal(ss->sig.info.birthtime, expected_creation_times[i]);
+        assert_int_equal(ss->sig.info.creation_set, 1);
+        assert_int_equal(ss->sig.info.creation, expected_creation_times[i]);
         // check SS_EXPIRATION_TIME
         assert_int_equal(ss->sig.info.duration_set, 0);
         assert_int_equal(ss->sig.info.duration, 0);
@@ -265,9 +265,9 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.signer_id_set, 1);
     assert_int_equal(memcmp(keyid, key->subsigs[0].sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.birthtime_set, 1);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, 1500569820);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, key->key.pubkey.birthtime);
+    assert_int_equal(key->subsigs[0].sig.info.creation_set, 1);
+    assert_int_equal(key->subsigs[0].sig.info.creation, 1500569820);
+    assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
     assert_int_equal(key->subsigs[0].sig.info.duration, 0);
@@ -287,9 +287,9 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.signer_id_set, 1);
     assert_int_equal(memcmp(keyid, key->subsigs[0].sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.birthtime_set, 1);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, 1500569851);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, key->key.pubkey.birthtime);
+    assert_int_equal(key->subsigs[0].sig.info.creation_set, 1);
+    assert_int_equal(key->subsigs[0].sig.info.creation, 1500569851);
+    assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
     assert_int_equal(key->subsigs[0].sig.info.duration, 0);
@@ -309,9 +309,9 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.signer_id_set, 1);
     assert_int_equal(memcmp(keyid, key->subsigs[0].sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.birthtime_set, 1);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, 1500569896);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, key->key.pubkey.birthtime);
+    assert_int_equal(key->subsigs[0].sig.info.creation_set, 1);
+    assert_int_equal(key->subsigs[0].sig.info.creation, 1500569896);
+    assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
     assert_int_equal(key->subsigs[0].sig.info.duration, 0);
@@ -335,8 +335,8 @@ test_load_check_bitfields_and_times(void **state)
         assert_int_equal(ss->sig.info.signer_id_set, 1);
         assert_int_equal(memcmp(keyid, ss->sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
         // check SS_CREATION_TIME
-        assert_int_equal(ss->sig.info.birthtime_set, 1);
-        assert_int_equal(ss->sig.info.birthtime, expected_creation_times[i]);
+        assert_int_equal(ss->sig.info.creation_set, 1);
+        assert_int_equal(ss->sig.info.creation, expected_creation_times[i]);
         // check SS_EXPIRATION_TIME
         assert_int_equal(ss->sig.info.duration_set, 0);
         assert_int_equal(ss->sig.info.duration, 0);
@@ -357,9 +357,9 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.signer_id_set, 1);
     assert_int_equal(memcmp(keyid, key->subsigs[0].sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.birthtime_set, 1);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, 1500569946);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, key->key.pubkey.birthtime);
+    assert_int_equal(key->subsigs[0].sig.info.creation_set, 1);
+    assert_int_equal(key->subsigs[0].sig.info.creation, 1500569946);
+    assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
     assert_int_equal(key->subsigs[0].sig.info.duration, 0);
@@ -379,9 +379,9 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(key->subsigs[0].sig.info.signer_id_set, 1);
     assert_int_equal(memcmp(keyid, key->subsigs[0].sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
-    assert_int_equal(key->subsigs[0].sig.info.birthtime_set, 1);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, 1500570165);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, key->key.pubkey.birthtime);
+    assert_int_equal(key->subsigs[0].sig.info.creation_set, 1);
+    assert_int_equal(key->subsigs[0].sig.info.creation, 1500570165);
+    assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
     assert_int_equal(key->subsigs[0].sig.info.duration, 0);
@@ -425,9 +425,9 @@ test_load_check_bitfields_and_times_v3(void **state)
     assert_int_equal(key->subsigs[0].sig.info.signer_id_set, 1);
     assert_int_equal(memcmp(keyid, key->subsigs[0].sig.info.signer_id, PGP_KEY_ID_SIZE), 0);
     // check creation time
-    assert_int_equal(key->subsigs[0].sig.info.birthtime_set, 1);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, 1005209227);
-    assert_int_equal(key->subsigs[0].sig.info.birthtime, key->key.pubkey.birthtime);
+    assert_int_equal(key->subsigs[0].sig.info.creation_set, 1);
+    assert_int_equal(key->subsigs[0].sig.info.creation, 1005209227);
+    assert_int_equal(key->subsigs[0].sig.info.creation, key->key.pubkey.creation);
     // check signature expiration time (V3 sigs have none)
     assert_int_equal(key->subsigs[0].sig.info.duration_set, 0);
     assert_int_equal(key->subsigs[0].sig.info.duration, 0);

--- a/tests/tst
+++ b/tests/tst
@@ -153,14 +153,14 @@ echo "======> pipeline and memory sign/verify"
 /usr/bin/rnp --sign < a | /usr/bin/rnp --cat > a5
 diff a a5 && good=26
 marktest 26 $good
-echo "======> verify within a duration"
+echo "======> verify within a expiration"
 cp Makefile.am h
-/usr/bin/rnp --sign --duration 6m --detached h
+/usr/bin/rnp --sign --expiration 6m --detached h
 /usr/bin/rnp --verify h.sig && good=27
 marktest 27 $good
 echo "======> invalid signature - expired"
 rm -f h.sig
-/usr/bin/rnp --sign --duration 2 --detached h
+/usr/bin/rnp --sign --expiration 2 --detached h
 sleep 3
 /usr/bin/rnp --verify h.sig || good=28
 marktest 28 $good


### PR DESCRIPTION
This PR renames birthtime to 'creation' and duration to 'expiration' which are used in RFC.

Closes #329 