### PR TITLE
Rework the ffi key provider and tweak key loading

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -141,12 +141,15 @@ rnp_key_store_t *rnp_key_store_new(const char *format, const char *path);
 
 bool rnp_key_store_load_keys(rnp_t *rnp, bool loadsecret);
 
-int rnp_key_store_load_from_file(pgp_io_t *io,
+int  rnp_key_store_load_from_file(pgp_io_t *io,
+                                  rnp_key_store_t *,
+                                  const unsigned,
+                                  const pgp_key_provider_t *key_provider);
+bool rnp_key_store_load_from_mem(pgp_io_t *io,
                                  rnp_key_store_t *,
                                  const unsigned,
-                                 rnp_key_store_t *);
-bool rnp_key_store_load_from_mem(
-  pgp_io_t *io, rnp_key_store_t *, const unsigned, rnp_key_store_t *, pgp_memory_t *);
+                                 pgp_memory_t *,
+                                 const pgp_key_provider_t *key_provider);
 
 bool rnp_key_store_write_to_file(pgp_io_t *io, rnp_key_store_t *, const unsigned);
 bool rnp_key_store_write_to_mem(pgp_io_t *io,
@@ -160,9 +163,7 @@ void rnp_key_store_free(rnp_key_store_t *);
 bool rnp_key_store_list(pgp_io_t *, const rnp_key_store_t *, const int);
 bool rnp_key_store_json(pgp_io_t *, const rnp_key_store_t *, json_object *, const int);
 
-bool rnp_key_store_add_key(pgp_io_t *, rnp_key_store_t *, pgp_key_t *);
-bool rnp_key_store_add_keydata(
-  pgp_io_t *, rnp_key_store_t *, pgp_keydata_key_t *, pgp_key_t **, pgp_content_enum);
+pgp_key_t *rnp_key_store_add_key(pgp_io_t *, rnp_key_store_t *, pgp_key_t *);
 
 bool rnp_key_store_remove_key(pgp_io_t *, rnp_key_store_t *, const pgp_key_t *);
 bool rnp_key_store_remove_key_by_id(pgp_io_t *, rnp_key_store_t *, const uint8_t *);

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -181,6 +181,8 @@ pgp_key_t *rnp_key_store_get_key_by_userid(pgp_io_t *,
                                            pgp_key_t *);
 
 bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
+
 pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, const rnp_key_store_t *, const uint8_t *);
+pgp_key_t *rnp_key_store_get_key_by_fpr(pgp_io_t *, const rnp_key_store_t *, const pgp_fingerprint_t *fpr);
 
 #endif /* KEY_STORE_H_ */

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -185,4 +185,6 @@ bool       rnp_key_store_get_key_grip(pgp_pubkey_t *, uint8_t *);
 pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, const rnp_key_store_t *, const uint8_t *);
 pgp_key_t *rnp_key_store_get_key_by_fpr(pgp_io_t *, const rnp_key_store_t *, const pgp_fingerprint_t *fpr);
 
+pgp_key_t *rnp_key_store_search(pgp_io_t *, const rnp_key_store_t *, const pgp_key_search_t *, pgp_key_t *);
+
 #endif /* KEY_STORE_H_ */

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -268,8 +268,10 @@ typedef enum {
 
     /* Errors */
     PGP_PARSER_ERROR = 0x500,      /* Internal Use: Parser Error */
-    PGP_PARSER_ERRCODE = 0x500 + 1 /* Internal Use: Parser Error
+    PGP_PARSER_ERRCODE = 0x500 + 1,/* Internal Use: Parser Error
                                     * with errcode returned */
+
+    PGP_PARSER_DONE = 0x600 /* parsing is complete */
 } pgp_content_enum;
 
 /** Public Key Algorithm Numbers.

--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -513,6 +513,7 @@ typedef enum pgp_op_t {
     PGP_OP_ENCRYPT_SYM = 8, /* symmetric encryption */
     PGP_OP_VERIFY = 9,      /* signature verification */
     PGP_OP_ADD_USERID = 10, /* adding a userid */
+    PGP_OP_MERGE_INFO = 11, /* merging information from one key to another */
 } pgp_op_t;
 
 /** Hashing Algorithm Numbers.

--- a/include/rnp/rnp2.h
+++ b/include/rnp/rnp2.h
@@ -741,8 +741,30 @@ rnp_result_t rnp_op_encrypt_destroy(rnp_op_encrypt_t op);
 
 rnp_result_t rnp_decrypt(rnp_ffi_t ffi, rnp_input_t input, rnp_output_t output);
 
-rnp_result_t rnp_public_key_bytes(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len);
-rnp_result_t rnp_secret_key_bytes(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len);
+/** retrieve the raw data for a public key
+ *
+ *  This will always be PGP packets and will never include ASCII armor.
+ *
+ *  @param handle the key handle
+ *  @param buf
+ *  @param buf_len
+ *  @return 0 on success, or any other value on error
+ */
+rnp_result_t rnp_get_public_key_data(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len);
+
+/** retrieve the raw data for a secret key
+ *
+ *  If this is a G10 key, this will be the s-expr data. Otherwise, it will
+ *  be PGP packets.
+ *
+ *  Note that this result will never include ASCII armor.
+ *
+ *  @param handle the key handle
+ *  @param buf
+ *  @param buf_len
+ *  @return 0 on success, or any other value on error
+ */
+rnp_result_t rnp_get_secret_key_data(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len);
 
 rnp_result_t rnp_key_to_json(rnp_key_handle_t handle, uint32_t flags, char **result);
 

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -65,6 +65,7 @@ typedef struct rnp_t {
     } action;
 
     pgp_password_provider_t password_provider;
+    pgp_key_provider_t      key_provider;
     rng_t                   rng; /* handle to rng_t */
 } rnp_t;
 

--- a/src/lib/key-provider.c
+++ b/src/lib/key-provider.c
@@ -60,7 +60,16 @@ rnp_key_provider_keyring(const pgp_key_request_ctx_t *ctx, pgp_key_t **key, void
             ks_key = rnp_key_store_get_key_by_id(
               rnp->io, rnp->secring, ctx->search.by.keyid, NULL, NULL);
         }
-    } else if (ctx->search.type == PGP_KEY_SEARCH_GRIP) {
+    } else if (ctx->search.type == PGP_KEY_SEARCH_FINGERPRINT) {
+        ks_key = rnp_key_store_get_key_by_fpr(rnp->io,
+                                              ks,
+                                              &ctx->search.by.fingerprint);
+        if (!ks_key && !ctx->secret) {
+            ks_key = rnp_key_store_get_key_by_fpr(rnp->io,
+                                                  rnp->secring,
+                                                  &ctx->search.by.fingerprint);
+        }
+     } else if (ctx->search.type == PGP_KEY_SEARCH_GRIP) {
         ks_key = rnp_key_store_get_key_by_grip(rnp->io, ks, ctx->search.by.grip);
         if (!ks_key && !ctx->secret) {
             ks_key = rnp_key_store_get_key_by_grip(rnp->io, rnp->secring, ctx->search.by.grip);

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -35,6 +35,7 @@ typedef struct pgp_key_t pgp_key_t;
 typedef enum {
     PGP_KEY_SEARCH_UNKNOWN,
     PGP_KEY_SEARCH_KEYID,
+    PGP_KEY_SEARCH_FINGERPRINT,
     PGP_KEY_SEARCH_GRIP,
     PGP_KEY_SEARCH_USERID
 } pgp_key_search_type_t;
@@ -44,6 +45,7 @@ typedef struct pgp_key_search_t {
     union {
         uint8_t keyid[PGP_KEY_ID_SIZE];
         uint8_t grip[PGP_FINGERPRINT_SIZE];
+        pgp_fingerprint_t fingerprint;
         char    userid[MAX_ID_LENGTH + 1];
     } by;
 } pgp_key_search_t;

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -26,9 +26,8 @@
 #ifndef RNP_KEY_PROVIDER_H
 #define RNP_KEY_PROVIDER_H
 
-#include <rnp/rnp_types.h>
-#include <rnp/rnp_sdk.h>
-#include "pass-provider.h"
+#include "types.h"
+#include "fingerprint.h"
 
 typedef struct pgp_key_t pgp_key_t;
 
@@ -64,6 +63,18 @@ typedef struct pgp_key_provider_t {
     pgp_key_callback_t *callback;
     void *              userdata;
 } pgp_key_provider_t;
+
+/** checks if a key matches search criteria
+ *
+ *  Note that this does not do any check on the type of key (public/secret),
+ *  that is left up to the caller.
+ *
+ *  @param key the key to check
+ *  @param search the search criteria to check against
+ *  @return true if the key satisfies the search criteria, false otherwise
+ **/
+bool
+rnp_key_matches_search(const pgp_key_t *key, const pgp_key_search_t *search);
 
 /** @brief request public or secret pgp key, according to information stored in ctx
  *  @param provider key provider structure

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -55,9 +55,7 @@ typedef struct pgp_key_request_ctx_t {
     pgp_key_search_t search;
 } pgp_key_request_ctx_t;
 
-typedef bool pgp_key_callback_t(const pgp_key_request_ctx_t *ctx,
-                                pgp_key_t **                 key,
-                                void *                       userdata);
+typedef pgp_key_t *pgp_key_callback_t(const pgp_key_request_ctx_t *ctx, void *userdata);
 
 typedef struct pgp_key_provider_t {
     pgp_key_callback_t *callback;
@@ -77,21 +75,17 @@ bool
 rnp_key_matches_search(const pgp_key_t *key, const pgp_key_search_t *search);
 
 /** @brief request public or secret pgp key, according to information stored in ctx
- *  @param provider key provider structure
  *  @param ctx information about the request - which operation requested the key, which search
  *  criteria should be used and whether secret or public key is needed
  *  @param key pointer to the key structure will be stored here on success
- *  @return true on success, or false if key was not found otherwise
+ *  @return a key pointer on success, or NULL if key was not found otherwise
  **/
-bool pgp_request_key(const pgp_key_provider_t *   provider,
-                     const pgp_key_request_ctx_t *ctx,
-                     pgp_key_t **                 key);
+pgp_key_t *pgp_request_key(const pgp_key_provider_t *   provider,
+                           const pgp_key_request_ctx_t *ctx);
 
 /** @brief key provider callback which searches for key in rnp_key_store_t. userdata must be
   *pointer to the rnp_t structure
  **/
-bool rnp_key_provider_keyring(const pgp_key_request_ctx_t *ctx,
-                              pgp_key_t **                 key,
-                              void *                       userdata);
+pgp_key_t *rnp_key_provider_keyring(const pgp_key_request_ctx_t *ctx, void *userdata);
 
 #endif

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -84,8 +84,30 @@ pgp_key_t *pgp_request_key(const pgp_key_provider_t *   provider,
                            const pgp_key_request_ctx_t *ctx);
 
 /** @brief key provider callback which searches for key in rnp_key_store_t. userdata must be
-  *pointer to the rnp_t structure
+ *pointer to the rnp_t structure
  **/
 pgp_key_t *rnp_key_provider_keyring(const pgp_key_request_ctx_t *ctx, void *userdata);
+
+/** key provider callback that searches a list of pgp_key_t pointers
+ *
+ *  @param ctx
+ *  @param userdata must be a list of key pgp_key_t**
+ */
+pgp_key_t *rnp_key_provider_key_ptr_list(const pgp_key_request_ctx_t *ctx, void *userdata);
+
+/** key provider callback that searches a given store
+ *
+ *  @param ctx
+ *  @param userdata must be a pointer to rnp_key_store_t
+ */
+pgp_key_t *rnp_key_provider_store(const pgp_key_request_ctx_t *ctx, void *userdata);
+
+/** key provider that calls other key providers
+ *
+ *  @param ctx
+ *  @param userdata must be an array pgp_key_provider_t pointers,
+ *         ending with a NULL.
+ */
+pgp_key_t *rnp_key_provider_chained(const pgp_key_request_ctx_t *ctx, void *userdata);
 
 #endif

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -379,6 +379,7 @@ decrypt_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         return PGP_KEEP_MEMORY;
 
     case PGP_PARSER_PACKET_END:
+    case PGP_PARSER_DONE:
         /* nothing to do */
         break;
 

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -1092,9 +1092,8 @@ find_suitable_key(pgp_op_t            op,
       .op = op, .secret = pgp_is_key_secret(key), .search.type = PGP_KEY_SEARCH_GRIP};
     while (subkey_grip) {
         memcpy(ctx.search.by.grip, subkey_grip, PGP_FINGERPRINT_SIZE);
-        pgp_key_t *subkey = NULL;
-        if (pgp_request_key(key_provider, &ctx, &subkey) && subkey &&
-            (subkey->key_flags & desired_usage)) {
+        pgp_key_t *subkey = pgp_request_key(key_provider, &ctx);
+        if (subkey && (subkey->key_flags & desired_usage)) {
             return subkey;
         }
         subkey_grip = list_next(subkey_grip);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -55,7 +55,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include "pass-provider.h"
-#include "key-provider.h"
 #include <repgp/repgp.h>
 #include <rekey/rnp_key_store.h>
 #include "memory.h"
@@ -87,6 +86,15 @@ struct pgp_key_t {
 };
 
 struct pgp_key_t *pgp_key_new(void);
+
+/** create a key from pgp_keydata_key_t
+ *
+ *  This sets up basic properties of the key like keyid/fpr/grip, type, etc.
+ *  It does not set primary_grip or subkey_grips (the key store does this).
+ */
+bool pgp_key_from_keydata(pgp_key_t *            key,
+                          pgp_keydata_key_t *    keydata,
+                          const pgp_content_enum tag);
 
 /** free the internal data of a key *and* the key structure itself
  *
@@ -257,5 +265,10 @@ pgp_key_t *find_suitable_key(pgp_op_t            op,
                              pgp_key_t *         key,
                              pgp_key_provider_t *key_provider,
                              uint8_t             desired_usage);
+
+pgp_key_t *pgp_get_primary_key_for(pgp_io_t *                io,
+                                   const pgp_key_t *         subkey,
+                                   const rnp_key_store_t *   store,
+                                   const pgp_key_provider_t *key_provider);
 
 #endif // RNP_PACKET_KEY_H

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -940,7 +940,7 @@ rnp_import_key(rnp_t *rnp, char *f)
     }
 
     // load the key(s)
-    if (!rnp_key_store_load_from_file(rnp->io, tmp_keystore, realarmor, rnp->pubring)) {
+    if (!rnp_key_store_load_from_file(rnp->io, tmp_keystore, realarmor, &rnp->key_provider)) {
         RNP_LOG("failed to load key from file %s", f);
         goto done;
     }

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -158,14 +158,12 @@ get_key_prefer_public(rnp_key_handle_t handle);
 static pgp_key_t *
 get_key_require_secret(rnp_key_handle_t handle);
 
-static bool
-key_provider_bounce(const pgp_key_request_ctx_t *ctx, pgp_key_t **key, void *userdata)
+static pgp_key_t *
+key_provider_bounce(const pgp_key_request_ctx_t *ctx, void *userdata)
 {
     rnp_ffi_t        ffi = (rnp_ffi_t) userdata;
     rnp_key_store_t *store = ctx->secret ? ffi->secring : ffi->pubring;
-    *key = rnp_key_store_search(&ffi->io, store, &ctx->search, NULL);
-    // TODO: if still not found, use ffi->getkeycb
-    return *key != NULL;
+    return rnp_key_store_search(&ffi->io, store, &ctx->search, NULL);
 }
 
 static void

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -3207,7 +3207,7 @@ key_to_bytes(pgp_key_t *key, uint8_t **buf, size_t *buf_len)
 }
 
 rnp_result_t
-rnp_public_key_bytes(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len)
+rnp_get_public_key_data(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len)
 {
     // checks
     if (!handle || !buf || !buf_len) {
@@ -3222,7 +3222,7 @@ rnp_public_key_bytes(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len)
 }
 
 rnp_result_t
-rnp_secret_key_bytes(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len)
+rnp_get_secret_key_data(rnp_key_handle_t handle, uint8_t **buf, size_t *buf_len)
 {
     // checks
     if (!handle || !buf || !buf_len) {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -134,6 +134,12 @@ typedef struct {
     pgp_errcode_t errcode;
 } pgp_parser_errcode_t;
 
+/** pgp_fingerprint_t */
+typedef struct pgp_fingerprint_t {
+    uint8_t  fingerprint[PGP_FINGERPRINT_SIZE];
+    unsigned length;
+} pgp_fingerprint_t;
+
 /** Structure to hold one packet tag.
  * \see RFC4880 4.2
  */
@@ -245,8 +251,9 @@ typedef struct pgp_sig_info_t {
     time_t  expiration;                 /* number of seconds it's valid for */
     uint8_t signer_id[PGP_KEY_ID_SIZE]; /* Eight-octet key ID
                                          * of signer */
-    pgp_pubkey_alg_t key_alg;           /* public key algorithm number */
-    pgp_hash_alg_t   hash_alg;          /* hashing algorithm number */
+    pgp_fingerprint_t signer_fpr;       /* signer fingerprint (length is 0 if not set) */
+    pgp_pubkey_alg_t  key_alg;          /* public key algorithm number */
+    pgp_hash_alg_t    hash_alg;         /* hashing algorithm number */
     union {
         pgp_rsa_sig_t     rsa;     /* An RSA Signature */
         pgp_dsa_sig_t     dsa;     /* A DSA Signature */
@@ -687,12 +694,6 @@ struct pgp_packet_t {
     uint8_t          critical; /* for sig subpackets */
     pgp_contents_t   u;        /* union for contents */
 };
-
-/** pgp_fingerprint_t */
-typedef struct pgp_fingerprint_t {
-    uint8_t  fingerprint[PGP_FINGERPRINT_SIZE];
-    unsigned length;
-} pgp_fingerprint_t;
 
 /** pgp_keydata_key_t
  */

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -32,8 +32,8 @@
 
 bool rnp_key_store_g10_from_mem(pgp_io_t *,
                                 rnp_key_store_t *,
-                                rnp_key_store_t *,
-                                pgp_memory_t *);
+                                pgp_memory_t *,
+                                const pgp_key_provider_t *);
 bool rnp_key_store_g10_key_to_mem(pgp_io_t *, pgp_key_t *, pgp_memory_t *);
 bool g10_write_seckey(pgp_output_t *output, pgp_seckey_t *seckey, const char *password);
 pgp_seckey_t *g10_decrypt_seckey(const uint8_t *     data,

--- a/src/librekey/key_store_kbx.c
+++ b/src/librekey/key_store_kbx.c
@@ -372,7 +372,10 @@ rnp_key_store_kbx_parse_blob(uint8_t *image, uint32_t image_len)
 }
 
 bool
-rnp_key_store_kbx_from_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_t *memory)
+rnp_key_store_kbx_from_mem(pgp_io_t *                io,
+                           rnp_key_store_t *         key_store,
+                           pgp_memory_t *            memory,
+                           const pgp_key_provider_t *key_provider)
 {
     size_t   has_bytes;
     uint8_t *buf;
@@ -422,7 +425,7 @@ rnp_key_store_kbx_from_mem(pgp_io_t *io, rnp_key_store_t *key_store, pgp_memory_
                 return false;
             }
 
-            if (!rnp_key_store_pgp_read_from_mem(io, key_store, 0, &mem)) {
+            if (!rnp_key_store_pgp_read_from_mem(io, key_store, 0, &mem, key_provider)) {
                 return false;
             }
         }

--- a/src/librekey/key_store_kbx.h
+++ b/src/librekey/key_store_kbx.h
@@ -30,7 +30,10 @@
 #include <rnp/rnp.h>
 #include <rekey/rnp_key_store.h>
 
-bool rnp_key_store_kbx_from_mem(pgp_io_t *, rnp_key_store_t *, pgp_memory_t *);
+bool rnp_key_store_kbx_from_mem(pgp_io_t *,
+                                rnp_key_store_t *,
+                                pgp_memory_t *,
+                                const pgp_key_provider_t *);
 bool rnp_key_store_kbx_to_mem(pgp_io_t *, rnp_key_store_t *, pgp_memory_t *);
 
 #endif // RNP_KEY_STORE_KBX_H

--- a/src/librekey/key_store_pgp.c
+++ b/src/librekey/key_store_pgp.c
@@ -100,6 +100,7 @@ parse_key_attributes(pgp_key_t *key, const pgp_packet_t *pkt, pgp_cbdata_t *cbin
     // handle these earlier, since they don't actually
     // require a key
     switch (pkt->tag) {
+    case PGP_PARSER_DONE:
     case PGP_PARSER_PTAG:
     case PGP_GET_PASSWORD:
         return PGP_RELEASE_MEMORY;
@@ -354,6 +355,8 @@ cb_keyring_parse(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
         return PGP_KEEP_MEMORY;
     case PGP_PTAG_CT_ARMOR_HEADER:
     case PGP_PTAG_CT_ARMOR_TRAILER:
+        break;
+    case PGP_PARSER_DONE:
         break;
     default:
         return parse_key_attributes(cb->key, pkt, cbinfo);

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -63,7 +63,8 @@
 bool rnp_key_store_pgp_read_from_mem(pgp_io_t *,
                                      rnp_key_store_t *,
                                      const unsigned,
-                                     pgp_memory_t *);
+                                     pgp_memory_t *,
+                                     const pgp_key_provider_t *);
 
 int rnp_key_store_pgp_write_to_mem(pgp_io_t *,
                                    rnp_key_store_t *,

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -924,3 +924,23 @@ rnp_key_store_get_key_grip(pgp_pubkey_t *key, uint8_t *grip)
 
     return pgp_hash_finish(&hash, grip) == PGP_FINGERPRINT_SIZE;
 }
+
+pgp_key_t *
+rnp_key_store_search(pgp_io_t *              io,
+                     const rnp_key_store_t * keyring,
+                     const pgp_key_search_t *search,
+                     pgp_key_t *             after)
+{
+    // if after is provided, make sure it is a member of the appropriate list
+    assert(!after || list_is_member(keyring->keys, (list_item *) after));
+    for (list_item *key_item = after ? list_next((list_item *) after) :
+                                       list_front(keyring->keys);
+         key_item;
+         key_item = list_next(key_item)) {
+        pgp_key_t *key = (pgp_key_t *) key_item;
+        if (rnp_key_matches_search(key, search)) {
+            return key;
+        }
+    }
+    return NULL;
+}

--- a/src/librekey/rnp_key_store.c
+++ b/src/librekey/rnp_key_store.c
@@ -701,6 +701,20 @@ rnp_key_store_get_key_by_grip(pgp_io_t *             io,
     return NULL;
 }
 
+pgp_key_t *
+rnp_key_store_get_key_by_fpr(pgp_io_t *io, const rnp_key_store_t *keyring, const pgp_fingerprint_t *fpr)
+{
+    for (list_item *key_item = list_front(keyring->keys); key_item;
+         key_item = list_next(key_item)) {
+        pgp_key_t *key = (pgp_key_t *) key_item;
+        if (key->fingerprint.length == fpr->length &&
+            memcmp(key->fingerprint.fingerprint, fpr->fingerprint, fpr->length) == 0) {
+            return key;
+        }
+    }
+    return NULL;
+}
+
 /* convert a string keyid into a binary keyid */
 static void
 str2keyid(const char *userid, uint8_t *keyid, size_t len)

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -1807,6 +1807,9 @@ parse_one_sig_subpacket(pgp_sig_t *sig, pgp_region_t *region, pgp_stream_t *stre
             pkt.u.ss_issuer_fpr.len != 21 || pkt.u.ss_issuer_fpr.contents[0] != 0x04) {
             return false;
         }
+        memcpy(sig->info.signer_fpr.fingerprint,
+               pkt.u.ss_issuer_fpr.contents + 1,
+               pkt.u.ss_issuer_fpr.len - 1);
         break;
 
     case PGP_PTAG_SS_NOTATION_DATA:

--- a/src/librepgp/packet-parse.c
+++ b/src/librepgp/packet-parse.c
@@ -1009,6 +1009,7 @@ repgp_parser_content_free(pgp_packet_t *c)
     case PGP_PTAG_CT_SE_IP_DATA_BODY:
     case PGP_PTAG_CT_MDC:
     case PGP_GET_SECKEY:
+    case PGP_PARSER_DONE:
         break;
 
     case PGP_PTAG_CT_SIGNED_CLEARTEXT_HEADER:
@@ -3392,6 +3393,8 @@ repgp_parse(pgp_stream_t *stream, const bool show_errors)
     do {
         res = parse_packet(stream, &pktlen);
     } while (RNP_ERROR_EOF != res);
+    pgp_packet_t     pkt = {0};
+    CALLBACK(PGP_PARSER_DONE, &stream->cbinfo, &pkt);
     if (show_errors) {
         pgp_print_errors(stream->errors);
     }

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -1699,6 +1699,9 @@ pgp_print_packet(pgp_cbdata_t *cbinfo, const pgp_packet_t *pkt)
           print, PGP_PTAG_CT_ENCRYPTED_PK_SESSION_KEY, content->get_seckey.pk_sesskey);
         break;
 
+    case PGP_PARSER_DONE:
+        break;
+
     default:
         fprintf(stderr, "pgp_print_packet: unknown tag=%d (0x%x)\n", pkt->tag, pkt->tag);
         return false;

--- a/src/librepgp/repgp.c
+++ b/src/librepgp/repgp.c
@@ -354,7 +354,7 @@ repgp_list_packets(const void *ctx, const repgp_handle_t *input, bool dump_conte
 
     const rnp_t *rnp = rctx->rnp;
     if (rnp->pubring && rnp->secring) {
-        if (!rnp_key_store_load_from_file(rnp->io, rnp->pubring, rctx->armor, rnp->pubring)) {
+        if (!rnp_key_store_load_from_file(rnp->io, rnp->pubring, rctx->armor, &rnp->key_provider)) {
             RNP_LOG("Keystore can't load data");
             return RNP_ERROR_GENERIC;
         }

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -999,7 +999,7 @@ signed_src_finish(pgp_source_t *src)
         }
 
         /* Get the public key */
-        if (!pgp_request_key(param->ctx->handler.key_provider, &keyctx, &key)) {
+        if (!(key = pgp_request_key(param->ctx->handler.key_provider, &keyctx))) {
             RNP_LOG("signer's key not found");
             sinfo->no_signer = true;
             continue;
@@ -1949,7 +1949,7 @@ init_encrypted_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *r
                    ((pgp_pk_sesskey_pkt_t *) pe)->key_id,
                    sizeof(keyctx.search.by.keyid));
             /* Get the key if any */
-            if (!pgp_request_key(ctx->handler.key_provider, &keyctx, &seckey)) {
+            if (!(seckey = pgp_request_key(ctx->handler.key_provider, &keyctx))) {
                 continue;
             }
             /* Decrypt key */

--- a/src/librepgp/validate.c
+++ b/src/librepgp/validate.c
@@ -349,6 +349,7 @@ pgp_validate_key_cb(const pgp_packet_t *pkt, pgp_cbdata_t *cbinfo)
     case PGP_PARSER_PTAG:
     case PGP_PTAG_CT_SIGNATURE_HEADER:
     case PGP_PARSER_PACKET_END:
+    case PGP_PARSER_DONE:
         break;
 
     case PGP_GET_PASSWORD:

--- a/src/tests/ffi.c
+++ b/src/tests/ffi.c
@@ -185,7 +185,7 @@ load_test_data(const char *data_dir, const char *file, char **data, size_t *size
     FILE *fp = fopen(path, "r");
     assert_non_null(fp);
     assert_int_equal(st.st_size, fread(*data, 1, st.st_size, fp));
-    fclose(fp);
+    assert_int_equal(0, fclose(fp));
     free(path);
 }
 
@@ -1075,8 +1075,9 @@ test_ffi_encrypt_pass(void **state)
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
-    fwrite(plaintext, strlen(plaintext), 1, fp);
-    fclose(fp);
+    assert_non_null(fp);
+    assert_int_equal(1, fwrite(plaintext, strlen(plaintext), 1, fp));
+    assert_int_equal(0, fclose(fp));
 
     // create input+output w/ bad paths (should fail)
     input = NULL;
@@ -1207,8 +1208,9 @@ test_ffi_encrypt_pk(void **state)
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
-    fwrite(plaintext, strlen(plaintext), 1, fp);
-    fclose(fp);
+    assert_non_null(fp);
+    assert_int_equal(1, fwrite(plaintext, strlen(plaintext), 1, fp));
+    assert_int_equal(0, fclose(fp));
 
     // create input+output
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "plaintext"));
@@ -1314,8 +1316,9 @@ test_ffi_encrypt_and_sign(void **state)
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
-    fwrite(plaintext, strlen(plaintext), 1, fp);
-    fclose(fp);
+    assert_non_null(fp);
+    assert_int_equal(1, fwrite(plaintext, strlen(plaintext), 1, fp));
+    assert_int_equal(0, fclose(fp));
 
     // create input+output
     assert_rnp_success(rnp_input_from_path(&input, "plaintext"));
@@ -1476,8 +1479,9 @@ test_ffi_init_sign_file_input(void **state, rnp_input_t *input, rnp_output_t *ou
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
-    fwrite(plaintext, strlen(plaintext), 1, fp);
-    fclose(fp);
+    assert_non_null(fp);
+    assert_int_equal(1, fwrite(plaintext, strlen(plaintext), 1, fp));
+    assert_int_equal(0, fclose(fp));
 
     // create input+output
     assert_rnp_success(rnp_input_from_path(input, "plaintext"));

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -274,9 +274,11 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
     const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX};
     rnp_t       rnp;
     int         pipefd[2];
+    char *rnp_home = rnp_compose_path(rstate->home, ".rnp", NULL);
 
     for (size_t i = 0; i < sizeof(hashAlg) / sizeof(hashAlg[0]); i++) {
         for (size_t j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
+            delete_recursively(rnp_home);
             /* Setting up rnp again and decrypting memory */
             printf("keystore: %s\n", keystores[j]);
             rnp_assert_ok(rstate, setup_rnp_common(&rnp, keystores[j], NULL, pipefd));
@@ -308,6 +310,7 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
             rnp_end(&rnp); // Free memory and other allocated resources.
         }
     }
+    free(rnp_home);
 }
 
 void
@@ -330,9 +333,11 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
     const char *keystores[] = {RNP_KEYSTORE_GPG, RNP_KEYSTORE_GPG21, RNP_KEYSTORE_KBX};
     rnp_t       rnp;
     int         pipefd[2];
+    char *rnp_home = rnp_compose_path(rstate->home, ".rnp", NULL);
 
     for (size_t i = 0; i < sizeof(userIds) / sizeof(userIds[0]); i++) {
         for (size_t j = 0; j < sizeof(keystores) / sizeof(keystores[0]); j++) {
+            delete_recursively(rnp_home);
             /* Set the user id to be used*/
             snprintf(userId, sizeof(userId), "%s", userIds[i]);
 
@@ -360,6 +365,7 @@ rnpkeys_generatekey_verifyUserIdOption(void **state)
             rnp_end(&rnp); // Free memory and other allocated resources.
         }
     }
+    free(rnp_home);
 }
 
 void

--- a/src/tests/key-add-userid.c
+++ b/src/tests/key-add-userid.c
@@ -55,7 +55,7 @@ test_key_add_userid(void **state)
     pgp_memory_t mem = {0};
     paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/secring.gpg", NULL);
     assert_true(pgp_mem_readfile(&mem, path));
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem, NULL));
     pgp_memory_release(&mem);
 
     // locate our key
@@ -129,7 +129,7 @@ test_key_add_userid(void **state)
     ks = calloc(1, sizeof(*ks));
     assert_non_null(ks);
     // read from the saved packets
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem, NULL));
     pgp_memory_release(&mem);
     assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
 

--- a/src/tests/key-protect.c
+++ b/src/tests/key-protect.c
@@ -59,7 +59,7 @@ test_key_protect_load_pgp(void **state)
         pgp_memory_t mem = {0};
         paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/secring.gpg", NULL);
         assert_true(pgp_mem_readfile(&mem, path));
-        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem, NULL));
         pgp_memory_release(&mem);
 
         for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
@@ -147,7 +147,7 @@ test_key_protect_load_pgp(void **state)
         pgp_memory_t mem = {0};
         mem.buf = key->packets[0].raw;
         mem.length = key->packets[0].length;
-        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem));
+        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, 0, &mem, NULL));
 
         // grab the first key
         pgp_key_t *reloaded_key = NULL;

--- a/src/tests/key-store-search.c
+++ b/src/tests/key-store-search.c
@@ -57,6 +57,9 @@ test_key_store_search(void **state)
         for (size_t n = 0; n < testdata[i].count; n++) {
             pgp_key_t key = {0};
 
+            key.type = PGP_PTAG_CT_PUBLIC_KEY;
+            key.key.pubkey.version = 4;
+
             // set the keyid
             assert_true(rnp_hex_decode(testdata[i].keyid, key.keyid, sizeof(key.keyid)));
             // set the userids

--- a/src/tests/load-pgp.c
+++ b/src/tests/load-pgp.c
@@ -49,7 +49,7 @@ test_load_v3_keyring_pgp(void **state)
     assert_non_null(key_store);
 
     // load it in to the key store
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem, NULL));
     assert_int_equal(1, list_length(key_store->keys));
 
     // find the key by keyid
@@ -72,7 +72,7 @@ test_load_v3_keyring_pgp(void **state)
     key_store = calloc(1, sizeof(*key_store));
     assert_non_null(key_store);
 
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem, NULL));
     assert_int_equal(1, list_length(key_store->keys));
 
     static const uint8_t keyid2[] = {0x7D, 0x0B, 0xC1, 0x0E, 0x93, 0x34, 0x04, 0xC9};
@@ -119,7 +119,7 @@ test_load_v4_keyring_pgp(void **state)
     assert_non_null(key_store);
 
     // load it in to the key store
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem, NULL));
     assert_int_equal(7, list_length(key_store->keys));
 
     // find the key by keyid
@@ -151,7 +151,7 @@ check_pgp_keyring_counts(const char *   path,
     assert_non_null(key_store);
 
     // load it in to the key store
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem));
+    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, 0, &mem, NULL));
 
     // count primary keys first
     unsigned total_primary_count = 0;

--- a/src/tests/pgp-parse-data.h
+++ b/src/tests/pgp-parse-data.h
@@ -215,6 +215,7 @@ static const pgp_content_enum tags_keyrings_1_pubring[] = {
   PGP_PARSER_PTAG,
   PGP_PTAG_CT_TRUST,
   PGP_PARSER_PACKET_END,
+  PGP_PARSER_DONE
 };
 
 #endif

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -147,6 +147,8 @@ void test_ffi_signatures_detached(void **state);
 
 void test_ffi_signatures(void **state);
 
+void test_ffi_encrypt_pk_key_provider(void **state);
+
 void test_ffi_key_to_json(void **state);
 
 void test_ffi_key_iter(void **state);

--- a/src/tests/streams.c
+++ b/src/tests/streams.c
@@ -117,7 +117,7 @@ test_stream_signatures(void **state)
     /* load secret key */
     secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/test_stream_signatures/sec.asc");
     assert_non_null(secring);
-    assert_true(rnp_key_store_load_from_file(&io, secring, true, pubring));
+    assert_true(rnp_key_store_load_from_file(&io, secring, true, NULL));
     seckey = rnp_key_store_get_key_by_id(&io, secring, keyid, NULL, NULL);
     assert_non_null(seckey);
     assert_true(pgp_is_key_secret(seckey));


### PR DESCRIPTION
The main thing here is changing how the key provider works in the FFI. This changes it to just be a signal to inform the application that it should load the key via the ffi methods.

I also changed key loading a bit to use the key provider where it seemed to make sense.
This allows, for example, loading a subkey for which the primary wasn't loaded yet. The G10 store also now uses the key provider to load the pubkey, instead of having that confusing pubring parameter in there.

(I did some last minute changes here so I'll probably want to review this myself tomorrow too.)