### PR TITLE
Flush printf output in test_dsa_roundtrip to prevent CI timeouts.

### DIFF
--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -719,6 +719,7 @@ test_dsa_roundtrip(void **state)
                key_desc.dsa.p_bitlen,
                key_desc.dsa.q_bitlen,
                pgp_show_hash_alg(key_desc.hash_alg));
+        fflush(stdout);
 
         pgp_dsa_pubkey_t *pub1 = &sec_key1.pubkey.key.dsa;
         pgp_dsa_seckey_t *sec1 = &sec_key1.key.dsa;


### PR DESCRIPTION
I've seen `test_dsa_roundtrip` still timing out in travis fairly frequently. I tested flushing stdout and that made everything pass without any timeouts, so it seems like a good interim solution that I should have done in #625.
(Could also use `stderr` and rely on lack of buffering, but when I tested it I had better results this way)