### PR TITLE
Fixes for ECDH encryption and decryption

### DIFF
--- a/src/lib/crypto/ec.c
+++ b/src/lib/crypto/ec.c
@@ -122,7 +122,7 @@ pgp_genkey_ec_uncompressed(rng_t *                rng,
      *
      * P-521 is biggest supported curve
      */
-    uint8_t         point_bytes[BITS_TO_BYTES(521) * 2 + 1] = {0};
+    uint8_t         point_bytes[BITS_TO_BYTES(MAX_CURVE_BIT_SIZE) * 2 + 1] = {0};
     botan_privkey_t pr_key = NULL;
     botan_pubkey_t  pu_key = NULL;
     bignum_t *      public_x = NULL;

--- a/src/lib/crypto/ec.h
+++ b/src/lib/crypto/ec.h
@@ -36,6 +36,7 @@
 #include "crypto/rng.h"
 
 #define DEFAULT_CURVE PGP_CURVE_NIST_P_256
+#define MAX_CURVE_BIT_SIZE 521 // secp521r1
 
 typedef struct pgp_seckey_t pgp_seckey_t;
 

--- a/src/lib/crypto/ecdh.h
+++ b/src/lib/crypto/ecdh.h
@@ -32,10 +32,10 @@
 #include "ec.h"
 #include "rng.h"
 
-/* Size of wrapped and obfuscated key size
+/* Max size of wrapped and obfuscated key size
  *
- * RNP pads a key with PKCS-5 always to 40 bytes,
- * then 8 bytes is added by 3394.
+ * RNP pads a key with PKCS-5 always to 8 byte granularity,
+ * then 8 bytes is added by AES-wrap (RFC3394).
  */
 #define ECDH_WRAPPED_KEY_SIZE 48
 
@@ -84,7 +84,6 @@ bool set_ecdh_params(pgp_seckey_t *seckey, pgp_curve_t curve_id);
  * @return RNP_ERROR_NOT_SUPPORTED unknown curve
  * @return RNP_ERROR_BAD_PARAMETERS unexpected input provided
  * @return RNP_ERROR_SHORT_BUFFER `wrapped_key_len' to small to store result
- * @return RNP_ERROR_OUT_OF_MEMORY failed to allocated memory
  * @return RNP_ERROR_GENERIC implementation error
  */
 rnp_result_t pgp_ecdh_encrypt_pkcs5(rng_t *                  rng,


### PR DESCRIPTION
    * According to point RFC 4880bis04 (13.5) size of symmetric encryption key
      can be padded to 40 bytes (obfuscated) or padded to 8 nearest byte granularity.
      When encrypting, our implementation was padding the key to 40 bytes,
      but this is incompatible with GnuPG implementation (2.3.0-beta190). Also
      it is questionable how much security such solution bring. Also there is
      a bug in the RFC which states that PKCS5 padding must be used when
      padding symmetric key before it gets wrapped with AES-wrap. This makes
      it impossible to obfuscate size of the key to 40 bytes.
      Hence, I've change our implementation to pad symmetric key to nearest
      8 byte granularity.
      For more details see: https://dev.gnupg.org/T3763
    
    * Some cleanup and removal of unnecessary checking against NULL was introduced

    * When computing KEK, the KDF parameters (other_info) were wrongly supplied
      as salt to key derivation function `botan_pk_op_key_agreement'.
      It needs to be passed to KDF as a label.


Tests in #607
Closes #598
Requires #609