### PR TITLE
Fix leaks in rnp_tests and re-enforce sanitize-leaks CI run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
       sudo: true
 
     # codecov
-    - env: BUILD_MODE=coverage GPG_VERSION=stable
+    - env: BUILD_MODE=coverage GPG_VERSION=beta
       compiler: gcc
 
     # clang-format style checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,6 @@ matrix:
             - clang-format-4.0
 
   allow_failures:
-    # allowed to fail until we have eliminated all memory leaks from our test runs
-    - env: BUILD_MODE=sanitize-leaks GPG_VERSION=stable
-    - env: BUILD_MODE=sanitize-leaks GPG_VERSION=beta
     # allowed to fail until we have stabilized on a clang-format version
     - env: BUILD_MODE=style-check GPG_VERSION=stable
 

--- a/include/rnp/rnp2.h
+++ b/include/rnp/rnp2.h
@@ -361,8 +361,9 @@ rnp_result_t rnp_identifier_iterator_create(rnp_ffi_t                  ffi,
  *
  *  @param it the iterator
  *  @param identifier pointer that will be set to the identifier value.
- *         Must not be NULL. The application should free this with
- *         rnp_buffer_free.
+ *         Must not be NULL. This buffer should not be freed by the application.
+ *         It will be modified by subsequent calls to this function, and its
+ *         life is tied to the iterator.
  *  @return 0 on success, or any other value on error
  */
 rnp_result_t rnp_identifier_iterator_next(rnp_identifier_iterator_t it,

--- a/src/lib/crypto/sm2.c
+++ b/src/lib/crypto/sm2.c
@@ -250,6 +250,8 @@ pgp_sm2_encrypt(rng_t *                 rng,
     }
 
 done:
+    botan_mp_destroy(public_x);
+    botan_mp_destroy(public_y);
     botan_pk_op_encrypt_destroy(enc_op);
     botan_pubkey_destroy(sm2_key);
 

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -958,6 +958,7 @@ pgp_key_unprotect(pgp_key_t *key, const pgp_password_provider_t *password_provid
 
 done:
     pgp_seckey_free(decrypted_seckey);
+    free(decrypted_seckey);
     return ret;
 }
 

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -408,7 +408,6 @@ pgp_decrypt_seckey_pgp(const uint8_t *     data,
         goto done;
     }
     pgp_set_callback(stream, decrypt_cb, &decrypt);
-    stream->readinfo.accumulate = 1;
     repgp_parse(stream, !printerrors);
 
 done:

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -703,6 +703,7 @@ rnp_list_keys_json(rnp_t *rnp, char **json, const int psigs)
     const char *j = json_object_to_json_string(obj);
     ret = j != NULL;
     *json = strdup(j);
+    json_object_put(obj);
     return ret;
 }
 

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -1217,6 +1217,7 @@ rnp_result_t
 rnp_op_encrypt_destroy(rnp_op_encrypt_t op)
 {
     if (op) {
+        rnp_ctx_free(&op->rnpctx);
         free(op);
     }
     return RNP_SUCCESS;

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2616,6 +2616,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
         keysize = pgp_key_size(pkt.u.seckey.protection.symm_alg);
         if (keysize == 0) {
             (void) fprintf(stderr, "parse_seckey: unknown symmetric algo");
+            pgp_forget(password, strlen(password));
             return false;
         }
 

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2408,8 +2408,7 @@ parse_litdata(pgp_region_t *region, pgp_stream_t *stream)
         CALLBACK(PGP_PTAG_CT_LITDATA_BODY, &stream->cbinfo, &pkt);
     }
 
-    /* XXX - get rid of mem here? */
-
+    pgp_memory_free(mem);
     return true;
 }
 

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -3458,6 +3458,10 @@ pgp_stream_delete(pgp_stream_t *stream)
     if (stream->readinfo.accumulated) {
         free(stream->readinfo.accumulated);
     }
+    for (size_t i = 0; i < stream->hashc; i++) {
+        pgp_hash_finish(&stream->hashes[i].hash, NULL);
+    }
+    free(stream->hashes);
 
     free(stream);
 }

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -2776,6 +2776,7 @@ parse_seckey(pgp_content_enum tag, pgp_region_t *region, pgp_stream_t *stream)
         return false;
     }
     if (!ret) {
+        pgp_seckey_free(&pkt.u.seckey);
         return false;
     }
     CALLBACK(tag, &stream->cbinfo, &pkt);

--- a/src/librepgp/reader.c
+++ b/src/librepgp/reader.c
@@ -163,6 +163,7 @@ pgp_reader_pop(pgp_stream_t *stream)
 {
     pgp_reader_t *next = stream->readinfo.next;
 
+    free(stream->readinfo.accumulated);
     stream->readinfo = *next;
     free(next);
 }

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -365,7 +365,7 @@ literal_src_close(pgp_source_t *src)
     pgp_source_literal_param_t *param = src->param;
     if (param) {
         if (param->pkt.partial) {
-            param->pkt.readsrc->close(param->pkt.readsrc);
+            src_close(param->pkt.readsrc);
             free(param->pkt.readsrc);
             param->pkt.readsrc = NULL;
         }
@@ -469,7 +469,7 @@ compressed_src_close(pgp_source_t *src)
     pgp_source_compressed_param_t *param = src->param;
     if (param) {
         if (param->pkt.partial) {
-            param->pkt.readsrc->close(param->pkt.readsrc);
+            src_close(param->pkt.readsrc);
             free(param->pkt.readsrc);
             param->pkt.readsrc = NULL;
         }
@@ -758,7 +758,7 @@ encrypted_src_close(pgp_source_t *src)
         list_destroy(&param->pubencs);
 
         if (param->pkt.partial) {
-            param->pkt.readsrc->close(param->pkt.readsrc);
+            src_close(param->pkt.readsrc);
             free(param->pkt.readsrc);
             param->pkt.readsrc = NULL;
         }

--- a/src/librepgp/validate.h
+++ b/src/librepgp/validate.h
@@ -76,6 +76,7 @@ typedef struct {
     pgp_pubkey_t pubkey;
     pgp_pubkey_t subkey;
     pgp_seckey_t seckey;
+    bool         loaded_pubkey;
     enum { ATTRIBUTE = 1, ID } last_seen;
     uint8_t *              userid;
     pgp_data_t             userattr;

--- a/src/rnpkeys/main.c
+++ b/src/rnpkeys/main.c
@@ -113,6 +113,8 @@ main(int argc, char **argv)
         }
     }
 
+    rnp_cfg_free(&cfg);
+    rnp_cfg_free(&opt_cfg);
     rnp_end(&rnp);
     return ret;
 }

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -188,11 +188,13 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         bool        force = rnp_cfg_getbool(cfg, CFG_FORCE);
         ret = file ? init_file_dest(&dst, file, force) : init_stdout_dest(&dst);
         if (ret) {
+            free(s);
             return false;
         }
 
         dst_write(&dst, s, strlen(s));
         dst_close(&dst, false);
+        free(s);
         return true;
     }
     case CMD_IMPORT_KEY:

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -650,15 +650,15 @@ sm2_roundtrip(void **state)
 
     for (size_t i = 0; i < ARRAY_SIZE(hashes); ++i) {
         size_t        ctext_size = sizeof(ctext_buf);
-        pgp_errcode_t enc_result = pgp_sm2_encrypt(
+        rnp_result_t enc_result = pgp_sm2_encrypt(
           &global_rng, ctext_buf, &ctext_size, key, sizeof(key), hashes[i], pub_ecc);
-        rnp_assert_int_equal(rstate, enc_result, PGP_E_OK);
+        rnp_assert_int_equal(rstate, enc_result, RNP_SUCCESS);
 
         memset(decrypted, 0, sizeof(decrypted));
         size_t        decrypted_size = sizeof(decrypted);
         pgp_errcode_t dec_result =
           pgp_sm2_decrypt(decrypted, &decrypted_size, ctext_buf, ctext_size, sec_ecc, pub_ecc);
-        rnp_assert_int_equal(rstate, dec_result, PGP_E_OK);
+        rnp_assert_int_equal(rstate, dec_result, RNP_SUCCESS);
 
         rnp_assert_int_equal(rstate, decrypted_size, sizeof(key));
         for (size_t i = 0; i != decrypted_size; ++i)

--- a/src/tests/ffi.c
+++ b/src/tests/ffi.c
@@ -650,7 +650,6 @@ test_ffi_add_userid(void **state)
     rnp_ffi_destroy(ffi);
 }
 
-// TODO: Hash mismatch in secret key
 void
 test_ffi_keygen_json_sub_pass_required(void **state)
 {
@@ -962,8 +961,10 @@ test_ffi_encrypt_pk(void **state)
     rnp_key_handle_t key = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "userid", "key0-uid2", &key));
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_add_recipient(op, key));
+    rnp_key_handle_free(&key);
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "userid", "key1-uid1", &key));
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_add_recipient(op, key));
+    rnp_key_handle_free(&key);
     // set the data encryption cipher
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_set_cipher(op, "CAST5"));
     // execute the operation

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -1013,9 +1013,12 @@ test_generated_key_sigs(void **state)
             fake.packets[fake.packetc++] = sub_pub->packets[i];
         }
         // validate via an alternative method
-        pgp_validation_t vres = {0};
-        vres.rnp_ctx = &rnp_ctx;
-        assert_true(pgp_validate_key_sigs(&vres, &fake, pubring, NULL));
+        pgp_validation_t *vres = calloc(1, sizeof(*vres));
+        assert_non_null(vres);
+        vres->rnp_ctx = &rnp_ctx;
+        assert_true(pgp_validate_key_sigs(vres, &fake, pubring, NULL));
+        pgp_validate_result_free(vres);
+        FREE_ARRAY(pfake, packet);
     }
 
     rnp_key_store_free(pubring);

--- a/src/tests/key-add-userid.c
+++ b/src/tests/key-add-userid.c
@@ -130,6 +130,7 @@ test_key_add_userid(void **state)
     assert_non_null(ks);
     // read from the saved packets
     assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+    pgp_memory_release(&mem);
     assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &key));
     assert_non_null(key);
 

--- a/src/tests/key-unlock.c
+++ b/src/tests/key-unlock.c
@@ -90,7 +90,7 @@ test_key_unlock_pgp(void **state)
 
     // confirm that this key is indeed RSA first
     assert_int_equal(key->key.pubkey.alg, PGP_PKA_RSA);
-    // confirm the secret MPIs are now filled in
+    // confirm the secret MPIs are NULL
     assert_null(key->key.seckey.key.rsa.d);
     assert_null(key->key.seckey.key.rsa.p);
     assert_null(key->key.seckey.key.rsa.q);
@@ -114,7 +114,7 @@ test_key_unlock_pgp(void **state)
     rnp_assert_true(rstate, pgp_key_unlock(key, &provider));
     rnp_assert_false(rstate, pgp_key_is_locked(key));
 
-    // confirm the secret MPIs are NULL
+    // confirm the secret MPIs are now filled in
     assert_non_null(key->key.seckey.key.rsa.d);
     assert_non_null(key->key.seckey.key.rsa.p);
     assert_non_null(key->key.seckey.key.rsa.q);

--- a/src/tests/pgp-parse.c
+++ b/src/tests/pgp-parse.c
@@ -143,14 +143,6 @@ setup_keystore_1(rnp_test_state_t *state, rnp_t *rnp)
     bool         res = true;
     char         path[PATH_MAX] = {0};
 
-    // IO
-    pgp_io_t pgpio = {.errs = stderr, .res = stdout, .outs = stdout};
-    rnp->io = malloc(sizeof(pgp_io_t));
-    if (!rnp->io) {
-        return false;
-    }
-
-    memcpy(rnp->io, &pgpio, sizeof(pgp_io_t));
     assert(state->data_dir);
 
     paths_concat(path, sizeof(path), state->data_dir, "keyrings/1/pubring.gpg", NULL);
@@ -251,8 +243,6 @@ test_repgp_decrypt(void **state)
     assert_int_equal(memcmp(plaintext, in_buf, in_buf_size), 0);
 
     /* Cleanup */
-    free(rnp.io);
-    rnp.io = NULL;
     rnp_end(&rnp);
     delete_recursively(tmpdir);
     free(tmpdir);
@@ -299,8 +289,6 @@ test_repgp_verify(void **state)
     repgp_destroy_io(io);
 
     /* Cleanup */
-    free(rnp.io);
-    rnp.io = NULL;
     rnp_end(&rnp);
 }
 
@@ -341,7 +329,5 @@ test_repgp_list_packets(void **state)
     repgp_destroy_handle(input);
 
     /* Cleanup */
-    free(rnp.io);
-    rnp.io = NULL;
     rnp_end(&rnp);
 }

--- a/src/tests/pgp-parse.c
+++ b/src/tests/pgp-parse.c
@@ -314,6 +314,7 @@ test_repgp_list_packets(void **state)
     repgp_handle_t *input = create_filepath_handle(input_file);
     rnp_assert_int_equal(rstate, repgp_list_packets(&ctx, input, false), RNP_SUCCESS);
     repgp_destroy_handle(input);
+    repgp_destroy_io(io);
 
     /* Test listing from memory */
     FILE *f = fopen(input_file, "rb");
@@ -327,6 +328,7 @@ test_repgp_list_packets(void **state)
     input = create_filepath_handle(input_file);
     rnp_assert_int_equal(rstate, repgp_list_packets(&ctx, input, false), RNP_SUCCESS);
     repgp_destroy_handle(input);
+    repgp_destroy_io(io);
 
     /* Cleanup */
     rnp_end(&rnp);

--- a/src/tests/utils-list.c
+++ b/src/tests/utils-list.c
@@ -217,6 +217,7 @@ test_utils_list(void **state)
             assert_false(list_is_member(list2, item));
             item = list_next(item);
         }
+        list_destroy(&list2);
     }
 
     // remove all


### PR DESCRIPTION
**Note**: The other PRs I have open should be merged before this one so that we can see the sanitize-leaks CI run pass. (I expect it to fail here initially)

Right now in master `rnp_tests` leaks quite a bit for me:
```SUMMARY: AddressSanitizer: 265317 byte(s) leaked in 1587 allocation(s).```

This, combined with the other PRs, should get us back to 0 so that we can re-enforce the sanitize-leaks CI run. (Hoping to add a valgrind run soon too)