### PR TITLE
Add defaults.h and change default symmetric cipher to AES256

### DIFF
--- a/include/rnp/rnp_def.h
+++ b/include/rnp/rnp_def.h
@@ -50,18 +50,6 @@
 #define MAX_PASSWORD_ATTEMPTS 3
 #define INFINITE_ATTEMPTS -1
 
-/* SHA1 is not considered secured anymore and SHOULD NOT be used to create messages (as per
- * Appendix C of RFC 4880-bis-02). SHA2 MUST be implemented.
- * Let's pre-empt this by specifying SHA256 - gpg interoperates just fine with SHA256 - agc,
- * 20090522
- */
-#define DEFAULT_HASH_ALG "SHA256"
-#define PGP_SA_DEFAULT_CIPHER_MODE PGP_CIPHER_MODE_CFB
-#define DEFAULT_PK_ALG PGP_PKA_RSA
-#define DEFAULT_RSA_NUMBITS 2048
-#define PGP_SA_DEFAULT_CIPHER PGP_SA_AES_256
-#define PGP_DEFAULT_HASH_ALGORITHM PGP_HASH_SHA256
-
 /*
  * Error code definitions
  */

--- a/src/lib/crypto/s2k.h
+++ b/src/lib/crypto/s2k.h
@@ -33,8 +33,6 @@
 
 #include "hash.h"
 
-#define PGP_S2K_DEFAULT_ITERATIONS 524288
-
 int pgp_s2k_simple(pgp_hash_alg_t alg, uint8_t *out, size_t output_len, const char *password);
 
 int pgp_s2k_salted(pgp_hash_alg_t alg,

--- a/src/lib/defaults.h
+++ b/src/lib/defaults.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2018, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DEFAULTS_H_
+#define DEFAULTS_H_
+
+/* SHA1 is not considered secured anymore and SHOULD NOT be used to create messages (as per
+ * Appendix C of RFC 4880-bis-02). SHA2 MUST be implemented.
+ * Let's pre-empt this by specifying SHA256 - gpg interoperates just fine with SHA256 - agc,
+ * 20090522
+ */
+#define DEFAULT_HASH_ALG "SHA256"
+
+/* Default hash algorithm as PGP constant */
+#define DEFAULT_PGP_HASH_ALG PGP_HASH_SHA256
+
+/* Default symmetric algorithm */
+#define DEFAULT_SYMM_ALG "AES256"
+
+/* Default symmetric algorithm as PGP constant */
+#define DEFAULT_PGP_SYMM_ALG PGP_SA_AES_256
+
+/* Default number of S2K iterations */
+#define DEFAULT_S2K_ITERATIONS 524288
+
+/* Default compression algorithm and level */
+#define DEFAULT_Z_ALG PGP_C_ZIP
+#define DEFAULT_Z_LEVEL 6
+
+/* Default AEAD algorithm */
+#define DEFAULT_AEAD_ALG "EAX"
+
+/* Default AEAD chunk bits, equals to 100MB chunks */
+#define DEFAULT_AEAD_CHUNK_BITS 21
+
+/* Default cipher mode for secret key encryption */
+#define DEFAULT_CIPHER_MODE PGP_CIPHER_MODE_CFB
+
+/* Default public key algorithm for new key generation */
+#define DEFAULT_PK_ALG PGP_PKA_RSA
+
+/* Default RSA key length */
+#define DEFAULT_RSA_NUMBITS 2048
+
+#endif

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -37,6 +37,7 @@
 #include "crypto/ecdsa.h"
 #include "pgp-key.h"
 #include "memory.h"
+#include "defaults.h"
 
 static const pgp_symm_alg_t DEFAULT_SYMMETRIC_ALGS[] = {
   PGP_SA_AES_256, PGP_SA_AES_192, PGP_SA_AES_128, PGP_SA_TRIPLEDES};

--- a/src/lib/hash.c
+++ b/src/lib/hash.c
@@ -80,6 +80,8 @@
 #include <stdio.h>
 #include "crypto/ecdsa.h"
 #include "crypto/dsa.h"
+#include "defaults.h"
+
 static const struct hash_alg_map_t {
     pgp_hash_alg_t type;
     const char *   name;
@@ -133,7 +135,7 @@ pgp_hash_alg_t
 pgp_str_to_hash_alg(const char *hash)
 {
     if (hash == NULL) {
-        return PGP_DEFAULT_HASH_ALGORITHM;
+        return DEFAULT_PGP_HASH_ALG;
     }
     for (size_t i = 0; i < ARRAY_SIZE(hash_alg_map); i++) {
         if (!rnp_strcasecmp(hash, hash_alg_map[i].name)) {

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -63,6 +63,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include "defaults.h"
 
 void
 pgp_free_user_prefs(pgp_user_prefs_t *prefs)
@@ -862,11 +863,10 @@ pgp_key_protect_password(pgp_key_t *                  key,
                          const char *                 password)
 {
     bool                        ret = false;
-    rnp_key_protection_params_t default_protection = {.symm_alg = PGP_SA_DEFAULT_CIPHER,
-                                                      .cipher_mode =
-                                                        PGP_SA_DEFAULT_CIPHER_MODE,
-                                                      .iterations = 65536,
-                                                      .hash_alg = PGP_DEFAULT_HASH_ALGORITHM};
+    rnp_key_protection_params_t default_protection = {.symm_alg = DEFAULT_PGP_SYMM_ALG,
+                                                      .cipher_mode = DEFAULT_CIPHER_MODE,
+                                                      .iterations = DEFAULT_S2K_ITERATIONS,
+                                                      .hash_alg = DEFAULT_PGP_HASH_ALG};
 
     // sanity check
     if (!key || !password) {

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -94,6 +94,7 @@ __RCSID("$NetBSD: rnp.c,v 1.98 2016/06/28 16:34:40 christos Exp $");
 #include <rnp/rnp_def.h>
 #include "pgp-key.h"
 #include "list.h"
+#include "defaults.h"
 #include <librepgp/stream-def.h>
 #include <librepgp/stream-armor.h>
 #include <librepgp/stream-parse.h>
@@ -1774,7 +1775,7 @@ rnp_encrypt_add_password(rnp_ctx_t *ctx)
            &info,
            password,
            ctx->halg /* TODO: should be separate s2k-specific */,
-           PGP_S2K_DEFAULT_ITERATIONS /* TODO: make this configurable */,
+           DEFAULT_S2K_ITERATIONS /* TODO: make this configurable */,
            ctx->ealg /* TODO: should be separate s2k-specific */))) {
         goto done;
     }

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -31,6 +31,7 @@
 #include "hash.h"
 #include "list.h"
 #include "pgp-key.h"
+#include "defaults.h"
 #include <assert.h>
 #include <json_object.h>
 #include <librepgp/packet-show.h>
@@ -155,7 +156,7 @@ rnp_ctx_init_ffi(rnp_ctx_t *ctx, rnp_ffi_t ffi)
 {
     memset(ctx, 0, sizeof(*ctx));
     ctx->rng = &ffi->rng;
-    ctx->ealg = PGP_SA_DEFAULT_CIPHER;
+    ctx->ealg = DEFAULT_PGP_SYMM_ALG;
 }
 
 static const pgp_map_t sig_type_map[] = {{PGP_SIG_BINARY, "binary"},
@@ -1092,10 +1093,10 @@ rnp_op_encrypt_add_password(rnp_op_encrypt_t op,
         s2k_hash = DEFAULT_HASH_ALG;
     }
     if (!iterations) {
-        iterations = PGP_S2K_DEFAULT_ITERATIONS;
+        iterations = DEFAULT_S2K_ITERATIONS;
     }
     if (!s2k_cipher) {
-        s2k_cipher = "AES256"; // TODO: make this a define somewhere
+        s2k_cipher = DEFAULT_SYMM_ALG;
     }
     // parse
     pgp_hash_alg_t hash_alg = PGP_HASH_UNKNOWN;

--- a/src/lib/symmetric.c
+++ b/src/lib/symmetric.c
@@ -51,6 +51,7 @@
 
 #include "crypto.h"
 #include "config.h"
+#include "defaults.h"
 #include <rnp/rnp_sdk.h>
 
 #include <string.h>
@@ -423,7 +424,7 @@ pgp_str_to_cipher(const char *cipher)
             return sp->i;
         }
     }
-    return PGP_SA_DEFAULT_CIPHER;
+    return DEFAULT_PGP_SYMM_ALG;
 }
 
 unsigned

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -107,9 +107,6 @@
 /* TODO: Review usage of this variable */
 #define RNP_BUFSIZ 8192
 
-/* Default chunk bits, equals to 1mb chunks */
-#define PGP_AEAD_DEF_CHUNK_BITS 14
-
 /* for silencing unused parameter warnings */
 #define RNP_USED(x) /*LINTED*/ (void) &(x)
 

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -50,6 +50,7 @@
 #include "rnpcfg.h"
 #include <rekey/rnp_key_store.h>
 #include "pgp-key.h"
+#include "defaults.h"
 #include <repgp/repgp.h>
 #include <librepgp/stream-parse.h>
 #include <librepgp/stream-armor.h>
@@ -392,7 +393,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, int cmd, char *f)
         ctx.zalg = rnp_cfg_getint(cfg, CFG_ZALG);
         ctx.zlevel = rnp_cfg_getint(cfg, CFG_ZLEVEL);
         ctx.aalg = rnp_cfg_getint(cfg, CFG_AEAD);
-        ctx.abits = rnp_cfg_getint_default(cfg, CFG_AEAD_CHUNK, PGP_AEAD_DEF_CHUNK_BITS);
+        ctx.abits = rnp_cfg_getint_default(cfg, CFG_AEAD_CHUNK, DEFAULT_AEAD_CHUNK_BITS);
         ret = rnp_protect_file(&ctx, f, rnp_cfg_getstr(cfg, CFG_OUTFILE)) == RNP_SUCCESS;
         break;
     }

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -35,6 +35,7 @@
 
 #include "rnpcfg.h"
 #include "utils.h"
+#include "defaults.h"
 #include <rnp/rnp_sdk.h>
 #include <rekey/rnp_key_store.h>
 
@@ -73,9 +74,9 @@ rnp_cfg_load_defaults(rnp_cfg_t *cfg)
     rnp_cfg_setbool(cfg, CFG_OVERWRITE, false);
     rnp_cfg_setstr(cfg, CFG_OUTFILE, NULL);
     rnp_cfg_setstr(cfg, CFG_HASH, DEFAULT_HASH_ALG);
-    rnp_cfg_setint(cfg, CFG_ZALG, PGP_C_ZIP);
-    rnp_cfg_setint(cfg, CFG_ZLEVEL, 6);
-    rnp_cfg_setstr(cfg, CFG_CIPHER, "cast5");
+    rnp_cfg_setint(cfg, CFG_ZALG, DEFAULT_Z_ALG);
+    rnp_cfg_setint(cfg, CFG_ZLEVEL, DEFAULT_Z_LEVEL);
+    rnp_cfg_setstr(cfg, CFG_CIPHER, DEFAULT_SYMM_ALG);
     rnp_cfg_setint(cfg, CFG_MAXALLOC, 4194304);
     rnp_cfg_setstr(cfg, CFG_SUBDIRGPG, SUBDIRECTORY_RNP);
     rnp_cfg_setstr(cfg, CFG_SUBDIRSSH, SUBDIRECTORY_SSH);

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -37,6 +37,7 @@
 #include "librepgp/reader.h"
 #include "librepgp/validate.h"
 #include "signature.h"
+#include "defaults.h"
 
 extern rng_t global_rng;
 
@@ -71,7 +72,7 @@ rnpkeys_generatekey_testSignature(void **state)
         strcat(userId, hashAlg[i]);
 
         /* Generate the RSA key and make sure it was generated */
-        set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_DEFAULT_HASH_ALGORITHM);
+        set_default_rsa_key_desc(&rnp.action.generate_key_ctx, DEFAULT_PGP_HASH_ALG);
         strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
                 userId,
                 sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
@@ -180,7 +181,7 @@ rnpkeys_generatekey_testEncryption(void **state)
 
     strcpy(userId, "ciphertest");
     /* Generate the RSA key and make sure it was generated */
-    set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_DEFAULT_HASH_ALGORITHM);
+    set_default_rsa_key_desc(&rnp.action.generate_key_ctx, DEFAULT_PGP_HASH_ALG);
     strncpy((char *) rnp.action.generate_key_ctx.primary.keygen.cert.userid,
             userId,
             sizeof(rnp.action.generate_key_ctx.primary.keygen.cert.userid));
@@ -213,7 +214,7 @@ rnpkeys_generatekey_testEncryption(void **state)
             ctx.ealg = pgp_str_to_cipher(cipherAlg[i]);
             /* checking whether we have correct cipher constant */
             rnp_assert_true(rstate,
-                            (ctx.ealg != PGP_SA_DEFAULT_CIPHER) ||
+                            (ctx.ealg != DEFAULT_PGP_SYMM_ALG) ||
                               (strcmp(cipherAlg[i], "AES256") == 0));
             rnp_assert_non_null(rstate,
                                 list_append(&ctx.recipients, userId, strlen(userId) + 1));


### PR DESCRIPTION
This PR moves all default algorithms and other constants related to default parameters selection to single defaults.h header.

We use cast5 as default symmetric algorithm, and, at least, AEAD without --cipher parameter doesn't work (since cast5 has 8-byte block).
RFC4880bis has AES-128 as a single MUST-implement algorithm. However, since ffi already used AES256, and GnuPG uses it as default, I replaced cast5 with aes256.
