### PR TITLE
Enable AEAD tests against GnuPG

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -932,8 +932,7 @@ class Encryption(unittest.TestCase):
         AEAD_MODES = ['eax', 'ocb']
         AEAD_BITS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 18, 24, 30, 40, 50, 56]
 
-        #usegpg = gpg_supports_aead()
-        usegpg = False
+        usegpg = gpg_supports_aead()
 
         # Encrypt and decrypt cleartext using the AEAD
         for run in range(0, Encryption.RUNS):


### PR DESCRIPTION
This PR should be merged only when https://dev.gnupg.org/T3774 is resolved.
Before that tests could fail randomly.