### PR TITLE
Multiple-key signing

### DIFF
--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -42,11 +42,11 @@
 #define CFG_SUBDIRGPG "subdirgpg"     /* gpg/rnp files subdirectory: .rnp by default */
 #define CFG_SUBDIRSSH "subdirssh"     /* ssh files (keys) subdirectory: .ssh by default */
 #define CFG_COREDUMPS "coredumps"     /* enable/disable core dumps. 1 or 0. */
-#define CFG_NEEDSUSERID "needsuserid" /* needs user id for the ongoing operation */
 #define CFG_NEEDSSECKEY "needsseckey" /* needs secret key for the ongoing operation */
 #define CFG_KEYRING "keyring"       /* path to the keyring ?? seems not to be used anywhere */
 #define CFG_USERID "userid"         /* userid for the ongoing operation */
 #define CFG_RECIPIENTS "recipients" /* list of encrypted data recipients */
+#define CFG_SIGNERS "signers"       /* list of signers */
 #define CFG_VERBOSE "verbose"       /* verbose logging */
 #define CFG_HOMEDIR "homedir"       /* home directory - folder with keyrings and so on */
 #define CFG_PASSFD "pass-fd"        /* password file descriptor */


### PR DESCRIPTION
This PR allows to stack `-u/--user` CLI parameters to sign/clearsign/detached sign file with multiple keys. Includes CLI test case.

Next PR, built on top of this and #619 , will allow encrypt-and-sign.

Fixes #620 