### PR TITLE
Fix G10 protected keys and also fix some static analysis issues

### DIFF
--- a/src/fuzzing/fuzz_keys.c
+++ b/src/fuzzing/fuzz_keys.c
@@ -5,7 +5,7 @@ int
 main(int argc, char *argv[])
 {
     rnp_t        rnp;
-    rnp_params_t params;
+    rnp_params_t params = {0};
 
     rnp_init(&rnp, &params);
     rnp_key_store_t *key_store = rnp_key_store_new(RNP_KEYSTORE_GPG, argv[1]);

--- a/src/lib/crypto.c
+++ b/src/lib/crypto.c
@@ -194,7 +194,7 @@ pgp_decrypt_decode_mpi(rng_t *             rng,
             return -1;
         }
 
-        if (!pgp_fingerprint(&fingerprint, &seckey->pubkey)) {
+        if (pgp_fingerprint(&fingerprint, &seckey->pubkey)) {
             RNP_LOG("ECDH fingerprint calculation failed");
             return -1;
         }

--- a/src/lib/fingerprint.c
+++ b/src/lib/fingerprint.c
@@ -126,9 +126,9 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_pubkey_t *key)
         }
     } else {
         RNP_LOG("unsupported key version");
-        return false;
+        return RNP_ERROR_NOT_SUPPORTED;
     }
-    return true;
+    return RNP_SUCCESS;
 }
 
 /**
@@ -148,22 +148,23 @@ pgp_keyid(uint8_t *keyid, const size_t idlen, const pgp_pubkey_t *key)
         if (key->alg != PGP_PKA_RSA && key->alg != PGP_PKA_RSA_ENCRYPT_ONLY &&
             key->alg != PGP_PKA_RSA_SIGN_ONLY) {
             RNP_LOG("bad algorithm");
-            return false;
+            return RNP_ERROR_NOT_SUPPORTED;
         }
 
         if (!bn_num_bytes(key->key.rsa.n, &n) || (n > sizeof(bn))) {
             RNP_LOG("Internal error: bignum too big");
-            return false;
+            return RNP_ERROR_BAD_FORMAT;
         }
         bn_bn2bin(key->key.rsa.n, bn);
         (void) memcpy(keyid, bn + n - idlen, idlen);
     } else {
         pgp_fingerprint_t finger;
 
-        if (!pgp_fingerprint(&finger, key)) {
-            return false;
+        rnp_result_t ret;
+        if ((ret = pgp_fingerprint(&finger, key))) {
+            return ret;
         }
         (void) memcpy(keyid, finger.fingerprint + finger.length - idlen, idlen);
     }
-    return true;
+    return RNP_SUCCESS;
 }

--- a/src/lib/generate-key.c
+++ b/src/lib/generate-key.c
@@ -84,7 +84,7 @@ load_generated_key(pgp_output_t **    output,
     // this would be better on the stack but the key store does not allow it
     key_store = calloc(1, sizeof(*key_store));
     if (!key_store) {
-        return false;
+        goto end;
     }
 
     // if this is a subkey, add the primary in first
@@ -425,8 +425,6 @@ end:
 
     if (output && mem) {
         pgp_teardown_memory_write(output, mem);
-        output = NULL;
-        mem = NULL;
     }
     // we don't need this as we have loaded the encrypted key
     // into primary_sec
@@ -570,6 +568,9 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
 
     ok = true;
 end:
+    if (output && mem) {
+        pgp_teardown_memory_write(output, mem);
+    }
     pgp_seckey_free(&seckey);
     if (decrypted_primary_seckey) {
         pgp_seckey_free(decrypted_primary_seckey);

--- a/src/lib/hash.c
+++ b/src/lib/hash.c
@@ -173,7 +173,7 @@ pgp_hash_create(pgp_hash_t *hash, pgp_hash_alg_t alg)
 
     rc = botan_hash_output_length(impl, &outlen);
     if (rc != 0) {
-        botan_hash_destroy(hash->handle);
+        botan_hash_destroy(impl);
         RNP_LOG("In pgp_hash_create, botan_hash_output_length failed");
         return false;
     }

--- a/src/lib/packet-create.c
+++ b/src/lib/packet-create.c
@@ -759,7 +759,7 @@ pgp_write_selfsig_cert(pgp_output_t *               output,
         return false;
     }
 
-    if (!pgp_keyid(keyid, sizeof(keyid), &seckey->pubkey)) {
+    if (pgp_keyid(keyid, sizeof(keyid), &seckey->pubkey)) {
         RNP_LOG("failed to calculate keyid");
         goto end;
     }
@@ -857,7 +857,7 @@ pgp_write_selfsig_binding(pgp_output_t *                  output,
         return false;
     }
 
-    if (!pgp_keyid(keyid, sizeof(keyid), &primary_sec->pubkey)) {
+    if (pgp_keyid(keyid, sizeof(keyid), &primary_sec->pubkey)) {
         RNP_LOG("failed to calculate keyid");
         goto end;
     }

--- a/src/lib/pass-provider.c
+++ b/src/lib/pass-provider.c
@@ -38,7 +38,8 @@ rnp_getpass(const char *prompt, char *buffer, size_t size)
     struct termios saved_flags, noecho_flags;
     bool           restore_ttyflags = false;
     bool           ok = false;
-    FILE *         in, *out;
+    FILE *         in = NULL;
+    FILE *         out = NULL;
 
     // validate args
     if (!buffer) {
@@ -74,6 +75,9 @@ rnp_getpass(const char *prompt, char *buffer, size_t size)
 end:
     if (restore_ttyflags) {
         tcsetattr(fileno(in), TCSAFLUSH, &saved_flags);
+    }
+    if (in != stdin) {
+        fclose(in);
     }
     return ok;
 }

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -125,8 +125,8 @@ pgp_key_from_keydata(pgp_key_t *key, pgp_keydata_key_t *keydata, const pgp_conte
     assert(!key->key.pubkey.version);
     assert(tag == PGP_PTAG_CT_PUBLIC_KEY || tag == PGP_PTAG_CT_PUBLIC_SUBKEY ||
            tag == PGP_PTAG_CT_SECRET_KEY || tag == PGP_PTAG_CT_SECRET_SUBKEY);
-    if (!pgp_keyid(key->keyid, PGP_KEY_ID_SIZE, &keydata->pubkey) ||
-        !pgp_fingerprint(&key->fingerprint, &keydata->pubkey) ||
+    if (pgp_keyid(key->keyid, PGP_KEY_ID_SIZE, &keydata->pubkey) ||
+        pgp_fingerprint(&key->fingerprint, &keydata->pubkey) ||
         !rnp_key_store_get_key_grip(&keydata->pubkey, key->grip)) {
         return false;
     }

--- a/src/lib/pgp-key.c
+++ b/src/lib/pgp-key.c
@@ -440,6 +440,12 @@ done:
     return decrypt.seckey;
 }
 
+/* Note that this function essentially serves two purposes.
+ * - In the case of a protected key, it requests a password and
+ *   uses it to decrypt the key and fill in key->key.seckey.
+ * - In the case of an unprotected key, it simply re-loads
+ *   key->key.seckey by parsing the key data in packets[0].
+ */
 pgp_seckey_t *
 pgp_decrypt_seckey(const pgp_key_t *              key,
                    const pgp_password_provider_t *provider,

--- a/src/lib/rnp.c
+++ b/src/lib/rnp.c
@@ -697,7 +697,10 @@ bool
 rnp_list_keys_json(rnp_t *rnp, char **json, const int psigs)
 {
     json_object *obj = json_object_new_array();
-    bool         ret;
+
+    if (!obj) {
+        return false;
+    }
     if (rnp->pubring == NULL) {
         (void) fprintf(stderr, "No keyring\n");
         return false;
@@ -707,10 +710,13 @@ rnp_list_keys_json(rnp_t *rnp, char **json, const int psigs)
         return false;
     }
     const char *j = json_object_to_json_string(obj);
-    ret = j != NULL;
+    if (!j) {
+        json_object_put(obj);
+        return false;
+    }
     *json = strdup(j);
     json_object_put(obj);
-    return ret;
+    return *json != NULL;
 }
 
 DEFINE_ARRAY(strings_t, char *);

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -1583,7 +1583,9 @@ rnp_op_encrypt_add_password(rnp_op_encrypt_t op,
         return RNP_ERROR_BAD_FORMAT;
     }
     // derive key, etc
-    ret = rnp_encrypt_set_pass_info(&info, password, hash_alg, iterations, symm_alg);
+    if ((ret = rnp_encrypt_set_pass_info(&info, password, hash_alg, iterations, symm_alg))) {
+        goto done;
+    }
     if (!list_append(&op->rnpctx.passwords, &info, sizeof(info))) {
         ret = RNP_ERROR_OUT_OF_MEMORY;
         goto done;

--- a/src/lib/rnp2.c
+++ b/src/lib/rnp2.c
@@ -4131,37 +4131,38 @@ rnp_identifier_iterator_create(rnp_ffi_t                  ffi,
                                const char *               identifier_type)
 {
     rnp_result_t ret = RNP_ERROR_GENERIC;
+    struct rnp_identifier_iterator_st *obj = NULL;
 
     // checks
     if (!ffi || !it || !identifier_type) {
         return RNP_ERROR_NULL_POINTER;
     }
     // create iterator
-    *it = calloc(1, sizeof(**it));
-    if (!*it) {
+    obj = calloc(1, sizeof(*obj));
+    if (!obj) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
-    (*it)->ffi = ffi;
+    obj->ffi = ffi;
     // parse identifier type
-    (*it)->type = PGP_KEY_SEARCH_UNKNOWN;
-    ARRAY_LOOKUP_BY_STRCASE(identifier_type_map, string, type, identifier_type, (*it)->type);
-    if ((*it)->type == PGP_KEY_SEARCH_UNKNOWN) {
+    obj->type = PGP_KEY_SEARCH_UNKNOWN;
+    ARRAY_LOOKUP_BY_STRCASE(identifier_type_map, string, type, identifier_type, obj->type);
+    if (obj->type == PGP_KEY_SEARCH_UNKNOWN) {
         ret = RNP_ERROR_BAD_FORMAT;
         goto done;
     }
-    (*it)->tbl = json_object_new_object();
-    if (!(*it)->tbl) {
+    obj->tbl = json_object_new_object();
+    if (!obj->tbl) {
         ret = RNP_ERROR_OUT_OF_MEMORY;
         goto done;
     }
     // move to first item (if any)
-    key_iter_first_item(*it);
+    key_iter_first_item(obj);
+    *it = obj;
 
     ret = RNP_SUCCESS;
 done:
     if (ret) {
-        rnp_identifier_iterator_destroy(*it);
-        *it = NULL;
+        rnp_identifier_iterator_destroy(obj);
     }
     return ret;
 }

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -386,6 +386,7 @@ read_bignum(s_exp_t *s_exp, const char *name)
                 name,
                 rnp_strhexdump_upper(
                   buf, var->sub_elements[1].block.bytes, var->sub_elements[1].block.len, ""));
+        free(buf);
     }
     return res;
 }

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -1070,6 +1070,9 @@ rnp_key_store_g10_from_mem(pgp_io_t *       io,
         goto done;
     }
     key.packets[0].raw = malloc(memory->length);
+    if (!key.packets[0].raw) {
+        goto done;
+    }
     key.packets[0].length = memory->length;
     memcpy(key.packets[0].raw, memory->buf, memory->length);
     key.packetc++;

--- a/src/librekey/key_store_g10.c
+++ b/src/librekey/key_store_g10.c
@@ -1063,6 +1063,7 @@ rnp_key_store_g10_from_mem(pgp_io_t *       io,
     if (!pgp_key_from_keydata(&key, &keydata, PGP_PTAG_CT_SECRET_KEY)) {
         goto done;
     }
+    // this data belongs to the key now
     keydata = (pgp_keydata_key_t){{0}};
     EXPAND_ARRAY((&key), packet);
     if (!key.packets) {
@@ -1073,7 +1074,7 @@ rnp_key_store_g10_from_mem(pgp_io_t *       io,
     memcpy(key.packets[0].raw, memory->buf, memory->length);
     key.packetc++;
     key.format = G10_KEY_STORE;
-    key.is_protected = keydata.seckey.encrypted;
+    key.is_protected = key.key.seckey.encrypted;
     if (!rnp_key_store_add_key(io, key_store, &key)) {
         goto done;
     }

--- a/src/librepgp/packet-print.c
+++ b/src/librepgp/packet-print.c
@@ -438,6 +438,7 @@ pgp_sprint_key(pgp_io_t *             io,
     ptimestr(creation, sizeof(creation), pubkey->creation);
 
     if (!format_key_usage(key_usage, sizeof(key_usage), key->key_flags)) {
+        free(uid_notices);
         return -1;
     }
 

--- a/src/librepgp/repgp.c
+++ b/src/librepgp/repgp.c
@@ -76,6 +76,7 @@ create_buffer_handle(const size_t buffer_size)
 
     s->buffer.data = (unsigned char *) malloc(buffer_size);
     if (!s->buffer.data) {
+        free(s);
         return NULL;
     }
 
@@ -95,6 +96,7 @@ create_data_handle(const uint8_t *data, size_t size)
 
     s->buffer.data = (unsigned char *) malloc(size);
     if (!s->buffer.data) {
+        free(s);
         return NULL;
     }
     memcpy(s->buffer.data, data, size);
@@ -131,6 +133,7 @@ create_stdin_handle(void)
         uint8_t *loc = realloc(data, newsize);
         if (loc == NULL) {
             RNP_LOG("Short read");
+            free(s);
             free(data);
             return NULL;
         }
@@ -141,6 +144,7 @@ create_stdin_handle(void)
 
     if (n < 0) {
         RNP_LOG("Error while reading from stdin [%s]", strerror(errno));
+        free(s);
         free(data);
         return NULL;
     }

--- a/src/librepgp/stream-common.c
+++ b/src/librepgp/stream-common.c
@@ -50,7 +50,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
     size_t              left = len;
     ssize_t             read;
     pgp_source_cache_t *cache = src->cache;
-    bool                readahead = cache->readahead;
+    bool                readahead = cache ? cache->readahead : false;
 
     if (src->eof || (len == 0)) {
         return 0;

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -1615,7 +1615,6 @@ stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig)
     } else {
         RNP_LOG("unknown signature version: %d", (int) ver);
         res = RNP_ERROR_BAD_FORMAT;
-        read = 0;
     }
 
     /* skipping the packet and returning error */

--- a/src/librepgp/stream-packet.c
+++ b/src/librepgp/stream-packet.c
@@ -620,7 +620,7 @@ stream_flush_packet_body(pgp_packet_body_t *body, pgp_dest_t *dst)
     hlen = 1 + write_packet_len(&hdr[1], body->len);
     dst_write(dst, hdr, hlen);
     dst_write(dst, body->data, body->len);
-    free(body->data);
+    free_packet_body(body);
 }
 
 rnp_result_t

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -1335,7 +1335,7 @@ encrypted_try_key(pgp_source_encrypted_param_t *param,
         bignum_t *ecdh_p;
 
         declen = sizeof(decbuf);
-        if (!pgp_fingerprint(&fingerprint, &seckey->pubkey)) {
+        if (pgp_fingerprint(&fingerprint, &seckey->pubkey)) {
             RNP_LOG("ECDH fingerprint calculation failed");
             return false;
         }

--- a/src/librepgp/stream-parse.c
+++ b/src/librepgp/stream-parse.c
@@ -1936,6 +1936,7 @@ init_encrypted_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *r
                    sizeof(keyctx.search.by.keyid));
             /* Get the key if any */
             if (!(seckey = pgp_request_key(ctx->handler.key_provider, &keyctx))) {
+                errcode = RNP_ERROR_NO_SUITABLE_KEY;
                 continue;
             }
             /* Decrypt key */
@@ -1945,6 +1946,7 @@ init_encrypted_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *r
                   ctx->handler.password_provider,
                   &(pgp_password_ctx_t){.op = PGP_OP_DECRYPT, .key = seckey});
                 if (!decrypted_seckey) {
+                    errcode = RNP_ERROR_BAD_PASSWORD;
                     continue;
                 }
             } else {
@@ -2001,7 +2003,9 @@ init_encrypted_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *r
 
     if (!have_key) {
         RNP_LOG("failed to obtain decrypting key or password");
-        errcode = RNP_ERROR_NO_SUITABLE_KEY;
+        if (!errcode) {
+            errcode = RNP_ERROR_NO_SUITABLE_KEY;
+        }
         goto finish;
     }
 

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -585,6 +585,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
         pkey.params.ecdh.mlen = outlen;
         if (!bn2mpi(p, &pkey.params.ecdh.p)) {
             ret = RNP_ERROR_BAD_STATE;
+            goto finish;
         }
         bn_free(p);
         break;

--- a/src/librepgp/stream-write.c
+++ b/src/librepgp/stream-write.c
@@ -504,9 +504,10 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
     /* Fill pkey */
     pkey.version = PGP_PKSK_V3;
     pkey.alg = pubkey->alg;
-    if (!pgp_keyid(pkey.key_id, PGP_KEY_ID_SIZE, pubkey)) {
+    rnp_result_t tmpret;
+    if ((tmpret = pgp_keyid(pkey.key_id, PGP_KEY_ID_SIZE, pubkey))) {
         RNP_LOG("key id calculation failed");
-        return RNP_ERROR_BAD_PARAMETERS;
+        return tmpret;
     }
 
     /* Encrypt the session key */
@@ -558,9 +559,8 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
         size_t            outlen = sizeof(pkey.params.ecdh.m);
         bignum_t *        p;
 
-        if (!pgp_fingerprint(&fingerprint, pubkey)) {
+        if ((ret = pgp_fingerprint(&fingerprint, pubkey))) {
             RNP_LOG("ECDH fingerprint calculation failed");
-            ret = RNP_ERROR_GENERIC;
             goto finish;
         }
         if (!(p = bn_new())) {

--- a/src/librepgp/validate.c
+++ b/src/librepgp/validate.c
@@ -489,6 +489,7 @@ pgp_validate_key_sigs(pgp_validation_t *     result,
     pgp_set_callback(stream, pgp_validate_key_cb, &keysigs);
     stream->readinfo.accumulate = 1;
     if (!pgp_key_reader_set(stream, key)) {
+        pgp_stream_delete(stream);
         return false;
     }
 

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -849,7 +849,7 @@ rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src)
         if (!rnp_cfg_val_copy(&val, &((rnp_cfg_item_t *) li)->val) ||
             !rnp_cfg_set(dst, ((rnp_cfg_item_t *) li)->key, &val)) {
             res = false;
-            return;
+            break;
         }
     }
 

--- a/src/rnp/rnpcfg.c
+++ b/src/rnp/rnpcfg.c
@@ -496,6 +496,7 @@ conffile(const char *homedir, char *userid, size_t length)
     (void) memset(&keyre, 0x0, sizeof(keyre));
     if (regcomp(&keyre, "^[ \t]*default-key[ \t]+([0-9a-zA-F]+)", REG_EXTENDED) != 0) {
         (void) fprintf(stderr, "conffile: failed to compile regular expression");
+        fclose(fp);
         return false;
     }
     while (fgets(buf, (int) sizeof(buf), fp) != NULL) {

--- a/src/rnpkeys/rnpkeys.c
+++ b/src/rnpkeys/rnpkeys.c
@@ -230,14 +230,16 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
             return false;
         }
         return rnp_generate_key(rnp);
-    case CMD_GET_KEY:
-        key = rnp_get_key(rnp, f, rnp_cfg_getstr(cfg, CFG_KEYFORMAT));
-        if (key) {
-            printf("%s", key);
+    case CMD_GET_KEY: {
+        char *keydesc = rnp_get_key(rnp, f, rnp_cfg_getstr(cfg, CFG_KEYFORMAT));
+        if (keydesc) {
+            printf("%s", keydesc);
+            free(keydesc);
             return true;
         }
         (void) fprintf(stderr, "key '%s' not found\n", f);
         return false;
+    }
     case CMD_TRUSTED_KEYS:
         return rnp_match_pubkeys(rnp, f, stdout);
     case CMD_HELP:

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -15,6 +15,7 @@ rnp_tests_SOURCES   = \
     utils-rnpcfg.c \
     pgp-parse.c \
     load-pgp.c \
+    load-g10.c \
     key-unlock.c \
     key-protect.c \
     key-add-userid.c \

--- a/src/tests/cipher.c
+++ b/src/tests/cipher.c
@@ -450,7 +450,7 @@ ecdh_roundtrip(void **state)
 
         pgp_fingerprint_t ecdh_key1_fpr;
         memset(&ecdh_key1_fpr, 0, sizeof(ecdh_key1_fpr));
-        rnp_assert_true(rstate, pgp_fingerprint(&ecdh_key1_fpr, &ecdh_key1.pubkey));
+        assert_rnp_success(pgp_fingerprint(&ecdh_key1_fpr, &ecdh_key1.pubkey));
 
         rnp_assert_int_equal(rstate,
                              pgp_ecdh_encrypt_pkcs5(&global_rng,
@@ -513,7 +513,7 @@ ecdh_decryptionNegativeCases(void **state)
 
     pgp_fingerprint_t ecdh_key1_fpr;
     memset(&ecdh_key1_fpr, 0, sizeof(ecdh_key1_fpr));
-    rnp_assert_true(rstate, pgp_fingerprint(&ecdh_key1_fpr, &ecdh_key1.pubkey));
+    assert_rnp_success(pgp_fingerprint(&ecdh_key1_fpr, &ecdh_key1.pubkey));
 
     rnp_assert_int_equal(rstate,
                          pgp_ecdh_encrypt_pkcs5(&global_rng,

--- a/src/tests/ffi.c
+++ b/src/tests/ffi.c
@@ -74,17 +74,19 @@ test_ffi_homedir(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, pub_path));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, sec_path));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     // free formats+paths
     rnp_buffer_destroy(pub_format);
-    rnp_buffer_destroy(pub_path);
-    rnp_buffer_destroy(sec_format);
-    rnp_buffer_destroy(sec_path);
     pub_format = NULL;
+    rnp_buffer_destroy(pub_path);
     pub_path = NULL;
+    rnp_buffer_destroy(sec_format);
     sec_format = NULL;
+    rnp_buffer_destroy(sec_path);
     sec_path = NULL;
     // check key counts
     size_t count = 0;
@@ -112,17 +114,19 @@ test_ffi_homedir(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, pub_path));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "KBX", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, sec_path));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "G10", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     // free formats+paths
     rnp_buffer_destroy(pub_format);
-    rnp_buffer_destroy(pub_path);
-    rnp_buffer_destroy(sec_format);
-    rnp_buffer_destroy(sec_path);
     pub_format = NULL;
+    rnp_buffer_destroy(pub_path);
     pub_path = NULL;
+    rnp_buffer_destroy(sec_format);
     sec_format = NULL;
+    rnp_buffer_destroy(sec_path);
     sec_path = NULL;
     // check key counts
     assert_int_equal(RNP_SUCCESS, rnp_get_public_key_count(ffi, &count));
@@ -140,9 +144,10 @@ test_ffi_homedir(void **state)
     assert_non_null(grip);
     assert_true(strcmp(grip, "63E59092E4B1AE9F8E675B2F98AA2B8BD9F4EA59") == 0);
     rnp_buffer_destroy(grip);
+    grip = NULL;
     rnp_key_handle_destroy(key);
-    // check grip (2)
     key = NULL;
+    // check grip (2)
     assert_int_equal(
       RNP_SUCCESS,
       rnp_locate_key(ffi, "grip", "7EAB41A2F46257C36F2892696F5A2F0432499AD3", &key));
@@ -152,6 +157,7 @@ test_ffi_homedir(void **state)
     assert_non_null(grip);
     assert_true(strcmp(grip, "7EAB41A2F46257C36F2892696F5A2F0432499AD3") == 0);
     rnp_buffer_destroy(grip);
+    grip = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_key_handle_destroy(key));
     key = NULL;
     // cleanup
@@ -593,6 +599,7 @@ tbl_getkeycb(rnp_ffi_t   ffi,
         assert_rnp_success(rnp_load_keys(ffi, format, input, flags));
         free(format);
         assert_rnp_success(rnp_input_destroy(input));
+        input = NULL;
     }
 }
 
@@ -672,6 +679,7 @@ test_ffi_keygen_json_pair(void **state)
     json_object *parsed_results = json_tokener_parse(results);
     assert_non_null(parsed_results);
     rnp_buffer_destroy(results);
+    results = NULL;
     // get a handle for the primary
     rnp_key_handle_t primary = NULL;
     {
@@ -746,6 +754,7 @@ test_ffi_keygen_json_primary(void **state)
     json_object *parsed_results = json_tokener_parse(results);
     assert_non_null(parsed_results);
     rnp_buffer_destroy(results);
+    results = NULL;
     // get a handle for the primary
     rnp_key_handle_t primary = NULL;
     {
@@ -809,6 +818,7 @@ test_ffi_keygen_json_sub(void **state)
     json_object *parsed_results = json_tokener_parse(results);
     assert_non_null(parsed_results);
     rnp_buffer_destroy(results);
+    results = NULL;
     // get a handle+grip for the primary
     rnp_key_handle_t primary = NULL;
     char *           primary_grip = NULL;
@@ -867,6 +877,7 @@ test_ffi_keygen_json_sub(void **state)
     parsed_results = json_tokener_parse(results);
     assert_non_null(parsed_results);
     rnp_buffer_destroy(results);
+    results = NULL;
     // get a handle for the sub
     rnp_key_handle_t sub = NULL;
     {
@@ -923,6 +934,7 @@ test_ffi_add_userid(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_generate_key_json(ffi, json, &results));
     assert_non_null(results);
     rnp_buffer_destroy(results);
+    results = NULL;
     free(json);
     json = NULL;
 
@@ -995,6 +1007,7 @@ test_ffi_keygen_json_sub_pass_required(void **state)
     json_object *parsed_results = json_tokener_parse(results);
     assert_non_null(parsed_results);
     rnp_buffer_destroy(results);
+    results = NULL;
     // get a handle+grip for the primary
     rnp_key_handle_t primary = NULL;
     char *           primary_grip = NULL;
@@ -1068,6 +1081,7 @@ test_ffi_keygen_json_sub_pass_required(void **state)
     parsed_results = json_tokener_parse(results);
     assert_non_null(parsed_results);
     rnp_buffer_destroy(results);
+    results = NULL;
     // get a handle for the sub
     rnp_key_handle_t sub = NULL;
     {
@@ -1117,9 +1131,11 @@ test_ffi_encrypt_pass(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/pubring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/secring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
@@ -1156,8 +1172,8 @@ test_ffi_encrypt_pass(void **state)
 
     // cleanup
     assert_int_equal(RNP_SUCCESS, rnp_input_destroy(input));
-    assert_int_equal(RNP_SUCCESS, rnp_output_destroy(output));
     input = NULL;
+    assert_int_equal(RNP_SUCCESS, rnp_output_destroy(output));
     output = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_destroy(op));
     op = NULL;
@@ -1173,8 +1189,8 @@ test_ffi_encrypt_pass(void **state)
     assert_int_not_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // decrypt (wrong pass, should fail)
@@ -1187,8 +1203,8 @@ test_ffi_encrypt_pass(void **state)
     assert_int_not_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // decrypt (pass1)
@@ -1200,7 +1216,9 @@ test_ffi_encrypt_pass(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
+    input = NULL;
     rnp_output_destroy(output);
+    output = NULL;
     // read in the decrypted file
     pgp_memory_t mem = {0};
     assert_true(pgp_mem_readfile(&mem, "decrypted"));
@@ -1220,7 +1238,9 @@ test_ffi_encrypt_pass(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
+    input = NULL;
     rnp_output_destroy(output);
+    output = NULL;
     // read in the decrypted file
     mem = (pgp_memory_t){0};
     assert_true(pgp_mem_readfile(&mem, "decrypted"));
@@ -1250,9 +1270,11 @@ test_ffi_encrypt_pk(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/pubring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/secring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
@@ -1272,9 +1294,11 @@ test_ffi_encrypt_pk(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "userid", "key0-uid2", &key));
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_add_recipient(op, key));
     rnp_key_handle_destroy(key);
+    key = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "userid", "key1-uid1", &key));
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_add_recipient(op, key));
     rnp_key_handle_destroy(key);
+    key = NULL;
     // set the data encryption cipher
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_set_cipher(op, "CAST5"));
     // execute the operation
@@ -1285,8 +1309,8 @@ test_ffi_encrypt_pk(void **state)
 
     // cleanup
     assert_int_equal(RNP_SUCCESS, rnp_input_destroy(input));
-    assert_int_equal(RNP_SUCCESS, rnp_output_destroy(output));
     input = NULL;
+    assert_int_equal(RNP_SUCCESS, rnp_output_destroy(output));
     output = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_destroy(op));
     op = NULL;
@@ -1302,8 +1326,8 @@ test_ffi_encrypt_pk(void **state)
     assert_int_not_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // decrypt (wrong pass, should fail)
@@ -1316,8 +1340,8 @@ test_ffi_encrypt_pk(void **state)
     assert_int_not_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // decrypt
@@ -1329,7 +1353,9 @@ test_ffi_encrypt_pk(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
+    input = NULL;
     rnp_output_destroy(output);
+    output = NULL;
     // read in the decrypted file
     pgp_memory_t mem = {0};
     assert_true(pgp_mem_readfile(&mem, "decrypted"));
@@ -1363,9 +1389,11 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/pubring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/secring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     // write out some data
     FILE *fp = fopen("plaintext", "w");
     assert_non_null(fp);
@@ -1385,8 +1413,8 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_add_recipient(op, key));
     // cleanup
     assert_int_equal(RNP_SUCCESS, rnp_key_handle_destroy(key));
-    // add recipient 2
     key = NULL;
+    // add recipient 2
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "userid", "key1-uid1", &key));
     assert_non_null(key);
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_add_recipient(op, key));
@@ -1395,8 +1423,8 @@ test_ffi_encrypt_pk_key_provider(void **state)
       RNP_SUCCESS, rnp_get_secret_key_data(key, &primary_sec_key_data, &primary_sec_size));
     assert_non_null(primary_sec_key_data);
     assert_int_equal(RNP_SUCCESS, rnp_key_handle_destroy(key));
-    // save the appropriate encrypting subkey for the key provider to use during decryption later
     key = NULL;
+    // save the appropriate encrypting subkey for the key provider to use during decryption later
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "keyid", "54505A936A4A970E", &key));
     assert_non_null(key);
     assert_int_equal(RNP_SUCCESS,
@@ -1404,6 +1432,7 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_non_null(sub_sec_key_data);
     // cleanup
     assert_int_equal(RNP_SUCCESS, rnp_key_handle_destroy(key));
+    key = NULL;
     // set the data encryption cipher
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_set_cipher(op, "CAST5"));
     // execute the operation
@@ -1412,8 +1441,8 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_true(rnp_file_exists("encrypted"));
     // cleanup
     assert_int_equal(RNP_SUCCESS, rnp_input_destroy(input));
-    assert_int_equal(RNP_SUCCESS, rnp_output_destroy(output));
     input = NULL;
+    assert_int_equal(RNP_SUCCESS, rnp_output_destroy(output));
     output = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_op_encrypt_destroy(op));
     op = NULL;
@@ -1428,6 +1457,7 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_non_null(input);
     assert_rnp_success(rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
 
     // decrypt (no key to decrypt, should fail)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "encrypted"));
@@ -1437,8 +1467,8 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_int_equal(RNP_ERROR_NO_SUITABLE_KEY, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // key_data key_data_size secret keyid grip userids
@@ -1456,7 +1486,9 @@ test_ffi_encrypt_pk_key_provider(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
+    input = NULL;
     rnp_output_destroy(output);
+    output = NULL;
     // read in the decrypted file
     pgp_memory_t mem = {0};
     assert_true(pgp_mem_readfile(&mem, "decrypted"));
@@ -1487,9 +1519,11 @@ test_ffi_encrypt_and_sign(void **state)
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/pubring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/secring.gpg"));
     assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
 
     // write out some data
     FILE *fp = fopen("plaintext", "w");
@@ -1509,9 +1543,11 @@ test_ffi_encrypt_and_sign(void **state)
     assert_rnp_success(rnp_locate_key(ffi, "userid", "key0-uid2", &key));
     assert_rnp_success(rnp_op_encrypt_add_recipient(op, key));
     rnp_key_handle_destroy(key);
+    key = NULL;
     assert_rnp_success(rnp_locate_key(ffi, "userid", "key1-uid1", &key));
     assert_rnp_success(rnp_op_encrypt_add_recipient(op, key));
     rnp_key_handle_destroy(key);
+    key = NULL;
     // set the data encryption cipher
     assert_rnp_success(rnp_op_encrypt_set_cipher(op, "CAST5"));
     // enable armoring
@@ -1525,6 +1561,7 @@ test_ffi_encrypt_and_sign(void **state)
     assert_rnp_success(rnp_locate_key(ffi, "userid", "key1-uid1", &key));
     assert_rnp_success(rnp_op_encrypt_add_signature(op, key, NULL));
     rnp_key_handle_destroy(key);
+    key = NULL;
     // execute the operation
     assert_rnp_success(rnp_ffi_set_pass_provider(ffi, getpasscb, "password"));
     assert_rnp_success(rnp_op_encrypt_execute(op));
@@ -1534,8 +1571,8 @@ test_ffi_encrypt_and_sign(void **state)
 
     // cleanup
     assert_rnp_success(rnp_input_destroy(input));
-    assert_rnp_success(rnp_output_destroy(output));
     input = NULL;
+    assert_rnp_success(rnp_output_destroy(output));
     output = NULL;
     assert_rnp_success(rnp_op_encrypt_destroy(op));
     op = NULL;
@@ -1551,8 +1588,8 @@ test_ffi_encrypt_and_sign(void **state)
     assert_rnp_failure(rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // decrypt (wrong pass, should fail)
@@ -1565,8 +1602,8 @@ test_ffi_encrypt_and_sign(void **state)
     assert_rnp_failure(rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
-    rnp_output_destroy(output);
     input = NULL;
+    rnp_output_destroy(output);
     output = NULL;
 
     // decrypt
@@ -1578,7 +1615,9 @@ test_ffi_encrypt_and_sign(void **state)
     assert_rnp_success(rnp_decrypt(ffi, input, output));
     // cleanup
     rnp_input_destroy(input);
+    input = NULL;
     rnp_output_destroy(output);
+    output = NULL;
     // read in the decrypted file
     pgp_memory_t mem = {0};
     assert_true(pgp_mem_readfile(&mem, "decrypted"));
@@ -1615,10 +1654,13 @@ test_ffi_encrypt_and_sign(void **state)
     assert_rnp_success(rnp_op_verify_signature_get_hash(sig, &hname));
     assert_string_equal(hname, "SHA256");
     rnp_buffer_destroy(hname);
+    hname = NULL;
     // cleanup
     rnp_op_verify_destroy(verify);
     rnp_input_destroy(input);
+    input = NULL;
     rnp_output_destroy(output);
+    output = NULL;
     // read in the decrypted file
     assert_true(pgp_mem_readfile(&mem, "verified"));
     // compare
@@ -1643,10 +1685,12 @@ test_ffi_init(void **state, rnp_ffi_t *ffi)
     assert_int_equal(RNP_SUCCESS,
                      rnp_load_keys(*ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/secring.gpg"));
     assert_int_equal(RNP_SUCCESS,
                      rnp_load_keys(*ffi, "GPG", input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
 }
 
 static void
@@ -1808,10 +1852,10 @@ test_ffi_signatures_memory(void **state)
 
     // cleanup
     assert_rnp_success(rnp_input_destroy(input));
-    assert_rnp_success(rnp_output_destroy(output));
-    assert_rnp_success(rnp_op_sign_destroy(op));
     input = NULL;
+    assert_rnp_success(rnp_output_destroy(output));
     output = NULL;
+    assert_rnp_success(rnp_op_sign_destroy(op));
     op = NULL;
 
     /* now verify */
@@ -1830,7 +1874,9 @@ test_ffi_signatures_memory(void **state)
     // cleanup
     assert_rnp_success(rnp_op_verify_destroy(verify));
     assert_rnp_success(rnp_input_destroy(input));
+    input = NULL;
     assert_rnp_success(rnp_output_destroy(output));
+    output = NULL;
     assert_rnp_success(rnp_ffi_destroy(ffi));
     rnp_buffer_destroy(signed_buf);
     rnp_buffer_destroy(verified_buf);
@@ -1860,10 +1906,10 @@ test_ffi_signatures(void **state)
 
     // cleanup
     assert_rnp_success(rnp_input_destroy(input));
-    assert_rnp_success(rnp_output_destroy(output));
-    assert_rnp_success(rnp_op_sign_destroy(op));
     input = NULL;
+    assert_rnp_success(rnp_output_destroy(output));
     output = NULL;
+    assert_rnp_success(rnp_op_sign_destroy(op));
     op = NULL;
 
     /* now verify */
@@ -1878,7 +1924,9 @@ test_ffi_signatures(void **state)
     // cleanup
     assert_rnp_success(rnp_op_verify_destroy(verify));
     assert_rnp_success(rnp_input_destroy(input));
+    input = NULL;
     assert_rnp_success(rnp_output_destroy(output));
+    output = NULL;
     assert_rnp_success(rnp_ffi_destroy(ffi));
     // check output
     test_ffi_check_recovered(state);
@@ -1912,10 +1960,10 @@ test_ffi_signatures_detached_memory(void **state)
 
     // cleanup
     assert_rnp_success(rnp_input_destroy(input));
-    assert_rnp_success(rnp_output_destroy(output));
-    assert_rnp_success(rnp_op_sign_destroy(op));
     input = NULL;
+    assert_rnp_success(rnp_output_destroy(output));
     output = NULL;
+    assert_rnp_success(rnp_op_sign_destroy(op));
     op = NULL;
 
     /* now verify */
@@ -1933,7 +1981,9 @@ test_ffi_signatures_detached_memory(void **state)
     rnp_buffer_destroy(signed_buf);
     assert_rnp_success(rnp_op_verify_destroy(verify));
     assert_rnp_success(rnp_input_destroy(input));
+    input = NULL;
     assert_rnp_success(rnp_input_destroy(signature));
+    signature = NULL;
     assert_rnp_success(rnp_ffi_destroy(ffi));
 }
 
@@ -1962,10 +2012,10 @@ test_ffi_signatures_detached(void **state)
 
     // cleanup
     assert_rnp_success(rnp_input_destroy(input));
-    assert_rnp_success(rnp_output_destroy(output));
-    assert_rnp_success(rnp_op_sign_destroy(op));
     input = NULL;
+    assert_rnp_success(rnp_output_destroy(output));
     output = NULL;
+    assert_rnp_success(rnp_op_sign_destroy(op));
     op = NULL;
 
     /* now verify */
@@ -1980,7 +2030,9 @@ test_ffi_signatures_detached(void **state)
     // cleanup
     assert_rnp_success(rnp_op_verify_destroy(verify));
     assert_rnp_success(rnp_input_destroy(input));
+    input = NULL;
     assert_rnp_success(rnp_input_destroy(signature));
+    signature = NULL;
     assert_rnp_success(rnp_ffi_destroy(ffi));
 }
 
@@ -2050,15 +2102,21 @@ test_ffi_key_to_json(void **state)
     assert_int_equal(RNP_SUCCESS,
                      rnp_load_keys(ffi, pub_format, input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, sec_path));
     assert_int_equal(RNP_SUCCESS,
                      rnp_load_keys(ffi, sec_format, input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     // free formats+paths
     rnp_buffer_destroy(pub_format);
+    pub_format = NULL;
     rnp_buffer_destroy(pub_path);
+    pub_path = NULL;
     rnp_buffer_destroy(sec_format);
+    sec_format = NULL;
     rnp_buffer_destroy(sec_path);
+    sec_path = NULL;
 
     // locate key (primary)
     key = NULL;
@@ -2133,14 +2191,14 @@ test_ffi_key_to_json(void **state)
     // cleanup
     json_object_put(jso);
     rnp_key_handle_destroy(key);
+    key = NULL;
     rnp_buffer_destroy(json);
+    json = NULL;
 
     // locate key (sub)
-    key = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_locate_key(ffi, "keyid", "074131BC8D16C5C9", &key));
     assert_non_null(key);
     // convert to JSON
-    json = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_key_to_json(key, 0xff, &json));
     assert_non_null(json);
     // parse it back in
@@ -2305,15 +2363,21 @@ test_ffi_key_iter(void **state)
     assert_int_equal(RNP_SUCCESS,
                      rnp_load_keys(ffi, pub_format, input, RNP_LOAD_SAVE_PUBLIC_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, sec_path));
     assert_int_equal(RNP_SUCCESS,
                      rnp_load_keys(ffi, sec_format, input, RNP_LOAD_SAVE_SECRET_KEYS));
     rnp_input_destroy(input);
+    input = NULL;
     // free formats+paths
     rnp_buffer_destroy(pub_format);
+    pub_format = NULL;
     rnp_buffer_destroy(pub_path);
+    pub_path = NULL;
     rnp_buffer_destroy(sec_format);
+    sec_format = NULL;
     rnp_buffer_destroy(sec_path);
+    sec_path = NULL;
 
     // keyid
     {

--- a/src/tests/generatekey.c
+++ b/src/tests/generatekey.c
@@ -551,6 +551,9 @@ ask_expert_details(rnp_t *ctx, rnp_cfg_t *ops, const char *rsp, size_t rsp_len)
     bool      ret = true;
     rnp_cfg_t cfg = {0};
     int       pipefd[2] = {0};
+    int       user_input_pipefd[2] = {0};
+
+    *ctx = (rnp_t){0};
     if (pipe(pipefd) == -1) {
         ret = false;
         goto end;
@@ -560,8 +563,6 @@ ask_expert_details(rnp_t *ctx, rnp_cfg_t *ops, const char *rsp, size_t rsp_len)
     if (!rnpkeys_init(&cfg, ctx, ops, true)) {
         return false;
     }
-
-    int user_input_pipefd[2] = {0};
 
     /* Write response to fd */
     if (pipe(user_input_pipefd) == -1) {

--- a/src/tests/load-g10.c
+++ b/src/tests/load-g10.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../librekey/key_store_pgp.h"
+#include "pgp-key.h"
+
+#include "rnp_tests.h"
+#include "support.h"
+
+/* This test loads G10 keyrings and verifies certain properties
+ * of the keys are correct.
+ */
+void
+test_load_g10(void **state)
+{
+    pgp_io_t         io = {.errs = stderr, .res = stdout, .outs = stdout};
+    uint8_t          keyid[PGP_KEY_ID_SIZE];
+    const pgp_key_t *key;
+
+    // load pubring
+    rnp_key_store_t *pub_store = rnp_key_store_new("KBX", "data/keyrings/3/pubring.kbx");
+    assert_non_null(pub_store);
+    assert_true(rnp_key_store_load_from_file(&io, pub_store, 0, NULL));
+    // load secring
+    rnp_key_store_t *sec_store = rnp_key_store_new("G10", "data/keyrings/3/private-keys-v1.d");
+    assert_non_null(sec_store);
+    pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store, .userdata = pub_store};
+    assert_true(rnp_key_store_load_from_file(&io, sec_store, 0, &key_provider));
+
+    // find (primary)
+    key = NULL;
+    assert_true(rnp_hex_decode("4BE147BB22DF1E60", keyid, sizeof(keyid)));
+    key = rnp_key_store_get_key_by_id(&io, sec_store, keyid, NULL, NULL);
+    assert_non_null(key);
+    // check properties
+    assert_true(key->is_protected);
+
+    // find (sub)
+    key = NULL;
+    assert_true(rnp_hex_decode("A49BAE05C16E8BC8", keyid, sizeof(keyid)));
+    key = rnp_key_store_get_key_by_id(&io, sec_store, keyid, NULL, NULL);
+    assert_non_null(key);
+    // check properties
+    assert_true(key->is_protected);
+
+    // cleanup
+    rnp_key_store_free(pub_store);
+    rnp_key_store_free(sec_store);
+}

--- a/src/tests/rnp_tests.c
+++ b/src/tests/rnp_tests.c
@@ -175,6 +175,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_load_keyring_and_count_pgp),
       cmocka_unit_test(test_load_check_bitfields_and_times),
       cmocka_unit_test(test_load_check_bitfields_and_times_v3),
+      cmocka_unit_test(test_load_g10),
       cmocka_unit_test(test_key_unlock_pgp),
       cmocka_unit_test(test_key_protect_load_pgp),
       cmocka_unit_test(test_key_add_userid),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -97,6 +97,8 @@ void test_load_check_bitfields_and_times(void **state);
 
 void test_load_check_bitfields_and_times_v3(void **state);
 
+void test_load_g10(void **state);
+
 void test_key_unlock_pgp(void **state);
 
 void test_key_protect_load_pgp(void **state);


### PR DESCRIPTION
* Fixed a regression in G10 protected keys.
* (Hopefully) Fixed a bunch of issues reported by Coverity (which is working again).
* Fixed some other issues reported by clang's static analyzer.
* Fixed some issues with `pgp_keyid` and `pgp_fingerprint` (note that these can no longer be treated as if they return bool).