### PR TITLE
Add a printf to test_dsa_roundtrip.

### DIFF
--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -718,6 +718,11 @@ test_dsa_roundtrip(void **state)
 
 
         assert_true(pgp_generate_seckey(&key_desc, &sec_key1));
+        // try to prevent timeouts in travis-ci
+        printf("p: %zu q: %zu h: %s\n",
+               key_desc.dsa.p_bitlen,
+               key_desc.dsa.q_bitlen,
+               pgp_show_hash_alg(key_desc.hash_alg));
         assert_true(pgp_generate_seckey(&key_desc, &sec_key2));
 
         pgp_dsa_pubkey_t *pub1 = &sec_key1.pubkey.key.dsa;


### PR DESCRIPTION
This is just to prevent travis-ci from thinking the process is hung.

This test is pretty thorough and takes 5x longer than all the other `rnp_tests` combined, so travis-ci will sometimes kill it after 10 minutes of no output.

Obviously there's a few other ways to handle this, but this is simple and should work.