### PR TITLE
Subkey export and tests for ElGamal decryption

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -177,6 +177,6 @@ bool rnp_key_store_get_next_key_by_name(
   pgp_io_t *, const rnp_key_store_t *, const char *, pgp_key_t *, pgp_key_t **);
 
 bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
-pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, rnp_key_store_t *, const uint8_t *);
+pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, const rnp_key_store_t *, const uint8_t *);
 
 #endif /* KEY_STORE_H_ */

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -151,7 +151,7 @@ void pgp_key_init(pgp_key_t *, const pgp_content_enum);
 
 pgp_key_flags_t pgp_pk_alg_capabilities(pgp_pubkey_alg_t alg);
 
-char *pgp_export_key(pgp_io_t *, const pgp_key_t *, const pgp_password_provider_t *);
+char *pgp_export_key(rnp_t *, const pgp_key_t *);
 
 /** check if a key is currently locked
  *

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -873,13 +873,15 @@ char *
 rnp_export_key(rnp_t *rnp, const char *name)
 {
     const pgp_key_t *key;
-    pgp_io_t *       io;
 
-    io = rnp->io;
+    if (!rnp) {
+        return NULL;
+    }
+
     if ((key = resolve_userid(rnp, rnp->pubring, name)) == NULL) {
         return NULL;
     }
-    return pgp_export_key(io, key, &rnp->password_provider);
+    return pgp_export_key(rnp, key);
 }
 
 #define IMPORT_ARMOR_HEAD "-----BEGIN PGP (PUBLIC)|(PRIVATE) KEY BLOCK-----"

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -545,8 +545,8 @@ rnp_key_store_add_keydata(pgp_io_t *         io,
         // find the last primary in the list
         pgp_key_t *primary = NULL;
         for (list_item *keyp = list_back(keyring->keys); keyp; keyp = list_prev(keyp)) {
-            if (pgp_key_is_primary_key((pgp_key_t*)keyp)) {
-                primary = (pgp_key_t*)keyp;
+            if (pgp_key_is_primary_key((pgp_key_t *) keyp)) {
+                primary = (pgp_key_t *) keyp;
                 break;
             }
         }
@@ -653,7 +653,9 @@ rnp_key_store_get_key_by_id(pgp_io_t *             io,
 }
 
 pgp_key_t *
-rnp_key_store_get_key_by_grip(pgp_io_t *io, rnp_key_store_t *keyring, const uint8_t *grip)
+rnp_key_store_get_key_by_grip(pgp_io_t *             io,
+                              const rnp_key_store_t *keyring,
+                              const uint8_t *        grip)
 {
     if (rnp_get_debug(__FILE__)) {
         fprintf(io->errs, "looking keyring %p\n", keyring);

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -977,7 +977,7 @@ class Encrypt(unittest.TestCase):
         self.assertTrue(e1.generte_key_batch(keygen_cmd))
         self.assertTrue(e1.export_key(keyfile, False))
         self.assertTrue(e2.import_key(keyfile))
-        self.assertTrue(e2.encrypt(enc_out, input))
+        self.assertTrue(e2.encrypt(e1.userid, enc_out, input))
         self.assertTrue(e1.decrypt(dec_out, enc_out))
         clear_workfiles()
 
@@ -1002,21 +1002,39 @@ class EncryptElgamal(Encrypt):
         Name-Email: {2}
         """
 
+    RNP_GENERATE_DSA_ELGAMAL_PATTERN = "16\n{0}\n"
+
     def test_encrypt_P1024_1024(self):
-        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(1024, 1024, self.rnp.userid)
+        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(1024, 1024, self.gpg.userid)
         self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
 
     def test_encrypt_P1024_2048(self):
-        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(1024, 2048, self.rnp.userid)
+        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(1024, 2048, self.gpg.userid)
         self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
 
     def test_encrypt_P2048_2048(self):
-        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(2048, 2048, self.rnp.userid)
+        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(2048, 2048, self.gpg.userid)
         self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
 
     def test_encrypt_P3072_3072(self):
-        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(3072, 3072, self.rnp.userid)
+        cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(3072, 3072, self.gpg.userid)
         self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
+
+    def test_decrypt_P1024(self):
+        cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(1024)
+        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
+
+    def test_decrypt_P2048(self):
+        cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(2048)
+        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
+
+    def test_decrypt_P3072(self):
+        cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(3072)
+        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
+
+    def test_decrypt_P1234(self):
+        cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(1234)
+        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
 
 class Sign(unittest.TestCase):
     # Message sizes to be tested

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -971,7 +971,8 @@ class SignDefault(unittest.TestCase):
             rnp_cleartext_signing_gpg_to_rnp(size)
 
 class Encrypt(unittest.TestCase):
-    def _encrypt_decrypt(self, e1, e2,  key_id, keygen_cmd):
+    def _encrypt_decrypt(self, e1, e2,  keygen_cmd):
+        key_id = "".join(self.id().split('.')[1:3])
         keyfile, input, enc_out, dec_out = reg_workfiles("encrypt"+str(key_id), '.gpg', '.in', '.enc', '.dec')
         random_text(input, 0x1337)
         self.assertTrue(e1.generte_key_batch(keygen_cmd))
@@ -986,6 +987,9 @@ class Encrypt(unittest.TestCase):
         self.gpg = GnuPG(GPGDIR, GPG)
         self.rnp.password = self.gpg.password = PASSWORD
         self.rnp.userid = self.gpg.userid = 'encrypttest@secure.gov'
+
+    def tearDown(self):
+        clear_keyrings()
 
 class EncryptElgamal(Encrypt):
 
@@ -1006,41 +1010,37 @@ class EncryptElgamal(Encrypt):
 
     def test_encrypt_P1024_1024(self):
         cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(1024, 1024, self.gpg.userid)
-        self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
+        self._encrypt_decrypt(self.gpg, self.rnp, cmd)
 
     def test_encrypt_P1024_2048(self):
         cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(1024, 2048, self.gpg.userid)
-        self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
+        self._encrypt_decrypt(self.gpg, self.rnp, cmd)
 
     def test_encrypt_P2048_2048(self):
         cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(2048, 2048, self.gpg.userid)
-        self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
+        self._encrypt_decrypt(self.gpg, self.rnp, cmd)
 
     def test_encrypt_P3072_3072(self):
         cmd = EncryptElgamal.GPG_GENERATE_DSA_ELGAMAL_PATERN.format(3072, 3072, self.gpg.userid)
-        self._encrypt_decrypt(self.gpg, self.rnp, 1, cmd)
+        self._encrypt_decrypt(self.gpg, self.rnp, cmd)
 
     def test_decrypt_P1024(self):
         cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(1024)
-        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
+        self._encrypt_decrypt(self.rnp, self.gpg, cmd)
 
     def test_decrypt_P2048(self):
         cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(2048)
-        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
-
-    def test_decrypt_P3072(self):
-        cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(3072)
-        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
+        self._encrypt_decrypt(self.rnp, self.gpg, cmd)
 
     def test_decrypt_P1234(self):
         cmd = EncryptElgamal.RNP_GENERATE_DSA_ELGAMAL_PATTERN.format(1234)
-        self._encrypt_decrypt(self.rnp, self.gpg, 1, cmd)
+        self._encrypt_decrypt(self.rnp, self.gpg, cmd)
 
 class Sign(unittest.TestCase):
     # Message sizes to be tested
     SIZES = [20, 1000, 5000, 20000, 150000, 1000000]
 
-    def _rnp_sign_verify(self, e1, e2, key_id, keygen_cmd):
+    def _rnp_sign_verify(self, e1, e2, keygen_cmd):
         '''
         Helper function for ECDSA verification
         1. e1 creates ECDSA key
@@ -1051,6 +1051,7 @@ class Sign(unittest.TestCase):
 
         eX == entityX
         '''
+        key_id = "".join(self.id().split('.')[1:3])
         keyfile, input, output = reg_workfiles("signing"+str(key_id), '.gpg', '.in', '.out')
         random_text(input, 0x1337)
         self.assertTrue(e1.generte_key_batch(keygen_cmd))
@@ -1065,6 +1066,9 @@ class Sign(unittest.TestCase):
         self.gpg = GnuPG(GPGDIR, GPG)
         self.rnp.password = self.gpg.password = PASSWORD
         self.rnp.userid = self.gpg.userid = 'singingtest@secure.gov'
+
+    def tearDown(self):
+        clear_keyrings()
 
 class SignECDSA(Sign):
     # {0} must be replaced by ID of the curve 3,4 or 5 (NIST-256,384,521)
@@ -1083,28 +1087,28 @@ class SignECDSA(Sign):
 
     def test_sign_P256(self):
         cmd = SignECDSA.RNP_GENERATE_ECDSA_PATTERN.format(1)
-        self._rnp_sign_verify(self.rnp, self.gpg, 1, cmd)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_sign_P384(self):
         cmd = SignECDSA.RNP_GENERATE_ECDSA_PATTERN.format(2)
-        self._rnp_sign_verify(self.rnp, self.gpg, 2, cmd)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_sign_P521(self):
         cmd = SignECDSA.RNP_GENERATE_ECDSA_PATTERN.format(3)
-        self._rnp_sign_verify(self.rnp, self.gpg, 3, cmd)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_verify_P256(self):
         cmd = SignECDSA.GPG_GENERATE_ECDSA_PATERN.format(
             "nistp256", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 3, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_verify_P384(self):
         cmd = SignECDSA.GPG_GENERATE_ECDSA_PATERN.format("nistp384", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 4, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_verify_P521(self):
         cmd = SignECDSA.GPG_GENERATE_ECDSA_PATERN.format("nistp521", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 5, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_hash_truncation(self):
         '''
@@ -1114,7 +1118,7 @@ class SignECDSA(Sign):
         cmd = SignECDSA.RNP_GENERATE_ECDSA_PATTERN.format(1)
         rnp = self.rnp.copy()
         rnp.hash = 'SHA512'
-        self._rnp_sign_verify(rnp, self.gpg, 1, cmd)
+        self._rnp_sign_verify(rnp, self.gpg, cmd)
 
 class SignDSA(Sign):
     # {0} must be replaced by ID of the curve 3,4 or 5 (NIST-256,384,521)
@@ -1133,39 +1137,39 @@ class SignDSA(Sign):
 
     def test_sign_P1024_Q160(self):
        cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(1024)
-       self._rnp_sign_verify(self.rnp, self.gpg, 1, cmd)
+       self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_verify_P1024_Q160(self):
         cmd = SignDSA.GPG_GENERATE_DSA_PATERN.format(
             "1024", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 3, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_sign_P2048_Q256(self):
         cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(2048)
-        self._rnp_sign_verify(self.rnp, self.gpg, 1, cmd)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_verify_P2048_Q256(self):
         cmd = SignDSA.GPG_GENERATE_DSA_PATERN.format(
             "2048", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 3, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_sign_P3072_Q256(self):
         cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(3072)
-        self._rnp_sign_verify(self.rnp, self.gpg, 1, cmd)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_verify_P3072_Q256(self):
         cmd = SignDSA.GPG_GENERATE_DSA_PATERN.format(
             "3072", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 3, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_sign_P2112_Q256(self):
         cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(2112)
-        self._rnp_sign_verify(self.rnp, self.gpg, 1, cmd)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
 
     def test_verify_P2112_Q256(self):
         cmd = SignDSA.GPG_GENERATE_DSA_PATERN.format(
             "2112", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, 3, cmd)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
     def test_hash_truncation(self):
         '''
@@ -1175,7 +1179,7 @@ class SignDSA(Sign):
         cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(1024)
         rnp = self.rnp.copy()
         rnp.hash = 'SHA512'
-        self._rnp_sign_verify(rnp, self.gpg, 1, cmd)
+        self._rnp_sign_verify(rnp, self.gpg, cmd)
 
 # Main thinghy
 

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -860,11 +860,11 @@ class Encryption(unittest.TestCase):
         gpg_import_secring()
 
     @classmethod
-    #def tearDownClass(cls):
-        #clear_keyrings()
+    def tearDownClass(cls):
+        clear_keyrings()
 
-    #def tearDown(self):
-        #clear_workfiles()
+    def tearDown(self):
+        clear_workfiles()
 
     def test_file_encryption__gpg_to_rnp(self):
         for run in range(0, Encryption.RUNS):

--- a/src/tests/gnupg.py
+++ b/src/tests/gnupg.py
@@ -104,10 +104,13 @@ class GnuPG(object):
             params += ['--digest-algo', self.hash]
         return self._run([self.__gpg] + params)
 
-    def encrypt(self, out, input):
+    def encrypt(self, recipient, out, input):
         params = self.common_params
         params += ['--passphrase', self.password]
+        params += ['-r', recipient]
         params += ['-o', out]
+        # Blindely trust the key without asking
+        params += ['--always-trust']
         params += ['--encrypt', input]
         return self._run([self.__gpg] + params)
 

--- a/src/tests/rnp.py
+++ b/src/tests/rnp.py
@@ -115,11 +115,11 @@ class Rnp(object):
             params += ['--hash', self.hash]
         return self._run([self.rnp_bin] + params)
 
-    def encrypt(self, output, input):
+    def encrypt(self, recipient, output, input):
         pipe = pswd_pipe(self.password)
         params = self.common_params
         params += ['--pass-fd', str(pipe)]
-        params += ['--userid', self.userid]
+        params += ['--userid', recipient]
         params += ['--encrypt', input]
         params += ['--output', output]
         try:


### PR DESCRIPTION
I would like to propose functionality for exporting primary key with all subkeys (public). This patch adds such functionality to ``rnpkeys --export`` (previously ``--export`` was exporting only primary key). This operation is exact opposite to ``--import`` which imports primary key + subkeys. It's also similar to what's implemented in GnuPG.
Additionally the patch:
* Adds tests for ElGamal decryption against GnuPG encrypted data (this and coming tests for ECDH are main reasons why I need to have possibility to export subkeys). Those tests are also testing public-key export
* Fixes ``cli_tests.py`` - I've found out that after tests are done, in some cases, keys and workfiles are not removed, which is causing clashes and some other tests to break