### PR TITLE
Update rnp_cfg_t to allow storage of lists

### DIFF
--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -28,6 +28,7 @@
 
 #include <rnp/rnp.h>
 #include <stdbool.h>
+#include "list.h"
 
 /* cfg variables known by rnp */
 #define CFG_OVERWRITE "overwrite" /* overwrite output file if it is already exist or fail */
@@ -53,7 +54,7 @@
 #define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
 #define CFG_EXPIRATION "expiration"     /* signature expiration time */
-#define CFG_CREATION "creation"       /* signature validity start */
+#define CFG_CREATION "creation"         /* signature validity start */
 #define CFG_CIPHER "cipher"             /* symmetric encryption algorithm as string */
 #define CFG_HASH "hash"                 /* hash algorithm used, string like 'SHA1'*/
 #define CFG_IO_OUTS "outs"              /* output stream */
@@ -71,23 +72,25 @@
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */
 typedef struct rnp_cfg_t {
-    unsigned count; /* number of elements used */
-    unsigned size;  /* allocated number of elements in the array */
-    char **  keys;  /* key names */
-    char **  vals;  /* values */
+    list vals;
+    // unsigned count; /* number of elements used */
+    // unsigned size;  /* allocated number of elements in the array */
+    // char **  keys;  /* key names */
+    // char **  vals;  /* values */
 } rnp_cfg_t;
 
-void rnp_cfg_init(rnp_cfg_t *cfg);
-void rnp_cfg_load_defaults(rnp_cfg_t *cfg);
-bool rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params);
-bool rnp_cfg_set(rnp_cfg_t *cfg, const char *key, const char *val);
-bool rnp_cfg_unset(rnp_cfg_t *cfg, const char *key);
-bool rnp_cfg_setint(rnp_cfg_t *cfg, const char *key, int val);
-bool rnp_cfg_setbool(rnp_cfg_t *cfg, const char *key, bool val);
-const char *rnp_cfg_get(const rnp_cfg_t *cfg, const char *key);
-int rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
-bool rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
-void rnp_cfg_free(rnp_cfg_t *cfg);
+void        rnp_cfg_init(rnp_cfg_t *cfg);
+void        rnp_cfg_load_defaults(rnp_cfg_t *cfg);
+bool        rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params);
+bool        rnp_cfg_setstr(rnp_cfg_t *cfg, const char *key, const char *val);
+bool        rnp_cfg_setint(rnp_cfg_t *cfg, const char *key, int val);
+bool        rnp_cfg_setbool(rnp_cfg_t *cfg, const char *key, bool val);
+bool        rnp_cfg_addstr(rnp_cfg_t *cfg, const char *key, const char *val);
+bool        rnp_cfg_unset(rnp_cfg_t *cfg, const char *key);
+const char *rnp_cfg_getstr(const rnp_cfg_t *cfg, const char *key);
+int         rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
+bool        rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
+void        rnp_cfg_free(rnp_cfg_t *cfg);
 
 /*
  *  @brief      Returns integer value for the key if there is one, or default value otherwise
@@ -114,10 +117,10 @@ void rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
 
 bool rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params);
 void rnp_cfg_get_defkey(rnp_cfg_t *cfg, rnp_params_t *params);
-int rnp_cfg_get_pswdtries(rnp_cfg_t *cfg);
+int  rnp_cfg_get_pswdtries(rnp_cfg_t *cfg);
 
 /* rnp CLI helper functions */
 uint64_t get_expiration(const char *s);
-int64_t get_creation(const char *s);
+int64_t  get_creation(const char *s);
 
 #endif

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -73,54 +73,182 @@
  * options */
 typedef struct rnp_cfg_t {
     list vals;
-    // unsigned count; /* number of elements used */
-    // unsigned size;  /* allocated number of elements in the array */
-    // char **  keys;  /* key names */
-    // char **  vals;  /* values */
 } rnp_cfg_t;
 
-void        rnp_cfg_init(rnp_cfg_t *cfg);
-void        rnp_cfg_load_defaults(rnp_cfg_t *cfg);
-bool        rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params);
-bool        rnp_cfg_setstr(rnp_cfg_t *cfg, const char *key, const char *val);
-bool        rnp_cfg_setint(rnp_cfg_t *cfg, const char *key, int val);
-bool        rnp_cfg_setbool(rnp_cfg_t *cfg, const char *key, bool val);
-bool        rnp_cfg_addstr(rnp_cfg_t *cfg, const char *key, const char *val);
-bool        rnp_cfg_unset(rnp_cfg_t *cfg, const char *key);
-const char *rnp_cfg_getstr(const rnp_cfg_t *cfg, const char *key);
-int         rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
-bool        rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
-void        rnp_cfg_free(rnp_cfg_t *cfg);
+typedef struct rnp_cfg_val_t rnp_cfg_val_t;
 
-/*
- *  @brief      Returns integer value for the key if there is one, or default value otherwise
+/** @brief initialize rnp_cfg structure internals. When structure is not needed anymore
+ *         it should be freed via rnp_cfg_free function call
+ *  @param cfg allocated rnp_cfg_t structure
+ **/
+void rnp_cfg_init(rnp_cfg_t *cfg);
+
+/** @brief load default settings to the rnp_cfg_t structure
+ *  @param cfg allocated and initialized rnp_cfg_t structure
+ **/
+void rnp_cfg_load_defaults(rnp_cfg_t *cfg);
+
+/** @brief apply configuration from keys-vals storage to rnp_params_t structure
+ *  @param cfg [in] rnp config, must be allocated and initialized
+ *  @param params [out] this structure will be filled so can be further feed into rnp_init.
+ *                Must be later freed using the rnp_params_free even if rnp_cfg_apply fails.
  *
- *  @param cfg  rnp config, must be allocated and initialized
- *  @param key  must be null-terminated string
- *  @param def  value returned if key not found
+ *  @return true on success, false if something went wrong
+ **/
+bool rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params);
+
+/** @brief set string value for the key in config
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *  @param val value, which will be set
  *
- *  @return     Integer value or def if there is no value or it is non-integer
+ *  @return true if operation succeeds or false otherwise
+ **/
+bool rnp_cfg_setstr(rnp_cfg_t *cfg, const char *key, const char *val);
+
+/** @brief set integer value for the key in config
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *  @param val value, which will be set
+ *
+ *  @return true if operation succeeds or false otherwise
+ **/
+bool rnp_cfg_setint(rnp_cfg_t *cfg, const char *key, int val);
+
+/** @brief set boolean value for the key in config
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *  @param val value, which will be set
+ *
+ *  @return true if operation succeeds or false otherwise
+ **/
+bool rnp_cfg_setbool(rnp_cfg_t *cfg, const char *key, bool val);
+
+/** @brief add string item to the list value
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *  @param val value, which will be appended to the list
+ *
+ *  @return true if operation succeeds or false otherwise
+ **/
+bool rnp_cfg_addstr(rnp_cfg_t *cfg, const char *key, const char *str);
+
+/** @brief unset value for the key in config, deleting it
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *
+ *  @return true if value was found and deleted or false otherwise
+ **/
+bool rnp_cfg_unset(rnp_cfg_t *cfg, const char *key);
+
+/** @brief return string value for the key if there is one
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *
+ *  @return stored string if item is found and has string value or NULL otherwise
+ **/
+const char *rnp_cfg_getstr(const rnp_cfg_t *cfg, const char *key);
+
+/** @brief return integer value for the key if there is one
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *
+ *  @return integer value or 0 if there is no value or it is non-integer
+ **/
+int rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
+
+/** @brief return boolean value for the key if there is one
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *
+ *  @return true if 'true', 'True', or non-zero integer is stored in value, false otherwise
+ **/
+bool rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
+
+/** @brief return list value for the key if there is one. Each list's element contains
+ *  rbp_cfg_val_t element with the corresponding value. List may be modified.
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *
+ *  @return pointer to the list on success or NULL if value was not found or has other type
+ **/
+list *rnp_cfg_getlist(rnp_cfg_t *cfg, const char *key);
+
+/** @brief free the memory allocated in rnp_cfg_t
+ *  @param cfg rnp config, must be allocated and initialized
+ **/
+void rnp_cfg_free(rnp_cfg_t *cfg);
+
+/** @brief get the string value from rnp_cfg_val_t record
+ *  @param val pointer to the value of rnp_cfg_val_t type, may be NULL
+ *  @return pointer to the NULL-terminated string if value has string, or NULL otherwise
+ */
+const char *rnp_cfg_val_getstr(rnp_cfg_val_t *val);
+
+/** @brief return integer value for the key if there is one, or default value otherwise
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *  @param def default value
+ *
+ *  @return integer value or def if there is no value or it is non-integer
  **/
 int rnp_cfg_getint_default(rnp_cfg_t *cfg, const char *key, int def);
 
-/*
- * @brief   Copies or overrides configuration
+/** @brief Copies or overrides configuration
+ *  @param dst resulting configuration object
+ *  @param src vals in dst will be overriden (if key exist) or coppied (if not)
+ *         from this object
  *
- * @param   dst resulting configuration object
- * @param   src vals in dst will be overriden (if key exist) or coppied (if not)
- *          from this object
- *
- * @pre     dst is correctly initialized and not NULL
+ *  @pre   dst is correctly initialized and not NULL
  *
  **/
 void rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
 
+/** @brief Fill the keyring pathes according to user-specified settings
+ *  @param cfg [in] rnp config, must be allocated and initialized
+ *  @param params [out] in this structure public and secret keyring pathes  will be filled
+ *  @return true on success or false if something went wrong
+ */
 bool rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params);
+
+/** @brief Attempt to get the default key id/name in a number of ways
+ *  Tries to find via user-specified parameters and  GnuPG conffile.
+ *
+ *  @param cfg [in] rnp config, must be allocated and initialized
+ *  @param params [out] in this structure defkey will be filled if found
+ */
 void rnp_cfg_get_defkey(rnp_cfg_t *cfg, rnp_params_t *params);
-int  rnp_cfg_get_pswdtries(rnp_cfg_t *cfg);
+
+/** @brief Get number of password tries according to defaults and value, stored in cfg
+ *  @param cfg allocated and initalized config
+ *  @return number of password tries or INFINITE_ATTEMPTS
+ */
+int rnp_cfg_get_pswdtries(rnp_cfg_t *cfg);
 
 /* rnp CLI helper functions */
+
+/** @brief Get signature validity expiration time from the user input
+ *
+ *  Signature expiration may be specified in different formats:
+ *  - 10d : 10 days (you can use [h]ours, d[ays], [w]eeks, [m]onthes)
+ *  - 2017-07-12 : as the exact date when signature becomes invalid
+ *  - 60000 : number of seconds
+ *
+ *  @param s [in] NULL-terminated string with the date
+ *  @param t [out] On successfull return result will be placed here
+ *  @return expiration time in seconds
+ */
 uint64_t get_expiration(const char *s);
-int64_t  get_creation(const char *s);
+
+/** @brief Get signature validity start time from the user input
+ *
+ *  Signature validity may be specified in different formats:
+ *  - 2017-07-12 : as the exact date when signature becomes invalid
+ *  - 1499334073 : timestamp
+ *
+ *  @param s [in] NULL-terminated string with the date
+ *  @return timestamp of the validity start
+ */
+int64_t get_creation(const char *s);
 
 #endif

--- a/src/rnpkeys/main.c
+++ b/src/rnpkeys/main.c
@@ -67,8 +67,8 @@ main(int argc, char **argv)
         } else {
             switch (ch) {
             case 'S':
-                rnp_cfg_set(&opt_cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
-                rnp_cfg_set(&opt_cfg, CFG_SSHKEYFILE, optarg);
+                rnp_cfg_setstr(&opt_cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
+                rnp_cfg_setstr(&opt_cfg, CFG_SSHKEYFILE, optarg);
                 break;
             case 'V':
                 print_praise();

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -122,7 +122,8 @@ match_keys(rnp_cfg_t *cfg, rnp_t *rnp, FILE *fp, char *f, const int psigs)
             return 0;
         }
     } else {
-        if (rnp_match_keys_json(rnp, &json, f, rnp_cfg_get(cfg, CFG_KEYFORMAT), psigs) == 0) {
+        if (rnp_match_keys_json(rnp, &json, f, rnp_cfg_getstr(cfg, CFG_KEYFORMAT), psigs) ==
+            0) {
             return 0;
         }
     }
@@ -162,7 +163,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         return match_keys(cfg, rnp, stdout, f, cmd == CMD_LIST_SIGS);
     case CMD_FIND_KEY:
         if ((key = f) == NULL) {
-            key = rnp_cfg_get(cfg, CFG_USERID);
+            key = rnp_cfg_getstr(cfg, CFG_USERID);
         }
         return rnp_find_key(rnp, key);
     case CMD_EXPORT_KEY: {
@@ -170,7 +171,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         rnp_result_t ret;
 
         if ((key = f) == NULL) {
-            key = rnp_cfg_get(cfg, CFG_USERID);
+            key = rnp_cfg_getstr(cfg, CFG_USERID);
         }
 
         if (!key) {
@@ -183,7 +184,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
             return false;
         }
 
-        const char *file = rnp_cfg_get(cfg, CFG_OUTFILE);
+        const char *file = rnp_cfg_getstr(cfg, CFG_OUTFILE);
         bool        force = rnp_cfg_getbool(cfg, CFG_FORCE);
         ret = file ? init_file_dest(&dst, file, force) : init_stdout_dest(&dst);
         if (ret) {
@@ -201,7 +202,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         }
         return rnp_import_key(rnp, f);
     case CMD_GENERATE_KEY:
-        key = f ? f : rnp_cfg_get(cfg, CFG_USERID);
+        key = f ? f : rnp_cfg_getstr(cfg, CFG_USERID);
         rnp_action_keygen_t *        action = &rnp->action.generate_key_ctx;
         rnp_keygen_primary_desc_t *  primary_desc = &action->primary.keygen;
         rnp_key_protection_params_t *protection = &action->primary.protection;
@@ -209,10 +210,10 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         if (key) {
             strcpy((char *) primary_desc->cert.userid, key);
         }
-        primary_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_get(cfg, CFG_HASH));
+        primary_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_getstr(cfg, CFG_HASH));
         primary_desc->crypto.rng = &rnp->rng;
         protection->hash_alg = primary_desc->crypto.hash_alg;
-        protection->symm_alg = pgp_str_to_cipher(rnp_cfg_get(cfg, CFG_CIPHER));
+        protection->symm_alg = pgp_str_to_cipher(rnp_cfg_getstr(cfg, CFG_CIPHER));
         action->subkey.keygen.crypto.rng = &rnp->rng;
 
         if (!rnp_cfg_getbool(cfg, CFG_EXPERT)) {
@@ -227,7 +228,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         }
         return rnp_generate_key(rnp);
     case CMD_GET_KEY:
-        key = rnp_get_key(rnp, f, rnp_cfg_get(cfg, CFG_KEYFORMAT));
+        key = rnp_get_key(rnp, f, rnp_cfg_getstr(cfg, CFG_KEYFORMAT));
         if (key) {
             printf("%s", key);
             return true;
@@ -273,28 +274,28 @@ setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg)
         exit(EXIT_SUCCESS);
     /* options */
     case OPT_SSHKEYS:
-        rnp_cfg_set(cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
+        rnp_cfg_setstr(cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
         break;
     case OPT_KEYRING:
         if (arg == NULL) {
             (void) fprintf(stderr, "No keyring argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_KEYRING, arg);
+        rnp_cfg_setstr(cfg, CFG_KEYRING, arg);
         break;
     case OPT_KEY_STORE_FORMAT:
         if (arg == NULL) {
             (void) fprintf(stderr, "No keyring format argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_KEYSTOREFMT, arg);
+        rnp_cfg_setstr(cfg, CFG_KEYSTOREFMT, arg);
         break;
     case OPT_USERID:
         if (arg == NULL) {
             (void) fprintf(stderr, "no userid argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_USERID, arg);
+        rnp_cfg_setstr(cfg, CFG_USERID, arg);
         break;
     case OPT_VERBOSE:
         rnp_cfg_setint(cfg, CFG_VERBOSE, rnp_cfg_getint(cfg, CFG_VERBOSE) + 1);
@@ -304,7 +305,7 @@ setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg)
             (void) fprintf(stderr, "no home directory argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_HOMEDIR, arg);
+        rnp_cfg_setstr(cfg, CFG_HOMEDIR, arg);
         break;
     case OPT_NUMBITS:
         if (arg == NULL) {
@@ -318,31 +319,31 @@ setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg)
             (void) fprintf(stderr, "No hash algorithm argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_HASH, arg);
+        rnp_cfg_setstr(cfg, CFG_HASH, arg);
         break;
     case OPT_PASSWDFD:
         if (arg == NULL) {
             (void) fprintf(stderr, "no pass-fd argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_PASSFD, arg);
+        rnp_cfg_setstr(cfg, CFG_PASSFD, arg);
         break;
     case OPT_RESULTS:
         if (arg == NULL) {
             (void) fprintf(stderr, "No output filename argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_IO_RESS, arg);
+        rnp_cfg_setstr(cfg, CFG_IO_RESS, arg);
         break;
     case OPT_SSHKEYFILE:
-        rnp_cfg_set(cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
-        rnp_cfg_set(cfg, CFG_SSHKEYFILE, arg);
+        rnp_cfg_setstr(cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
+        rnp_cfg_setstr(cfg, CFG_SSHKEYFILE, arg);
         break;
     case OPT_FORMAT:
-        rnp_cfg_set(cfg, CFG_KEYFORMAT, arg);
+        rnp_cfg_setstr(cfg, CFG_KEYFORMAT, arg);
         break;
     case OPT_CIPHER:
-        rnp_cfg_set(cfg, CFG_CIPHER, arg);
+        rnp_cfg_setstr(cfg, CFG_CIPHER, arg);
         break;
     case OPT_DEBUG:
         rnp_set_debug(arg);
@@ -352,7 +353,7 @@ setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg)
             (void) fprintf(stderr, "No output filename argument provided\n");
             exit(EXIT_ERROR);
         }
-        rnp_cfg_set(cfg, CFG_OUTFILE, arg);
+        rnp_cfg_setstr(cfg, CFG_OUTFILE, arg);
         break;
     case OPT_FORCE:
         rnp_cfg_setbool(cfg, CFG_FORCE, true);
@@ -417,8 +418,8 @@ rnpkeys_init(rnp_cfg_t *cfg, rnp_t *rnp, const rnp_cfg_t *override_cfg, bool is_
 
     rnp_cfg_load_defaults(cfg);
     rnp_cfg_setint(cfg, CFG_NUMBITS, DEFAULT_RSA_NUMBITS);
-    rnp_cfg_set(cfg, CFG_IO_RESS, "<stdout>");
-    rnp_cfg_set(cfg, CFG_KEYFORMAT, "human");
+    rnp_cfg_setstr(cfg, CFG_IO_RESS, "<stdout>");
+    rnp_cfg_setstr(cfg, CFG_KEYFORMAT, "human");
     rnp_cfg_copy(cfg, override_cfg);
 
     memset(rnp, '\0', sizeof(rnp_t));

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -12,6 +12,7 @@ rnp_tests_SOURCES   = \
     rnp_tests.c \
     user-prefs.c \
     utils-list.c \
+    utils-rnpcfg.c \
     pgp-parse.c \
     load-pgp.c \
     key-unlock.c \

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -726,7 +726,7 @@ generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **state)
     static const char test_ecdsa_384[] = "19\n2\n";
 
     rnp_assert_true(rstate, rnp_cfg_setbool(&ops, CFG_EXPERT, true));
-    rnp_assert_true(rstate, rnp_cfg_set(&ops, CFG_HASH, "SHA1"));
+    rnp_assert_true(rstate, rnp_cfg_setstr(&ops, CFG_HASH, "SHA1"));
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));
@@ -746,7 +746,7 @@ generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
     static const char test_ecdsa_384[] = "19\n2\n";
 
     rnp_assert_true(rstate, rnp_cfg_setbool(&ops, CFG_EXPERT, true));
-    rnp_assert_true(rstate, rnp_cfg_set(&ops, CFG_HASH, "SHA512"));
+    rnp_assert_true(rstate, rnp_cfg_setstr(&ops, CFG_HASH, "SHA512"));
 
     rnp_assert_true(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));
@@ -766,7 +766,7 @@ generatekeyECDSA_explicitlySetWrongDigest_ShouldFail(void **state)
     static const char test_ecdsa_384[] = "19\n2\n";
 
     rnp_assert_true(rstate, rnp_cfg_setbool(&ops, CFG_EXPERT, true));
-    rnp_assert_true(rstate, rnp_cfg_set(&ops, CFG_HASH, "WRONG_DIGEST_ALGORITHM"));
+    rnp_assert_true(rstate, rnp_cfg_setstr(&ops, CFG_HASH, "WRONG_DIGEST_ALGORITHM"));
 
     rnp_assert_false(rstate,
                      ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -161,6 +161,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed),
       cmocka_unit_test(generatekeyECDSA_explicitlySetWrongDigest_ShouldFail),
       cmocka_unit_test(test_utils_list),
+      cmocka_unit_test(test_rnpcfg),
       cmocka_unit_test(pgp_parse_keyrings_1_pubring),
       cmocka_unit_test(test_load_user_prefs),
       cmocka_unit_test(ecdh_roundtrip),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -73,6 +73,8 @@ void generatekeyECDSA_explicitlySetWrongDigest_ShouldFail(void **state);
 
 void test_utils_list(void **state);
 
+void test_rnpcfg(void **state);
+
 void pgp_parse_keyrings_1_pubring(void **state);
 
 void test_load_user_prefs(void **state);

--- a/src/tests/utils-rnpcfg.c
+++ b/src/tests/utils-rnpcfg.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rnp_tests.h"
+#include "support.h"
+#include "list.h"
+#include "utils.h"
+#include <rnp/rnpcfg.h>
+
+void
+test_rnpcfg(void **state)
+{
+    rnp_cfg_t cfg1 = {0}, cfg2 = {0};
+    rnp_cfg_t *cfgs[2] = {&cfg1, &cfg2};
+    rnp_cfg_t *cfg = NULL;
+    list *lst;
+    char buf[32];
+
+    assert_null(rnp_cfg_getstr(&cfg1, "key"));
+
+    /* set the values */ 
+
+    assert_true(rnp_cfg_setstr(&cfg1, "key_str", "val"));
+    assert_true(rnp_cfg_setstr(&cfg1, "key_true", "true"));
+    assert_true(rnp_cfg_setstr(&cfg1, "key_True", "True"));
+    assert_true(rnp_cfg_setint(&cfg1, "key_int", 999));
+    assert_true(rnp_cfg_setstr(&cfg1, "key_100", "100"));
+    assert_true(rnp_cfg_setbool(&cfg1, "key_bool", true));
+
+    for (int i = 0; i < 10; i++) {
+        snprintf(buf, sizeof(buf), "val%d", i);
+        assert_true(rnp_cfg_addstr(&cfg1, "key_list", buf));
+    }
+
+    /* copy to the cfg2 */
+
+    rnp_cfg_copy(&cfg2, &cfg1);
+
+    /* get values back, including transformations */
+
+    for (int i = 0; i < 2; i++) {
+        cfg = cfgs[i];
+
+        assert_int_equal(rnp_cfg_getint(cfg, "key_int"), 999);
+        assert_int_equal(rnp_cfg_getint(cfg, "key_100"), 100);
+        assert_true(rnp_cfg_getbool(cfg, "key_int"));
+        assert_true(rnp_cfg_getbool(cfg, "key_bool"));
+        assert_true(rnp_cfg_getbool(cfg, "key_true"));
+        assert_true(rnp_cfg_getbool(cfg, "key_True"));
+        assert_false(rnp_cfg_getbool(cfg, "key_notfound"));
+
+        assert_string_equal(rnp_cfg_getstr(cfg, "key_str"), "val");
+        assert_null(rnp_cfg_getstr(cfg, "key_str1"));
+        assert_null(rnp_cfg_getstr(cfg, "key_st"));
+
+        assert_non_null(lst = rnp_cfg_getlist(cfg, "key_list"));
+        assert_int_equal(list_length(*lst), 10);
+
+        list_item *li = list_front(*lst);
+
+        for (int j = 0; j < 10; j++) {
+            assert_non_null(li);
+            const char *val = rnp_cfg_val_getstr((rnp_cfg_val_t*)li);
+            assert_non_null(val);
+            snprintf(buf, sizeof(buf), "val%d", j);
+            assert_string_equal(buf, val);
+            li = list_next(li);
+        }
+    }
+
+    /* override value */
+
+    assert_true(rnp_cfg_setint(&cfg1, "key_int", 222));
+    assert_int_equal(rnp_cfg_getint(&cfg1, "key_int"), 222);
+    assert_int_equal(rnp_cfg_getint(&cfg2, "key_int"), 999);
+    assert_true(rnp_cfg_setstr(&cfg1, "key_int", "333"));
+    assert_int_equal(rnp_cfg_getint(&cfg1, "key_int"), 333);
+
+    /* unset value */
+
+    assert_true(rnp_cfg_unset(&cfg1, "key_int"));
+    assert_false(rnp_cfg_unset(&cfg1, "key_int"));
+
+    rnp_cfg_free(&cfg1);
+    rnp_cfg_free(&cfg2);
+}


### PR DESCRIPTION
During work on multiple signers/recipients I needed to allow storage of lists in rnp_cfg_t.
So redesigned it to work with list, and allow storage of typed information. Maybe this is overhead a bit  but, at least, it would be much more flexible for future needs.

So now all values stored in rnp_cfg_t have defined type and may be int, bool, char * (string) or list. Last one may contain the same value types stored in rnp_cfg_val_t.