### PR TITLE
ci: Make local CI runs simpler.

### DIFF
--- a/ci/local.sh
+++ b/ci/local.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux
+
+rsync -a /usr/local/rnp /tmp
+sudo -iu travis bash <<EOF
+cd /tmp/rnp
+env GPG_VERSION=$GPG_VERSION BUILD_MODE=$BUILD_MODE ci/run-local.sh
+EOF
+

--- a/ci/run-local.sh
+++ b/ci/run-local.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux
+
+export LOCAL_BUILDS="$HOME/local-builds"
+export BOTAN_INSTALL="${LOCAL_BUILDS}/botan-install"
+export CMOCKA_INSTALL="${LOCAL_BUILDS}/cmocka-install"
+export JSONC_INSTALL="${LOCAL_BUILDS}/jsonc-install"
+export GPG_INSTALL="${LOCAL_BUILDS}/gpg-install"
+export CC=clang
+export CORES=$(grep -c '^$' /proc/cpuinfo)
+ci/install.sh
+ci/main.sh
+

--- a/doc/DEVELOPMENT-GUIDE.md
+++ b/doc/DEVELOPMENT-GUIDE.md
@@ -94,36 +94,13 @@ We can use a container for this, like so:
 
 ``` sh
 ./travis.sh
-# or
-# docker run -ti --rm travisci/ci-garnet:packer-1490989530 bash -l
 ```
 
-(Refer to
-[here](https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image)
-and [here](https://hub.docker.com/r/travisci/ci-garnet/tags/))
-
-Inside the container, you will need to perform steps like the following:
+Inside the container, you can do local CI runs like so:
 
 ``` sh
-cd ~/
-git clone https://github.com/riboseinc/rnp
-# or if testing local copy
-# git clone /usr/local/rnp
-cd rnp
-export LOCAL_BUILDS="$HOME/local-builds"
-export BOTAN_INSTALL="${LOCAL_BUILDS}/botan-install"
-export CMOCKA_INSTALL="${LOCAL_BUILDS}/cmocka-install"
-export JSONC_INSTALL="${LOCAL_BUILDS}/jsonc-install"
-export GPG_INSTALL="${LOCAL_BUILDS}/gpg-install"
-export GPG_VERSION=stable
-export BUILD_MODE=normal
-ci/install.sh
-env CC=clang ci/main.sh
+env GPG_VERSION=beta BUILD_MODE=sanitize-leaks ci/local.sh
 ```
-
-(The above uses clang as the compiler -- use `CC=gcc` for GCC)
-Refer to the current `.travis.yml` for the most up-to-date information
-on what environment variables need to be set.
 
 # Code Coverage
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,3 +1,15 @@
 #!/bin/bash
-docker run -ti -v $(pwd):/usr/local/rnp --rm travisci/ci-garnet:packer-1490989530 bash -l
+
+[ $# -eq 0 ] && CMD='bash -l' || CMD=$*
+
+docker run \
+  --tty \
+  --interactive \
+  --cap-add SYS_PTRACE \
+  --volume "$(pwd):/usr/local/rnp" \
+  --workdir /usr/local/rnp \
+  --user 2000 \
+  --rm \
+  travisci/ci-garnet:packer-1512502276-986baf0 \
+  $CMD
 


### PR DESCRIPTION
This just makes it easier to run things locally.
You can now do something like:
```sh
./travis.sh
env GPG_VERSION=beta BUILD_MODE=sanitize-leaks ci/local.sh
```

Other related changes in `travis.sh`:
* Changed to all verbose options, for readability.
* Added the ptrace capability, since it's needed for sanitize-leaks.
* Run as the travis user (uid 2000).
* Switch to working directory `/usr/local/rnp` immediately.
* Default to `bash -l` as the command, but allow others.

There's some duplication here, but we already had that duplication in the docs, so it's not too bad.

Maybe the macOS devs can let me know if any of this actually works for you guys...