### PR TITLE
Fix up rnp_key_add_uid to handle locked keys and add uid to both keys.

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -509,7 +509,8 @@ typedef enum pgp_op_t {
     PGP_OP_UNPROTECT = 6,   /* removing protection from a (locked) key */
     PGP_OP_DECRYPT_SYM = 7, /* symmetric decryption */
     PGP_OP_ENCRYPT_SYM = 8, /* symmetric encryption */
-    PGP_OP_VERIFY = 9       /* signature verification */
+    PGP_OP_VERIFY = 9,      /* signature verification */
+    PGP_OP_ADD_USERID = 10, /* adding a userid */
 } pgp_op_t;
 
 /** Hashing Algorithm Numbers.

--- a/include/rnp/rnp2.h
+++ b/include/rnp/rnp2.h
@@ -237,18 +237,20 @@ rnp_result_t rnp_key_get_primary_uid(rnp_key_handle_t key, char **uid);
 rnp_result_t rnp_key_get_uid_count(rnp_key_handle_t key, size_t *count);
 rnp_result_t rnp_key_get_uid_at(rnp_key_handle_t key, size_t idx, char **uid);
 
-/**
-* Add a new user identifier to a key
-* @param key the key to add - must be a secret key
-* @param uid the UID to add
-* @param hash name of the hash function to use for the uid binding
-*        signature (eg "SHA256")
-* @param expiration time when this user id expires
-* @param key_flags usage flags, see section 5.2.3.21 of RFC 4880
-*        or just provide zero to indicate no special handling.
-* @param primary indicates if this is the primary UID
-*/
-rnp_result_t rnp_key_add_uid(rnp_key_handle_t key,
+/** Add a new user identifier to a key
+ *
+ *  @param ffi
+ *  @param key the key to add - must be a secret key
+ *  @param uid the UID to add
+ *  @param hash name of the hash function to use for the uid binding
+ *         signature (eg "SHA256")
+ *  @param expiration time when this user id expires
+ *  @param key_flags usage flags, see section 5.2.3.21 of RFC 4880
+ *         or just provide zero to indicate no special handling.
+ *  @param primary indicates if this is the primary UID
+ */
+rnp_result_t rnp_key_add_uid(rnp_ffi_t        ffi,
+                             rnp_key_handle_t key,
                              const char *     uid,
                              const char *     hash,
                              uint32_t         expiration,

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -222,6 +222,14 @@ bool pgp_key_unprotect(pgp_key_t *key, const pgp_password_provider_t *password_p
  **/
 bool pgp_key_is_protected(const pgp_key_t *key);
 
+/** add a new userid to a key
+ *
+ *  @param key
+ *  @param seckey the decrypted seckey for signing
+ *  @param hash_alg the hash algorithm to be used for the signature
+ *  @param cert the self-signature information
+ *  @return true if the userid was added, false otherwise
+ */
 bool pgp_key_add_userid(pgp_key_t *            key,
                         const pgp_seckey_t *   seckey,
                         pgp_hash_alg_t         hash_alg,


### PR DESCRIPTION
I didn't get a chance to review #621 originally but I looked back and fixed some issues I saw:
* Updated to handle locked keys.
* Adds uid to both pub and sec keys (depends on keyring format a bit).
* Fixed a small mem leak.