### PR TITLE
(dsa) Removes tests for 3072 key

### DIFF
--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -693,9 +693,6 @@ test_dsa_roundtrip(void **state)
         {2048, 256, PGP_HASH_SHA256},
         {2048, 256, PGP_HASH_SHA384},
         {2048, 256, PGP_HASH_SHA512},
-        // all 3072 key-hash combinations
-        {3072, 256, PGP_HASH_SHA384},
-        {3072, 256, PGP_HASH_SHA512},
         //misc
         {1088, 224, PGP_HASH_SHA224},
         {1088, 224, PGP_HASH_SHA256},

--- a/src/tests/cli_tests.py
+++ b/src/tests/cli_tests.py
@@ -1239,15 +1239,6 @@ class SignDSA(Sign):
             "2048", self.rnp.userid)
         self._rnp_sign_verify(self.gpg, self.rnp, cmd)
 
-    def test_sign_P3072_Q256(self):
-        cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(3072)
-        self._rnp_sign_verify(self.rnp, self.gpg, cmd)
-
-    def test_verify_P3072_Q256(self):
-        cmd = SignDSA.GPG_GENERATE_DSA_PATERN.format(
-            "3072", self.rnp.userid)
-        self._rnp_sign_verify(self.gpg, self.rnp, cmd)
-
     def test_sign_P2112_Q256(self):
         cmd = SignDSA.RNP_GENERATE_DSA_PATTERN.format(2112)
         self._rnp_sign_verify(self.rnp, self.gpg, cmd)


### PR DESCRIPTION
DSA key generation takes a lot of time and causes CI to break.
From the other hand it's not very important (as DSA is not required
by spec) and we test DSA with other key sizes.

In 'NORMAL' build with stable botan it takes now 22min vs 42min
The longest build (mode="SANITIZE" botan=beta) it takes now 35min vs 44min 


Those test may be added back once DSA keygen perf is improved, but it's good enough for now