### PR TITLE
Replace pgp_key_t subkey dynarray with a grip list.

### DIFF
--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -955,18 +955,18 @@ rnp_import_key(rnp_t *rnp, char *f)
             // keep track of what keys have been imported
             list_append(&imported_grips, key->grip, sizeof(key->grip));
             importedkey = rnp_key_store_get_key_by_grip(rnp->io, dest, key->grip);
-            for (unsigned j = 0; j < key->subkeyc; j++) {
-                pgp_key_t *subkey = key->subkeys[j];
-
+            list_item *subkey_grip = list_front(key->subkey_grips);
+            while (subkey_grip) {
+                pgp_key_t *subkey = rnp_key_store_get_key_by_grip(rnp->io, tmp_keystore, (uint8_t*)subkey_grip);
+                assert(subkey);
                 if (!rnp_key_store_add_key(rnp->io, dest, subkey)) {
                     RNP_LOG("failed to add key to destination key store");
                     goto done;
+
                 }
-                // fix up the subkeys dynarray pointers...
-                importedkey->subkeys[j] =
-                  rnp_key_store_get_key_by_grip(rnp->io, dest, subkey->grip);
                 // keep track of what keys have been imported
                 list_append(&imported_grips, subkey->grip, sizeof(subkey->grip));
+                subkey_grip = list_next(subkey_grip);
             }
         }
     }

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -72,7 +72,6 @@ typedef struct keyringcb_t {
     rnp_key_store_t *keyring; /* the keyring we're reading */
     pgp_io_t *       io;
     pgp_key_t *      key;          /* the key we're currently loading */
-    pgp_key_t *      last_primary; /* the last primary key we loaded */
 } keyringcb_t;
 
 #define SUBSIG_REQUIRED_BEFORE(str)                                 \
@@ -348,16 +347,6 @@ cb_keyring_parse(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         cb->key->format = GPG_KEY_STORE;
         if (pgp_is_key_secret(cb->key)) {
             cb->key->is_protected = cb->key->key.seckey.encrypted;
-        }
-        if (pgp_is_subkey_tag(pkt->tag) && cb->last_primary) {
-            EXPAND_ARRAY(cb->last_primary, subkey);
-            if (!cb->last_primary->subkeys) {
-                PGP_ERROR(cbinfo->errors, PGP_E_FAIL, "Failed to expand array.");
-                return PGP_FINISHED;
-            }
-            cb->last_primary->subkeys[cb->last_primary->subkeyc++] = cb->key;
-        } else if (pgp_is_primary_key_tag(pkt->tag)) {
-            cb->last_primary = cb->key;
         }
         // Set some default key flags which will be overridden by signature
         // subpackets for V4 keys.

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -354,15 +354,12 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
     }
 
     /* Use primary key if good for encryption, otherwise look in subkey list */
-    if (pgp_key_can_encrypt(userkey)) {
-        pubkey = &userkey->key.pubkey;
-    } else {
-        pgp_key_t *subkey = find_suitable_subkey(userkey, PGP_KF_ENCRYPT);
-        if (!subkey) {
-            return RNP_ERROR_NO_SUITABLE_KEY;
-        }
-        pubkey = &subkey->key.pubkey;
+    userkey =
+      find_suitable_key(PGP_OP_ENCRYPT_SYM, userkey, handler->key_provider, PGP_KF_ENCRYPT);
+    if (!userkey) {
+        return RNP_ERROR_NO_SUITABLE_KEY;
     }
+    pubkey = &userkey->key.pubkey;
 
     /* Fill pkey */
     pkey.version = PGP_PKSK_V3;

--- a/src/tests/load-pgp.c
+++ b/src/tests/load-pgp.c
@@ -172,7 +172,7 @@ check_pgp_keyring_counts(const char *   path,
         pgp_key_t *key = (pgp_key_t *) key_item;
         if (pgp_key_is_primary_key(key)) {
             // check the subkey count for this primary key
-            assert_int_equal(key->subkeyc, subkey_counts[primary++]);
+            assert_int_equal(list_length(key->subkey_grips), subkey_counts[primary++]);
         } else if (pgp_key_is_subkey(key)) {
             total_subkey_count++;
         }


### PR DESCRIPTION
This was done to avoid holding invalid pointers and such, from when the key store used a dynarray to store keys. But it's still nice to avoid having a key that points to a subkey that is actually in another store and similar oddities.