### PR TITLE
docs: Add missing step for release workflow.

### DIFF
--- a/doc/RELEASE-WORKFLOW.md
+++ b/doc/RELEASE-WORKFLOW.md
@@ -14,11 +14,15 @@ version (and x is a literal -- not a placeholder).
 git checkout -b release/v1.x master
 ```
 
-## Create a CHANGELOG.md
+## Create a CHANGELOG.md and version.txt
 
 ```
 vim CHANGELOG.md
 git add CHANGELOG.md
+
+git describe --long --dirty > version.txt
+git add version.txt
+
 git commit
 ```
 

--- a/doc/RELEASE-WORKFLOW.md
+++ b/doc/RELEASE-WORKFLOW.md
@@ -7,11 +7,11 @@
   Some steps would be omitted for minor releases.
 
 ## Create the Branch
-Release branches have names of the form `release/vN.x`, where N is the major
+Release branches have names of the form `release/N.x`, where N is the major
 version (and x is a literal -- not a placeholder).
 
 ```
-git checkout -b release/v1.x master
+git checkout -b release/1.x master
 ```
 
 ## Create a CHANGELOG.md and version.txt
@@ -38,7 +38,7 @@ git tag -a v1.0.0 -m ''
 
 ```
 # push the branch
-git push origin release/v1.x
+git push origin release/1.x
 
 # push the tag
 git push origin :v1.0.0


### PR DESCRIPTION
This step is important to ensure github/`git archive` tarballs are buildable.

I failed to do this for the initial release so we should discuss how to fix that. My thought is to simply amend the commit and move the tag in the release branch, since it's the release itself that is the problem and the code is not changing (so a version bump would be a bit misleading).