### PR TITLE
Add userid search and revise signer and recipient lists

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -169,12 +169,11 @@ bool rnp_key_store_remove_key_by_id(pgp_io_t *, rnp_key_store_t *, const uint8_t
 
 pgp_key_t *rnp_key_store_get_key_by_id(
   pgp_io_t *, const rnp_key_store_t *, const unsigned char *, pgp_key_t *, pgp_pubkey_t **);
-bool rnp_key_store_get_key_by_name(pgp_io_t *,
-                                   const rnp_key_store_t *,
-                                   const char *,
-                                   pgp_key_t **);
-bool rnp_key_store_get_next_key_by_name(
-  pgp_io_t *, const rnp_key_store_t *, const char *, pgp_key_t *, pgp_key_t **);
+
+pgp_key_t *rnp_key_store_get_key_by_name(pgp_io_t *,
+                                         const rnp_key_store_t *,
+                                         const char *,
+                                         pgp_key_t *);
 
 bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
 pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, const rnp_key_store_t *, const uint8_t *);

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -175,6 +175,11 @@ pgp_key_t *rnp_key_store_get_key_by_name(pgp_io_t *,
                                          const char *,
                                          pgp_key_t *);
 
+pgp_key_t *rnp_key_store_get_key_by_userid(pgp_io_t *,
+                                           const rnp_key_store_t *,
+                                           const char *,
+                                           pgp_key_t *);
+
 bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
 pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, const rnp_key_store_t *, const uint8_t *);
 

--- a/src/lib/key-provider.c
+++ b/src/lib/key-provider.c
@@ -66,10 +66,10 @@ rnp_key_provider_keyring(const pgp_key_request_ctx_t *ctx, pgp_key_t **key, void
             ks_key = rnp_key_store_get_key_by_grip(rnp->io, rnp->secring, ctx->search.by.grip);
         }
     } else if (ctx->search.type == PGP_KEY_SEARCH_USERID) {
-        rnp_key_store_get_key_by_name(rnp->io, ks, ctx->search.by.userid, &ks_key);
+        ks_key = rnp_key_store_get_key_by_name(rnp->io, ks, ctx->search.by.userid, NULL);
         if (!ks_key && !ctx->secret) {
-            rnp_key_store_get_key_by_name(
-              rnp->io, rnp->secring, ctx->search.by.userid, &ks_key);
+            ks_key = rnp_key_store_get_key_by_name(
+              rnp->io, rnp->secring, ctx->search.by.userid, NULL);
         }
     }
 

--- a/src/lib/key-provider.c
+++ b/src/lib/key-provider.c
@@ -66,9 +66,9 @@ rnp_key_provider_keyring(const pgp_key_request_ctx_t *ctx, pgp_key_t **key, void
             ks_key = rnp_key_store_get_key_by_grip(rnp->io, rnp->secring, ctx->search.by.grip);
         }
     } else if (ctx->search.type == PGP_KEY_SEARCH_USERID) {
-        ks_key = rnp_key_store_get_key_by_name(rnp->io, ks, ctx->search.by.userid, NULL);
+        ks_key = rnp_key_store_get_key_by_userid(rnp->io, ks, ctx->search.by.userid, NULL);
         if (!ks_key && !ctx->secret) {
-            ks_key = rnp_key_store_get_key_by_name(
+            ks_key = rnp_key_store_get_key_by_userid(
               rnp->io, rnp->secring, ctx->search.by.userid, NULL);
         }
     }

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -117,7 +117,8 @@ resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid)
         userid += 2;
     }
     io = rnp->io;
-    if (!rnp_key_store_get_key_by_name(io, keyring, userid, &key)) {
+    key = rnp_key_store_get_key_by_name(io, keyring, userid, NULL);
+    if (!key) {
         (void) fprintf(io->errs, "cannot find key '%s'\n", userid);
         return NULL;
     }
@@ -726,7 +727,8 @@ rnp_match_keys(rnp_t *rnp, char *name, const char *fmt, void *vp, const int psig
     }
     (void) memset(&pubs, 0x0, sizeof(pubs));
     do {
-        if (!rnp_key_store_get_next_key_by_name(rnp->io, rnp->pubring, name, key, &key)) {
+        key = rnp_key_store_get_key_by_name(rnp->io, rnp->pubring, name, NULL);
+        if (!key) {
             return 0;
         }
         if (key != NULL) {
@@ -776,7 +778,8 @@ rnp_match_keys_json(rnp_t *rnp, char **json, char *name, const char *fmt, const 
     printf("%s,%d, NAME: %s\n", __FILE__, __LINE__, name);
     *json = NULL;
     do {
-        if (!rnp_key_store_get_next_key_by_name(rnp->io, rnp->pubring, name, key, &key)) {
+        key = rnp_key_store_get_key_by_name(rnp->io, rnp->pubring, name, key);
+        if (!key) {
             return 0;
         }
         if (key != NULL) {
@@ -818,7 +821,8 @@ rnp_match_pubkeys(rnp_t *rnp, char *name, void *vp)
     FILE *     fp = (FILE *) vp;
 
     do {
-        if (!rnp_key_store_get_next_key_by_name(rnp->io, rnp->pubring, name, key, &key)) {
+        key = rnp_key_store_get_key_by_name(rnp->io, rnp->pubring, name, key);
+        if (!key) {
             return 0;
         }
         if (key != NULL) {
@@ -842,7 +846,8 @@ rnp_find_key(rnp_t *rnp, const char *id)
         (void) fprintf(io->errs, "NULL id to search for\n");
         return false;
     }
-    if (!rnp_key_store_get_key_by_name(rnp->io, rnp->pubring, id, &key)) {
+    key = rnp_key_store_get_key_by_name(rnp->io, rnp->pubring, id, NULL);
+    if (!key) {
         return false;
     }
     return key != NULL;
@@ -1700,10 +1705,8 @@ rnp_write_sshkey(rnp_t *rnp, char *s, const char *userid, char *out, size_t size
     }
 
     /* get rsa key */
-    if (!rnp_key_store_get_next_key_by_name(rnp->io, rnp->pubring, userid, key, &key)) {
-        goto done;
-    }
-    if (key == NULL) {
+    key = rnp_key_store_get_key_by_name(rnp->io, rnp->pubring, userid, key);
+    if (!key) {
         (void) fprintf(stderr, "no key found for '%s'\n", userid);
         goto done;
     }

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -2152,7 +2152,7 @@ find_key_by_locator(pgp_io_t *io, rnp_key_store_t *store, const pgp_key_search_t
     switch (locator->type) {
     case PGP_KEY_SEARCH_USERID:
         // TODO: this isn't really a userid search...
-        rnp_key_store_get_key_by_name(io, store, locator->by.userid, &key);
+        key = rnp_key_store_get_key_by_name(io, store, locator->by.userid, NULL);
         break;
     case PGP_KEY_SEARCH_KEYID: {
         key = rnp_key_store_get_key_by_id(io, store, locator->by.keyid, NULL, NULL);

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -2151,8 +2151,7 @@ find_key_by_locator(pgp_io_t *io, rnp_key_store_t *store, const pgp_key_search_t
     pgp_key_t *key = NULL;
     switch (locator->type) {
     case PGP_KEY_SEARCH_USERID:
-        // TODO: this isn't really a userid search...
-        key = rnp_key_store_get_key_by_name(io, store, locator->by.userid, NULL);
+        key = rnp_key_store_get_key_by_userid(io, store, locator->by.userid, NULL);
         break;
     case PGP_KEY_SEARCH_KEYID: {
         key = rnp_key_store_get_key_by_id(io, store, locator->by.keyid, NULL, NULL);

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -97,7 +97,7 @@ struct rnp_op_sign_st {
 };
 
 struct rnp_op_sign_signature_st {
-    char *         keyid;
+    pgp_key_t *    key;
     pgp_hash_alg_t halg;
     uint32_t       create;
     uint32_t       expires;
@@ -150,6 +150,12 @@ struct rnp_identifier_iterator_st {
         }                            \
         RNP_LOG_FD(fp, __VA_ARGS__); \
     } while (0)
+
+static pgp_key_t *
+get_key_prefer_public(rnp_key_handle_t handle);
+
+static pgp_key_t *
+get_key_require_secret(rnp_key_handle_t handle);
 
 static pgp_key_t *find_key_by_locator(pgp_io_t *              io,
                                       rnp_key_store_t *       store,
@@ -1320,10 +1326,10 @@ rnp_op_add_signature(list *signatures, rnp_key_handle_t key, rnp_op_sign_signatu
     if (!newsig) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
-    rnp_result_t res = rnp_key_get_keyid(key, &newsig->keyid);
-    if (res) {
+    newsig->key = get_key_require_secret(key);
+    if (!newsig->key) {
         list_remove((list_item *) newsig);
-        return res;
+      return RNP_ERROR_NO_SUITABLE_KEY;
     }
     if (sig) {
         *sig = newsig;
@@ -1415,9 +1421,6 @@ rnp_op_set_file_mtime(rnp_ctx_t *ctx, uint32_t mtime)
 static void
 rnp_op_signatures_destroy(list *signatures)
 {
-    for (list_item *sig = list_front(*signatures); sig; sig = list_next(sig)) {
-        rnp_buffer_free(((rnp_op_sign_signature_t) sig)->keyid);
-    }
     list_destroy(signatures);
 }
 
@@ -1445,20 +1448,15 @@ rnp_op_encrypt_create(rnp_op_encrypt_t *op,
 }
 
 rnp_result_t
-rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_handle_t key)
+rnp_op_encrypt_add_recipient(rnp_op_encrypt_t op, rnp_key_handle_t handle)
 {
     // checks
-    if (!op || !key) {
+    if (!op || !handle) {
         return RNP_ERROR_NULL_POINTER;
     }
 
-    // TODO: lower layers are currently limited to this
-    if (key->locator.type != PGP_KEY_SEARCH_USERID) {
-        return RNP_ERROR_NOT_IMPLEMENTED;
-    }
-    if (!list_append(&op->rnpctx.recipients,
-                     key->locator.by.userid,
-                     strlen(key->locator.by.userid) + 1)) {
+    pgp_key_t *key = get_key_prefer_public(handle);
+    if (!list_append(&op->rnpctx.recipients, &key, sizeof(key))) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     return RNP_SUCCESS;
@@ -1630,8 +1628,8 @@ rnp_op_encrypt_execute(rnp_op_encrypt_t op)
     rnp_result_t ret;
     if (list_length(op->signatures)) {
         for (list_item *sig = list_front(op->signatures); sig; sig = list_next(sig)) {
-            char *keyid = ((rnp_op_sign_signature_t) sig)->keyid;
-            if (!list_append(&op->rnpctx.signers, keyid, strlen(keyid) + 1)) {
+            pgp_key_t *key = ((rnp_op_sign_signature_t)sig)->key;
+            if (!list_append(&op->rnpctx.signers, &key, sizeof(key))) {
                 return RNP_ERROR_OUT_OF_MEMORY;
             }
         }
@@ -1813,9 +1811,11 @@ rnp_op_sign_execute(rnp_op_sign_t op)
     };
 
     for (list_item *sig = list_front(op->signatures); sig; sig = list_next(sig)) {
-        char *keyid = ((rnp_op_sign_signature_t) sig)->keyid;
-
-        if (!list_append(&op->rnpctx.signers, keyid, strlen(keyid) + 1)) {
+        pgp_key_t *key = ((rnp_op_sign_signature_t)sig)->key;
+        if (!key) {
+            return RNP_ERROR_NO_SUITABLE_KEY;
+        }
+        if (!list_append(&op->rnpctx.signers, &key, sizeof(key))) {
             return RNP_ERROR_OUT_OF_MEMORY;
         }
     }

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -777,37 +777,15 @@ get_key_by_name(pgp_io_t *             io,
     return true;
 }
 
-/**
-   \ingroup HighLevel_KeyringFind
-
-   \brief Finds key from its User ID
-
-   \param keyring Keyring to be searched
-   \param userid User ID of required key
-
-   \return Pointer to Key, if found; NULL, if not found
-
-   \note This returns a pointer to the key inside the keyring, not a
-   copy.  Do not free it.
-
-*/
-bool
+pgp_key_t *
 rnp_key_store_get_key_by_name(pgp_io_t *             io,
                               const rnp_key_store_t *keyring,
                               const char *           name,
-                              pgp_key_t **           key)
+                              pgp_key_t *            after)
 {
-    return get_key_by_name(io, keyring, name, NULL, key);
-}
-
-bool
-rnp_key_store_get_next_key_by_name(pgp_io_t *             io,
-                                   const rnp_key_store_t *keyring,
-                                   const char *           name,
-                                   pgp_key_t *            after,
-                                   pgp_key_t **           key)
-{
-    return get_key_by_name(io, keyring, name, after, key);
+    pgp_key_t *key = NULL;
+    get_key_by_name(io, keyring, name, after, &key);
+    return key;
 }
 
 // TODO: This looks very similar to bn_hash()

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -653,6 +653,32 @@ rnp_key_store_get_key_by_id(pgp_io_t *             io,
 }
 
 pgp_key_t *
+rnp_key_store_get_key_by_userid(pgp_io_t *             io,
+                                const rnp_key_store_t *keyring,
+                                const char *           userid,
+                                pgp_key_t *            after)
+{
+    if (!keyring || !userid) {
+        return NULL;
+    }
+
+    // if after is provided, make sure it is a member of the appropriate list
+    assert(!after || list_is_member(keyring->keys, (list_item *) after));
+    for (list_item *key_item = after ? list_next((list_item *) after) :
+                                       list_front(keyring->keys);
+         key_item;
+         key_item = list_next(key_item)) {
+        pgp_key_t *key = (pgp_key_t *) key_item;
+        for (size_t i = 0; i < key->uidc; i++) {
+            if (!strcmp(userid, (char *) key->uids[i])) {
+                return key;
+            }
+        }
+    }
+    return NULL;
+}
+
+pgp_key_t *
 rnp_key_store_get_key_by_grip(pgp_io_t *             io,
                               const rnp_key_store_t *keyring,
                               const uint8_t *        grip)

--- a/src/rnp/rnp.c
+++ b/src/rnp/rnp.c
@@ -33,6 +33,7 @@
 #include <sys/param.h>
 #include <sys/stat.h>
 
+#include <assert.h>
 #include <time.h>
 #include <errno.h>
 #include <getopt.h>
@@ -347,15 +348,37 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                 return false;
             }
 
-            rnp_cfg_copylist_str(cfg, &ctx->signers, CFG_SIGNERS);
+            list signers = NULL;
+            if (!rnp_cfg_copylist_str(cfg, &signers, CFG_SIGNERS)) {
+                return false;
+            }
+            for (list_item *signer = list_front(signers); signer; signer = list_next(signer)) {
+                pgp_key_t *key = rnp_key_store_get_key_by_name(
+                  rnp->io, rnp->secring, (const char *) signer, NULL);
+                if (!key) {
+                    fprintf(
+                      stderr, "Invalid or unavailable signer: %s\n", (const char *) signer);
+                    list_destroy(&signers);
+                    return false;
+                }
+                if (!list_append(&ctx->signers, &key, sizeof(key))) {
+                    list_destroy(&signers);
+                    return false;
+                }
+            }
+            list_destroy(&signers);
 
             if (!list_length(ctx->signers)) {
                 if (!rnp->defkey) {
                     fprintf(stderr, "No userid or default key for signing\n");
                     return false;
                 }
-
-                if (!list_append(&ctx->signers, rnp->defkey, strlen(rnp->defkey) + 1)) {
+                pgp_key_t *key =
+                  rnp_key_store_get_key_by_name(rnp->io, rnp->secring, rnp->defkey, NULL);
+                if (!key) {
+                    return false;
+                }
+                if (!list_append(&ctx->signers, &key, sizeof(key))) {
                     RNP_LOG("allocation failed");
                     return false;
                 }
@@ -390,15 +413,43 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
 
             /* adding recipients if public-key encryption is used */
             if (rnp_cfg_getbool(cfg, CFG_ENCRYPT_PK)) {
-                rnp_cfg_copylist_str(cfg, &ctx->recipients, CFG_RECIPIENTS);
+                list recipients = NULL;
+                if (!rnp_cfg_copylist_str(cfg, &recipients, CFG_RECIPIENTS)) {
+                    return false;
+                }
+                for (list_item *recipient = list_front(recipients); recipient;
+                     recipient = list_next(recipient)) {
+                    pgp_key_t *key = rnp_key_store_get_key_by_name(
+                      rnp->io, rnp->pubring, (const char *) recipient, NULL);
+                    if (!key) {
+                        fprintf(stderr,
+                                "Invalid or unavailable recipient: %s\n",
+                                (const char *) recipient);
+                        list_destroy(&recipients);
+                        return false;
+                    }
+                    if (!list_append(&ctx->recipients, &key, sizeof(key))) {
+                        list_destroy(&recipients);
+                        return false;
+                    }
+                }
+                list_destroy(&recipients);
 
                 if (!list_length(ctx->recipients)) {
                     if (!rnp->defkey) {
                         fprintf(stderr, "No userid or default key for encryption\n");
                         return false;
                     }
+                    pgp_key_t *key = rnp_key_store_get_key_by_name(
+                      rnp->io, rnp->pubring, (const char *) rnp->defkey, NULL);
+                    if (!key) {
+                        fprintf(stderr,
+                                "Invalid or unavailable recipient: %s\n",
+                                (const char *) rnp->defkey);
+                        return false;
+                    }
 
-                    if (!list_append(&ctx->recipients, rnp->defkey, strlen(rnp->defkey) + 1)) {
+                    if (!list_append(&ctx->recipients, &key, sizeof(key))) {
                         RNP_LOG("allocation failed");
                         return false;
                     }
@@ -485,7 +536,7 @@ setcmd(rnp_cfg_t *cfg, int cmd, const char *arg)
         break;
     case CMD_CLEARSIGN:
         rnp_cfg_setbool(cfg, CFG_CLEARTEXT, true);
-        /* FALLTHROUGH */
+    /* FALLTHROUGH */
     case CMD_SIGN:
         rnp_cfg_setbool(cfg, CFG_NEEDSSECKEY, true);
         rnp_cfg_setbool(cfg, CFG_SIGN_NEEDED, true);
@@ -499,7 +550,7 @@ setcmd(rnp_cfg_t *cfg, int cmd, const char *arg)
     case CMD_VERIFY:
         /* single verify will discard output, decrypt will not */
         rnp_cfg_setbool(cfg, CFG_NO_OUTPUT, true);
-        /* FALLTHROUGH */
+    /* FALLTHROUGH */
     case CMD_VERIFY_CAT:
         newcmd = CMD_PROCESS;
         break;

--- a/src/tests/key-add-userid.c
+++ b/src/tests/key-add-userid.c
@@ -59,7 +59,7 @@ test_key_add_userid(void **state)
     pgp_memory_release(&mem);
 
     // locate our key
-    assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &key));
+    assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
     assert_non_null(key);
 
     // unlock the key
@@ -131,8 +131,7 @@ test_key_add_userid(void **state)
     // read from the saved packets
     assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
     pgp_memory_release(&mem);
-    assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &key));
-    assert_non_null(key);
+    assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
 
     // confirm that the counts have increased as expected
     assert_int_equal(key->uidc, uidc + 2);

--- a/src/tests/key-protect.c
+++ b/src/tests/key-protect.c
@@ -65,7 +65,7 @@ test_key_protect_load_pgp(void **state)
         for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
             pgp_key_t * key = NULL;
             const char *keyid = keyids[i];
-            assert_true(rnp_key_store_get_key_by_name(&io, ks, keyid, &key));
+            assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyid, NULL));
             assert_non_null(key);
             // all keys in this keyring are encrypted and thus should be both protected and
             // locked initially
@@ -74,7 +74,7 @@ test_key_protect_load_pgp(void **state)
         }
 
         pgp_key_t *tmp = NULL;
-        assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &tmp));
+        assert_non_null(tmp = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
         assert_non_null(tmp);
 
         // steal this key from the store
@@ -151,7 +151,8 @@ test_key_protect_load_pgp(void **state)
 
         // grab the first key
         pgp_key_t *reloaded_key = NULL;
-        assert_true(rnp_key_store_get_key_by_name(&io, ks, keyids[0], &reloaded_key));
+        assert_non_null(reloaded_key =
+                          rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
         assert_non_null(reloaded_key);
 
         // should not be locked, nor protected

--- a/src/tests/key-store-search.c
+++ b/src/tests/key-store-search.c
@@ -90,7 +90,7 @@ test_key_store_search(void **state)
     for (size_t i = 0; i < ARRAY_SIZE(testdata); i++) {
         list       seen_keys = NULL;
         pgp_key_t *key = NULL;
-        assert_true(rnp_key_store_get_key_by_name(&io, store, testdata[i].keyid, &key));
+        key = rnp_key_store_get_key_by_name(&io, store, testdata[i].keyid, NULL);
         while (key) {
             // check that the keyid actually matches
             uint8_t expected_keyid[PGP_KEY_ID_SIZE];
@@ -103,8 +103,7 @@ test_key_store_search(void **state)
             assert_non_null(list_append(&seen_keys, &key, sizeof(key)));
 
             // this only returns false on error, regardless of whether it found a match
-            assert_true(
-              rnp_key_store_get_next_key_by_name(&io, store, testdata[i].keyid, key, &key));
+            key = rnp_key_store_get_key_by_name(&io, store, testdata[i].keyid, key);
         }
         // check the count
         assert_int_equal(list_length(seen_keys), testdata[i].count);
@@ -118,7 +117,7 @@ test_key_store_search(void **state)
             list        seen_keys = NULL;
             pgp_key_t * key = NULL;
             const char *userid = testdata[i].userids[uidn];
-            assert_true(rnp_key_store_get_key_by_name(&io, store, userid, &key));
+            key = rnp_key_store_get_key_by_name(&io, store, userid, NULL);
             while (key) {
                 // check that the userid actually matches
                 bool found = false;
@@ -133,9 +132,7 @@ test_key_store_search(void **state)
                 // keep track of what key pointers we have seen
                 assert_non_null(list_append(&seen_keys, &key, sizeof(key)));
 
-                // this only returns false on error, regardless of whether it found a match
-                assert_true(rnp_key_store_get_next_key_by_name(
-                  &io, store, testdata[i].keyid, key, &key));
+                key = rnp_key_store_get_key_by_name(&io, store, testdata[i].keyid, key);
             }
             // check the count
             assert_int_equal(list_length(seen_keys), testdata[i].count);
@@ -149,15 +146,14 @@ test_key_store_search(void **state)
         list        seen_keys = NULL;
         pgp_key_t * key = NULL;
         const char *userid = "user1-.*";
-        assert_true(rnp_key_store_get_key_by_name(&io, store, userid, &key));
+        key = rnp_key_store_get_key_by_name(&io, store, userid, NULL);
         while (key) {
             // check that we have not already encountered this key pointer
             assert_null(list_find(seen_keys, &key, sizeof(key)));
             // keep track of what key pointers we have seen
             assert_non_null(list_append(&seen_keys, &key, sizeof(key)));
 
-            // this only returns false on error, regardless of whether it found a match
-            assert_true(rnp_key_store_get_next_key_by_name(&io, store, userid, key, &key));
+            key = rnp_key_store_get_key_by_name(&io, store, userid, key);
         }
         // check the count
         assert_int_equal(list_length(seen_keys), 3);

--- a/src/tests/key-unlock.c
+++ b/src/tests/key-unlock.c
@@ -63,9 +63,8 @@ test_key_unlock_pgp(void **state)
 
     for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
         const char *keyid = keyids[i];
-        key = NULL;
-        rnp_assert_true(rstate,
-                        rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyid, &key));
+        rnp_assert_non_null(
+          rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyid, NULL));
         assert_non_null(key);
         // all keys in this keyring are encrypted and thus should be locked initially
         rnp_assert_true(rstate, pgp_key_is_locked(key));
@@ -83,9 +82,8 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_free(&ctx);
 
     // grab the signing key to unlock
-    key = NULL;
-    rnp_assert_true(rstate,
-                    rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], &key));
+    rnp_assert_non_null(
+      rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
     rnp_assert_non_null(rstate, key);
 
     // confirm that this key is indeed RSA first
@@ -180,9 +178,8 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_free(&ctx);
 
     // grab the encrypting key to unlock
-    key = NULL;
-    rnp_assert_true(rstate,
-                    rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[1], &key));
+    rnp_assert_non_null(
+      rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[1], NULL));
 
     // unlock the encrypting key
     provider = (pgp_password_provider_t){.callback = string_copy_password_callback,

--- a/src/tests/key-unlock.c
+++ b/src/tests/key-unlock.c
@@ -75,7 +75,8 @@ test_key_unlock_pgp(void **state)
       (pgp_password_provider_t){.callback = failing_password_callback, .userdata = NULL};
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
-    rnp_assert_non_null(rstate, list_append(&ctx.signers, keyids[0], strlen(keyids[0]) + 1));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
     rnp_assert_int_not_equal(rstate, ret, RNP_SUCCESS);
@@ -125,7 +126,8 @@ test_key_unlock_pgp(void **state)
     // sign, with no password
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
-    rnp_assert_non_null(rstate, list_append(&ctx.signers, keyids[0], strlen(keyids[0]) + 1));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
     rnp_assert_int_equal(rstate, ret, RNP_SUCCESS);
@@ -154,7 +156,8 @@ test_key_unlock_pgp(void **state)
     // sign, with no password (should now fail)
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
-    rnp_assert_non_null(rstate, list_append(&ctx.signers, keyids[0], strlen(keyids[0]) + 1));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
     rnp_assert_int_not_equal(rstate, ret, RNP_SUCCESS);
@@ -163,7 +166,8 @@ test_key_unlock_pgp(void **state)
     // encrypt
     rnp_ctx_init(&ctx, &rnp);
     ctx.ealg = PGP_SA_AES_256;
-    list_append(&ctx.recipients, keyids[1], strlen(keyids[1]) + 1);
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, keyids[1], NULL));
+    list_append(&ctx.recipients, &key, sizeof(key));
     // Note: keyids[1] is an encrypting subkey
     ret = rnp_protect_mem(&ctx, data, strlen(data), encrypted, sizeof(encrypted), &enclen);
     rnp_assert_int_equal(rstate, ret, RNP_SUCCESS);

--- a/src/tests/user-prefs.c
+++ b/src/tests/user-prefs.c
@@ -78,8 +78,8 @@ test_load_user_prefs(void **state)
 
         // find the key
         pgp_key_t *key = NULL;
-        rnp_assert_true(rstate,
-                        rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, &key));
+        rnp_assert_non_null(
+          rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, NULL));
         assert_non_null(key);
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);
@@ -124,8 +124,8 @@ test_load_user_prefs(void **state)
 
         // find the key
         pgp_key_t *key = NULL;
-        rnp_assert_true(rstate,
-                        rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, &key));
+        rnp_assert_non_null(
+          rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, NULL));
         assert_non_null(key);
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);


### PR DESCRIPTION
While trying to finish up the ffi key provider stuff this week I ran into an issue, which led me to some limitation that I needed to get rid of, so here's some revisions that I think help:

* Revised `rnp_key_store_get_key_by_name` (and removed a sibling function) to have an interface more aligned with the other search functions. There's probably room for improvement on all of these really.
* Added an actual userid search, separate from the "name" search which is mostly useful for kind of fuzzy CLI searches.
* Switched the `rnp_ctx_t` signers and recipients lists to use key pointers, rather than strings. Previously the streaming framework code would resolve these strings to the appropriate keys during the execution of whatever operation (like [so](https://github.com/riboseinc/rnp/blob/a570e42331a407cc4fbd95c88b7abb0a09e4c76e/src/librepgp/stream-write.c#L511)). But it seems like these functions already do too much and this is an easy step to separate out (and will probably be useful when adding per-signer hash alg stuff, etc). Plus it allows us to better differentiate between different search types (userid,keyid,etc).
* As part of the above, removed the use of the key provider for encrypt and sign operations. Generally my view is that the key provider should only be used for decrypt and verify, because these are the two operations that deal with unknown keys (until parsed).