### PR TITLE
Remove max-alloc CLI parameter

### DIFF
--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -122,7 +122,6 @@ enum optdefs {
     OPT_PASSWDFD,
     OPT_PASSWD,
     OPT_SSHKEYFILE,
-    OPT_MAX_MEM_ALLOC,
     OPT_EXPIRATION,
     OPT_CREATION,
     OPT_CIPHER,
@@ -188,9 +187,6 @@ static struct option options[] = {
   {"password", required_argument, NULL, OPT_PASSWD},
   {"output", required_argument, NULL, OPT_OUTPUT},
   {"results", required_argument, NULL, OPT_RESULTS},
-  {"maxmemalloc", required_argument, NULL, OPT_MAX_MEM_ALLOC},
-  {"max-mem", required_argument, NULL, OPT_MAX_MEM_ALLOC},
-  {"max-alloc", required_argument, NULL, OPT_MAX_MEM_ALLOC},
   {"creation", required_argument, NULL, OPT_CREATION},
   {"expiration", required_argument, NULL, OPT_EXPIRATION},
   {"expiry", required_argument, NULL, OPT_EXPIRATION},
@@ -585,9 +581,6 @@ setoption(rnp_cfg_t *cfg, int *cmd, int val, char *arg)
     case OPT_SSHKEYFILE:
         rnp_cfg_setstr(cfg, CFG_KEYSTOREFMT, RNP_KEYSTORE_SSH);
         rnp_cfg_setstr(cfg, CFG_SSHKEYFILE, arg);
-        break;
-    case OPT_MAX_MEM_ALLOC:
-        rnp_cfg_setstr(cfg, CFG_MAXALLOC, arg);
         break;
     case OPT_EXPIRATION:
         rnp_cfg_setstr(cfg, CFG_EXPIRATION, arg);

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -77,7 +77,6 @@ rnp_cfg_load_defaults(rnp_cfg_t *cfg)
     rnp_cfg_setint(cfg, CFG_ZALG, DEFAULT_Z_ALG);
     rnp_cfg_setint(cfg, CFG_ZLEVEL, DEFAULT_Z_LEVEL);
     rnp_cfg_setstr(cfg, CFG_CIPHER, DEFAULT_SYMM_ALG);
-    rnp_cfg_setint(cfg, CFG_MAXALLOC, 4194304);
     rnp_cfg_setstr(cfg, CFG_SUBDIRGPG, SUBDIRECTORY_RNP);
     rnp_cfg_setstr(cfg, CFG_SUBDIRSSH, SUBDIRECTORY_SSH);
     rnp_cfg_setint(cfg, CFG_NUMTRIES, MAX_PASSWORD_ATTEMPTS);

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -37,7 +37,6 @@
 #define CFG_DETACHED "detached"          /* produce the detached signature */
 #define CFG_OUTFILE "outfile"            /* name/path of the output file */
 #define CFG_RESULTS "results"            /* name/path for results, not used right now */
-#define CFG_MAXALLOC "maxalloc" /* maximum memory allocation during the reading from stdin */
 #define CFG_KEYSTOREFMT "keystorefmt" /* keyring format : GPG, SSH */
 #define CFG_SSHKEYFILE "sshkeyfile"   /* SSH key file */
 #define CFG_SUBDIRGPG "subdirgpg"     /* gpg/rnp files subdirectory: .rnp by default */


### PR DESCRIPTION
Since stdin is now processed in streamed manner this parameter is no longer needed.