### PR TITLE
ffi: Remove/replace rnp_keyring_t.

### DIFF
--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -197,6 +197,8 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_signatures_detached_memory),
       cmocka_unit_test(test_ffi_signatures_detached),
       cmocka_unit_test(test_ffi_signatures),
+      cmocka_unit_test(test_ffi_load_keys),
+      cmocka_unit_test(test_ffi_save_keys),
       cmocka_unit_test(test_ffi_key_to_json),
       cmocka_unit_test(test_ffi_key_iter),
     };

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -129,6 +129,10 @@ void test_ffi_add_userid(void **state);
 
 void test_ffi_detect_key_format(void **state);
 
+void test_ffi_load_keys(void **state);
+
+void test_ffi_save_keys(void **state);
+
 void test_ffi_encrypt_pass(void **state);
 
 void test_ffi_encrypt_pk(void **state);


### PR DESCRIPTION
* Removed rnp_keyring_t. This was used a lot originally, but it has become less and less useful and was sort of sticking out as an oddity. This is pretty much replaced with `rnp_load_keys`/`rnp_save_keys`.
* Using `rnp_input_t`/`rnp_output_t` for key loading/saving. We kind of cheat for now, but at least the interface is there.
* Renamed `rnp_input_from_file`->`rnp_input_from_path` (same for output), mostly because the argument can now be a directory for G10. It's maybe a little hacky, but I'm not sure there's a better way to do it at the moment.
* Some minor key format conversions should be doable now, though there's no tests for this. You should be able to load a GPG ring and save as KBX, or the reverse, etc. It's something we could already do internally, but I don't think the previous interface supported it.
* Some small revisions to docs where I felt that I worded things poorly.

I think there's room for improvement and more iterations here (noted in some TODOs) but I figure this is a start. I'm continuing on some FFI key provider revisions at the moment.