### PR TITLE
Fix errors in key generation tests and some other CLI test improvements

### DIFF
--- a/ci/main.sh
+++ b/ci/main.sh
@@ -37,5 +37,5 @@ cd src/tests
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${GPG21_INSTALL}/lib"
 export LD_LIBRARY_PATH
-env RNPC_GPG_PATH="${GPG21_INSTALL}/bin/gpg" python2 cli_tests.py -w -v
+env RNPC_GPG_PATH="${GPG21_INSTALL}/bin/gpg" python2 cli_tests.py -w -v -d
 

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -985,7 +985,7 @@ cleartext_process_line(pgp_source_t *src, const uint8_t *buf, size_t len, bool e
 
     /* if we have eol after this line then strip trailing spaces and tabs */
     if (eol) {
-        for (; ((*bufen == CH_SPACE) || (*bufen == CH_TAB)) && (bufen >= buf); bufen--)
+        for (; (bufen >= buf) && ((*bufen == CH_SPACE) || (*bufen == CH_TAB)); bufen--)
             ;
     }
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -109,7 +109,7 @@ def clear_keyrings():
     shutil.rmtree(RNPDIR, ignore_errors=True)
     os.mkdir(RNPDIR, 0700)
 
-    run_proc('gpg-connect-agent', ['killagent', '/bye'])
+    run_proc('kill', ['-9', 'gpg-agent'])
     while os.path.isdir(GPGDIR):
         try:
             shutil.rmtree(GPGDIR)


### PR DESCRIPTION
This PR:
- fixes gpg key generation test
- reduces number of encryption test runs (we really don't need to run each file size for each algorithm, just need to check all algos/all sizes/all compression algorithm combinations)
- enables debug logging for CI
- fixes buffer underflow in cleartext_process_line (see https://github.com/riboseinc/rnp/pull/581#issuecomment-360343555)