### PR TITLE
Fix leak when encrypted_decrypt_cfb_header fails to decrypt.

### DIFF
--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -1332,6 +1332,7 @@ encrypted_decrypt_cfb_header(pgp_source_encrypted_param_t *param,
 
         return true;
     } else {
+        pgp_cipher_cfb_finish(&crypt);
         return false;
     }
 }


### PR DESCRIPTION
This is a rare case because we have to pass checks on the algorithm id earlier in the code in order to reach this point.
Nevertheless, this did leak randomly on occasion (less than 2% chance in some of my tests).