### PR TITLE
Allow multiple-recipient encryption

### DIFF
--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -392,6 +392,34 @@ rnp_cfg_getlist(rnp_cfg_t *cfg, const char *key)
     return NULL;
 }
 
+bool
+rnp_cfg_copylist_str(rnp_cfg_t *cfg, list *dst, const char *key)
+{
+    rnp_cfg_item_t *it = rnp_cfg_find(cfg, key);
+
+    if (!it || (it->val.type != RNP_CFG_VAL_LIST)) {
+        goto fail;
+    }
+
+    for (list_item *li = list_front(it->val.val._list); li; li = list_next(li)) {
+        rnp_cfg_val_t *val = (rnp_cfg_val_t *) li;
+        if ((val->type != RNP_CFG_VAL_STRING) || !val->val._string) {
+            RNP_LOG("wrong item in string list");
+            goto fail;
+        }
+        if (!list_append(dst, val->val._string, strlen(val->val._string) + 1)) {
+            RNP_LOG("allocation failed");
+            goto fail;
+        }
+    }
+
+    return true;
+
+fail:
+    list_destroy(dst);
+    return false;
+}
+
 void
 rnp_cfg_free(rnp_cfg_t *cfg)
 {

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -52,6 +52,7 @@
 #define CFG_HOMEDIR "homedir"       /* home directory - folder with keyrings and so on */
 #define CFG_PASSFD "pass-fd"        /* password file descriptor */
 #define CFG_PASSWD "password"       /* password as command-line constant */
+#define CFG_PASSWORDC "passwordc"   /* number of passwords for symmetric encryption */
 #define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
 #define CFG_EXPIRATION "expiration"     /* signature expiration time */

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -45,12 +45,13 @@
 #define CFG_COREDUMPS "coredumps"     /* enable/disable core dumps. 1 or 0. */
 #define CFG_NEEDSUSERID "needsuserid" /* needs user id for the ongoing operation */
 #define CFG_NEEDSSECKEY "needsseckey" /* needs secret key for the ongoing operation */
-#define CFG_KEYRING "keyring" /* path to the keyring ?? seems not to be used anywhere */
-#define CFG_USERID "userid"   /* userid for the ongoing operation */
-#define CFG_VERBOSE "verbose" /* verbose logging */
-#define CFG_HOMEDIR "homedir" /* home directory - folder with keyrings and so on */
-#define CFG_PASSFD "pass-fd"  /* password file descriptor */
-#define CFG_PASSWD "password" /* password as command-line constant */
+#define CFG_KEYRING "keyring"       /* path to the keyring ?? seems not to be used anywhere */
+#define CFG_USERID "userid"         /* userid for the ongoing operation */
+#define CFG_RECIPIENTS "recipients" /* list of encrypted data recipients */
+#define CFG_VERBOSE "verbose"       /* verbose logging */
+#define CFG_HOMEDIR "homedir"       /* home directory - folder with keyrings and so on */
+#define CFG_PASSFD "pass-fd"        /* password file descriptor */
+#define CFG_PASSWD "password"       /* password as command-line constant */
 #define CFG_USERINPUTFD "user-input-fd" /* user input file descriptor */
 #define CFG_NUMTRIES "numtries"         /* number of password request tries, or 'unlimited' */
 #define CFG_EXPIRATION "expiration"     /* signature expiration time */
@@ -168,13 +169,22 @@ int rnp_cfg_getint(rnp_cfg_t *cfg, const char *key);
 bool rnp_cfg_getbool(rnp_cfg_t *cfg, const char *key);
 
 /** @brief return list value for the key if there is one. Each list's element contains
- *  rbp_cfg_val_t element with the corresponding value. List may be modified.
+ *  rnp_cfg_val_t element with the corresponding value. List may be modified.
  *  @param cfg rnp config, must be allocated and initialized
  *  @param key must be null-terminated string
  *
  *  @return pointer to the list on success or NULL if value was not found or has other type
  **/
 list *rnp_cfg_getlist(rnp_cfg_t *cfg, const char *key);
+
+/** @brief copy string values as char * from the list to destination
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param dst pointer to the list structure, where strings will be stored
+ *  @param key must be null-terminated string
+ *
+ *  @return true on success or false otherwise
+ **/
+bool rnp_cfg_copylist_str(rnp_cfg_t *cfg, list *dst, const char *key);
 
 /** @brief free the memory allocated in rnp_cfg_t
  *  @param cfg rnp config, must be allocated and initialized

--- a/src/tests/cli_common.py
+++ b/src/tests/cli_common.py
@@ -28,6 +28,12 @@ def size_to_readable(num, suffix = 'B'):
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
 
+def list_upto(lst, count):
+    res = lst[:]
+    while len(res) < count:
+        res = res + lst[:]
+    return res[:count]
+
 def pswd_pipe(password):
     pr, pw = os.pipe()
     with os.fdopen(pw, 'w') as fw:

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -169,7 +169,7 @@ def rnp_genkey_rsa(userid, bits=2048):
 
 
 def rnp_encrypt_file(recipient, src, dst, zlevel=6, zalgo='zip', armor=False):
-    params = ['--homedir', RNPDIR, '--userid', recipient, '-z',
+    params = ['--homedir', RNPDIR, '-r', recipient, '-z',
               str(zlevel), '--' + zalgo, '--encrypt', src, '--output', dst]
     if armor:
         params += ['--armor']

--- a/src/tests/rnp.py
+++ b/src/tests/rnp.py
@@ -119,7 +119,7 @@ class Rnp(object):
         pipe = pswd_pipe(self.password)
         params = self.common_params
         params += ['--pass-fd', str(pipe)]
-        params += ['--userid', recipient]
+        params += ['--recipient', recipient]
         params += ['--encrypt', input]
         params += ['--output', output]
         try:


### PR DESCRIPTION
This PR adds support for multiple-key encryption via `-r` or `--recipient` CLI parameter, which replaces previously used `--userid`. `--userid` will be used for signer's private key selection.
Also it adds `--passwords` CLI option which allows symmetric encryption to multiple passwords.

I didn't add CLI tests yet since we lack a functionality on keyring manipulation (or do I miss somehow the option to export private key, delete key from keyring, and so on?)

Fixes #236 