### PR TITLE
Fix uninitialized data used in G10 keys.

### DIFF
--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -319,8 +319,8 @@ parse_sexp(s_exp_t *s_exp, const char **r_bytes, size_t *r_length)
 static unsigned
 block_to_unsigned(s_exp_block_t *block)
 {
-    char s[sizeof(STR(UINT_MAX)) + 1];
-    if (block->len >= sizeof(s)) {
+    char s[sizeof(STR(UINT_MAX)) + 1] = {0};
+    if (!block->len || block->len >= sizeof(s)) {
         return UINT_MAX;
     }
 


### PR DESCRIPTION
The main thing here is the trailing byte. I added the `block->len` check as well since I don't think that case would be valid.

I also noticed the sizeof portion of this isn't really correct, but it doesn't look like a big deal so I'm not touching it here. I'm not sure that value can really be determined at compile-time, you would probably want to use log10 or snprintf or use a fixed upper value etc.