### PR TITLE
(rnpkeys) Return NULL if key was not found

### DIFF
--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -116,8 +116,9 @@ resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid)
         userid += 2;
     }
     io = rnp->io;
-    if (rnp_key_store_get_key_by_name(io, keyring, userid, &key)) {
+    if (!rnp_key_store_get_key_by_name(io, keyring, userid, &key)) {
         (void) fprintf(io->errs, "cannot find key '%s'\n", userid);
+        return NULL;
     }
     return key;
 }

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -994,7 +994,6 @@ class SignECDSA(Sign):
     def test_verify_P256(self):
         cmd = SignECDSA.GPG_GENERATE_ECDSA_PATERN.format(
             "nistp256", self.rnp.userid)
-        print(cmd)
         self._rnp_sign_verify(self.gpg, self.rnp, 3, cmd)
 
     def test_verify_P384(self):


### PR DESCRIPTION
Bug introduced by me, myself and I.