### PR TITLE
Split DSA roundtrip test into 2 cases

### DIFF
--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1257,6 +1257,15 @@ class SignDSA(Sign):
             "2112", self.rnp.userid)
         self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
+    def test_sign_P1088_Q224(self):
+        cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(1088)
+        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
+
+    def test_verify_P1088_Q224(self):
+        cmd = SignDSA.GPG_GENERATE_DSA_PATERN.format(
+            "1088", self.rnp.userid)
+        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
+
     def test_hash_truncation(self):
         '''
         Signs message hashed with SHA512 with a key of size 160 bits. Implementation

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -169,6 +169,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(ecdh_decryptionNegativeCases),
       cmocka_unit_test(sm2_roundtrip),
       cmocka_unit_test(test_dsa_roundtrip),
+      cmocka_unit_test(test_dsa_verify_negative),
       cmocka_unit_test(test_load_v3_keyring_pgp),
       cmocka_unit_test(test_load_v4_keyring_pgp),
       cmocka_unit_test(test_load_keyring_and_count_pgp),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -139,6 +139,8 @@ void test_ffi_key_iter(void **state);
 
 void test_dsa_roundtrip(void **state);
 
+void test_dsa_verify_negative(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \


### PR DESCRIPTION
Splits DSA test into 2. One is testing all key sizes required by RFC, the other one does some negative tests for selected key.
This should make dsa roundtrip test a bit less than 2x faster as key generation is done only once

More improvements are possible, but let see first if that's fast enough...

Closes #629 