### PR TITLE
AEAD OCB mode and GnuPG compatibility

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -119,6 +119,9 @@
 /* Maximum authenticated data length for AEAD */
 #define PGP_AEAD_MAX_AD_LEN 32
 
+/* Default chunk bits, equals to 1mb chunks */
+#define PGP_AEAD_DEF_CHUNK_BITS 14
+
 /** Old Packet Format Lengths.
  * Defines the meanings of the 2 bits for length type in the
  * old packet format.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -98,33 +98,6 @@
 /* Size of the fingerprint */
 #define PGP_FINGERPRINT_SIZE 20
 
-/* Maximum length of the packet header */
-#define PGP_MAX_HEADER_SIZE 6
-
-/* Nonce len for AEAD/EAX */
-#define PGP_AEAD_EAX_NONCE_LEN 16
-
-/* Nonce len for AEAD/OCB */
-#define PGP_AEAD_OCB_NONCE_LEN 15
-
-/* Maximum AEAD nonce length */
-#define PGP_AEAD_MAX_NONCE_LEN 16
-
-/* Authentication tag len for AEAD/EAX and AEAD/OCB */
-#define PGP_AEAD_EAX_OCB_TAG_LEN 16
-
-/* Maximum AEAD tag length */
-#define PGP_AEAD_MAX_TAG_LEN 16
-
-/* Maximum authenticated data length for AEAD */
-#define PGP_AEAD_MAX_AD_LEN 32
-
-/* Default chunk bits, equals to 1mb chunks */
-#define PGP_AEAD_DEF_CHUNK_BITS 14
-
-/* Preallocated cache length for AEAD encryption/decryption */
-#define PGP_AEAD_CACHE_LEN (PGP_INPUT_CACHE_SIZE + PGP_AEAD_MAX_TAG_LEN)
-
 /** Old Packet Format Lengths.
  * Defines the meanings of the 2 bits for length type in the
  * old packet format.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -101,14 +101,17 @@
 /* Maximum length of the packet header */
 #define PGP_MAX_HEADER_SIZE 6
 
-/* Nonce (IV) len for AEAD/EAX */
+/* Nonce len for AEAD/EAX */
 #define PGP_AEAD_EAX_NONCE_LEN 16
+
+/* Nonce len for AEAD/OCB */
+#define PGP_AEAD_OCB_NONCE_LEN 15
 
 /* Maximum AEAD nonce length */
 #define PGP_AEAD_MAX_NONCE_LEN 16
 
-/* Authentication tag len for AEAD/EAX */
-#define PGP_AEAD_EAX_TAG_LEN 16
+/* Authentication tag len for AEAD/EAX and AEAD/OCB */
+#define PGP_AEAD_EAX_OCB_TAG_LEN 16
 
 /* Maximum AEAD tag length */
 #define PGP_AEAD_MAX_TAG_LEN 16

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -122,6 +122,9 @@
 /* Default chunk bits, equals to 1mb chunks */
 #define PGP_AEAD_DEF_CHUNK_BITS 14
 
+/* Preallocated cache length for AEAD encryption/decryption */
+#define PGP_AEAD_CACHE_LEN (PGP_INPUT_CACHE_SIZE + PGP_AEAD_MAX_TAG_LEN)
+
 /** Old Packet Format Lengths.
  * Defines the meanings of the 2 bits for length type in the
  * old packet format.

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -116,6 +116,7 @@ typedef struct rnp_ctx_t {
     int             zalg;          /* compression algorithm used */
     int             zlevel;        /* compression level */
     pgp_aead_alg_t  aalg;          /* non-zero to use AEAD */
+    int             abits;         /* AEAD chunk bits */
     bool            overwrite;     /* allow to overwrite output file if exists */
     bool            armor;         /* whether to use ASCII armor on output */
     list            recipients;    /* recipients of the encrypted message */

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -290,7 +290,7 @@ write_protected_seckey_body(pgp_output_t *output, pgp_seckey_t *seckey, const ch
     uint8_t     sesskey[PGP_MAX_KEY_SIZE];
     size_t      sesskey_size = pgp_key_size(seckey->protection.symm_alg);
     unsigned    block_size = pgp_block_size(seckey->protection.symm_alg);
-    pgp_crypt_t crypt = {0};
+    pgp_crypt_t crypt = {{{0}}, 0};
     pgp_hash_t  hash = {0};
     unsigned    writers_pushed = 0;
     bool        ret = false;

--- a/src/lib/symmetric.h
+++ b/src/lib/symmetric.h
@@ -54,6 +54,18 @@
 
 #include "crypto/rng.h"
 
+/* Nonce len for AEAD/EAX */
+#define PGP_AEAD_EAX_NONCE_LEN 16
+
+/* Nonce len for AEAD/OCB */
+#define PGP_AEAD_OCB_NONCE_LEN 15
+
+/* Maximum AEAD nonce length */
+#define PGP_AEAD_MAX_NONCE_LEN 16
+
+/* Authentication tag len for AEAD/EAX and AEAD/OCB */
+#define PGP_AEAD_EAX_OCB_TAG_LEN 16
+
 /** pgp_crypt_t */
 typedef struct pgp_crypt_t {
     union {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -595,7 +595,7 @@ typedef struct {
     unsigned       version;
     pgp_symm_alg_t alg;
     pgp_s2k_t      s2k;
-    uint8_t        enckey[PGP_MAX_KEY_SIZE + PGP_AEAD_EAX_TAG_LEN + 1];
+    uint8_t        enckey[PGP_MAX_KEY_SIZE + PGP_AEAD_MAX_TAG_LEN + 1];
     unsigned       enckeylen;
     /* v5 specific fields */
     pgp_aead_alg_t aalg;

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -75,6 +75,15 @@
 #define PGP_MPINT_BITS (16384)
 #define PGP_MPINT_SIZE (PGP_MPINT_BITS >> 3)
 
+/* Maximum AEAD tag length */
+#define PGP_AEAD_MAX_TAG_LEN 16
+
+/* Maximum authenticated data length for AEAD */
+#define PGP_AEAD_MAX_AD_LEN 32
+
+/* Maximum length of the packet header */
+#define PGP_MAX_HEADER_SIZE 6
+
 /** General-use structure for variable-length data
  */
 

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -107,6 +107,9 @@
 /* TODO: Review usage of this variable */
 #define RNP_BUFSIZ 8192
 
+/* Default chunk bits, equals to 1mb chunks */
+#define PGP_AEAD_DEF_CHUNK_BITS 14
+
 /* for silencing unused parameter warnings */
 #define RNP_USED(x) /*LINTED*/ (void) &(x)
 

--- a/src/librepgp/stream-def.h
+++ b/src/librepgp/stream-def.h
@@ -56,4 +56,7 @@
 #define EXT_PGP (".pgp")
 #define EXT_GPG (".gpg")
 
+/* Preallocated cache length for AEAD encryption/decryption */
+#define PGP_AEAD_CACHE_LEN (PGP_INPUT_CACHE_SIZE + PGP_AEAD_MAX_TAG_LEN)
+
 #endif /* !STREAM_DEF_H_ */

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -736,8 +736,8 @@ stream_parse_sk_sesskey(pgp_source_t *src, pgp_sk_sesskey_t *skey)
 
     if (skey->version == PGP_SKSK_V5) {
         /* v5: iv + esk + tag. For both EAX and OCB ivlen and taglen are 16 octets */
-        size_t ivlen = pgp_cipher_aead_nonce_len(skey->aalg);
-        size_t taglen = pgp_cipher_aead_tag_len(skey->aalg);
+        ssize_t ivlen = pgp_cipher_aead_nonce_len(skey->aalg);
+        ssize_t taglen = pgp_cipher_aead_tag_len(skey->aalg);
         if (len > ivlen + taglen + PGP_MAX_KEY_SIZE) {
             RNP_LOG("too long esk");
             return RNP_ERROR_BAD_FORMAT;

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -92,8 +92,6 @@ typedef struct pgp_source_packet_param_t {
     uint64_t      len; /* packet body length if non-partial and non-indeterminate */
 } pgp_source_packet_param_t;
 
-#define PGP_AEAD_CACHE_LEN (PGP_INPUT_CACHE_SIZE + PGP_AEAD_MAX_TAG_LEN)
-
 typedef struct pgp_source_encrypted_param_t {
     pgp_source_packet_param_t pkt;            /* underlying packet-related params */
     list                      symencs;        /* array of sym-encrypted session keys */
@@ -528,7 +526,7 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     bool    res = false;
     ssize_t read;
     ssize_t tagread;
-    ssize_t  taglen;
+    ssize_t taglen;
     uint8_t tag[PGP_AEAD_MAX_TAG_LEN * 2];
 
     param->cachepos = 0;

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -528,7 +528,7 @@ encrypted_src_read_aead_part(pgp_source_encrypted_param_t *param)
     bool    res = false;
     ssize_t read;
     ssize_t tagread;
-    size_t  taglen;
+    ssize_t  taglen;
     uint8_t tag[PGP_AEAD_MAX_TAG_LEN * 2];
 
     param->cachepos = 0;

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -820,7 +820,7 @@ encrypted_start_aead(pgp_dest_encrypted_param_t *param, uint8_t *enckey)
     hdr[0] = 1;
     hdr[1] = param->ctx->ealg;
     hdr[2] = param->ctx->aalg;
-    hdr[3] = 4; /* 1Kb chunks */
+    hdr[3] = param->ctx->abits;
 
     /* generate iv */
     nlen = pgp_cipher_aead_nonce_len(param->ctx->aalg);
@@ -883,6 +883,11 @@ init_encrypted_dst(pgp_write_handler_t *handler, pgp_dest_t *dst, pgp_dest_t *wr
 
         if ((pgp_block_size(handler->ctx->ealg) != 16)) {
             RNP_LOG("wrong AEAD symmetric algorithm");
+            return RNP_ERROR_BAD_PARAMETERS;
+        }
+
+        if ((handler->ctx->abits < 0) || (handler->ctx->abits > 56)) {
+            RNP_LOG("wrong AEAD chunk bits");
             return RNP_ERROR_BAD_PARAMETERS;
         }
     }

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -200,7 +200,7 @@ static struct option options[] = {
   {"bzip", no_argument, NULL, OPT_ZALG_BZIP},
   {"bzip2", no_argument, NULL, OPT_ZALG_BZIP},
   {"overwrite", no_argument, NULL, OPT_OVERWRITE},
-  {"aead", no_argument, NULL, OPT_AEAD},
+  {"aead", optional_argument, NULL, OPT_AEAD},
 
   {NULL, 0, NULL, 0},
 };
@@ -605,9 +605,20 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
     case OPT_ZALG_BZIP:
         rnp_cfg_setint(cfg, CFG_ZALG, PGP_C_BZIP2);
         break;
-    case OPT_AEAD:
-        rnp_cfg_setint(cfg, CFG_AEAD, PGP_AEAD_EAX);
+    case OPT_AEAD: {
+        pgp_aead_alg_t alg = 0;
+        if (!arg || !strcmp(arg, "1") || !rnp_strcasecmp(arg, "eax")) {
+            alg = PGP_AEAD_EAX;
+        } else if (!strcmp(arg, "2") || !rnp_strcasecmp(arg, "ocb")) {
+            alg = PGP_AEAD_OCB;
+        } else {
+            (void) fprintf(stderr, "Wrong AEAD algorithm: %s\n", arg);
+            exit(EXIT_ERROR);
+        }
+
+        rnp_cfg_setint(cfg, CFG_AEAD, alg);
         break;
+    }
     case OPT_OVERWRITE:
         rnp_cfg_setbool(cfg, CFG_OVERWRITE, true);
         break;

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -66,6 +66,7 @@
 #define CFG_ZLEVEL "zlevel"             /* compression level: 0..9 (0 for no compression) */
 #define CFG_ZALG "zalg"                 /* compression algorithm: zip, zlib or bzip2 */
 #define CFG_AEAD "aead"                 /* if nonzero then AEAD enryption mode, int */
+#define CFG_AEAD_CHUNK "aead_chunk"     /* AEAD chunk size bits, int from 0 to 56 */
 #define CFG_KEYSTORE_DISABLED \
     "disable_keystore"    /* indicates wether keystore must be initialized */
 #define CFG_FORCE "force" /* force command to succeed operation */

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -932,7 +932,8 @@ class Encryption(unittest.TestCase):
         AEAD_MODES = ['eax', 'ocb']
         AEAD_BITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 24, 30, 40, 50, 56]
 
-        usegpg = gpg_supports_aead()
+        #usegpg = gpg_supports_aead()
+        usegpg = False
 
         # Encrypt and decrypt cleartext using the AEAD
         for run in range(0, Encryption.RUNS):


### PR DESCRIPTION
This PR adds support for AEAD-OCB encryption mode and ensures compatibility with latest GnuPG development build.
It updates CLI tests to check AEAD implementation against GnuPG (if it has AEAD implementation).

To select AEAD algorithm CLI parameter `--aead[=EAX|=OCB]` should be used.
Also (mostly for tests) you may control AEAD chunk size as per RFC4880bis via `--aead-chunk-bits` parameter.
