### PR TITLE
ci: Enable more debug info, improve stack traces.

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -17,7 +17,7 @@ if [ ! -e "${BOTAN_INSTALL}/lib/libbotan-2.so" ] && \
 
   git clone https://github.com/randombit/botan "${botan_build}"
   pushd "${botan_build}"
-  ./configure.py --prefix="${BOTAN_INSTALL}"
+  ./configure.py --prefix="${BOTAN_INSTALL}" --with-debug-info --cxxflags="-fno-omit-frame-pointer"
   ${MAKE} -j${CORES} install
   popd
 fi
@@ -61,7 +61,7 @@ if [ ! -e "${JSONC_INSTALL}/lib/libjson-c.so" ] && \
   tar xzf json-c.tar.gz --strip 1
 
   autoreconf -ivf
-  ./configure --prefix="${JSONC_INSTALL}"
+  env CFLAGS="-fno-omit-frame-pointer -g" ./configure --prefix="${JSONC_INSTALL}"
   ${MAKE} -j${CORES} install
   popd
 fi

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -6,7 +6,7 @@ set -eux
 : "${CORES:=2}"
 
 LD_LIBRARY_PATH="${BOTAN_INSTALL}/lib:${CMOCKA_INSTALL}/lib:${JSONC_INSTALL}/lib"
-CFLAGS=""
+CFLAGS="-g"
 
 [ "$BUILD_MODE" = "coverage" ] && CFLAGS+=" -O0 --coverage"
 


### PR DESCRIPTION
Previously, in some cases we were getting mostly useless stack traces from clang's sanitizers.
Adding fno-omit-frame-pointer for external libs will help ensure we get useful stack traces and adding debug info will get us line numbers.