### PR TITLE
CMake: Fix library versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@
 # 3.7+ for the BZip2 target in the cmake-bundled finder
 cmake_minimum_required(VERSION 3.7)
 
+# contact email, other info
+include(cmake/info.cmake)
+
 # determine version
 include(cmake/version.cmake)
 determine_version("${CMAKE_CURRENT_SOURCE_DIR}" RNP)
@@ -39,9 +42,6 @@ project(RNP
 # options
 option(ENABLE_COVERAGE "Enable code coverage testing.")
 option(ENABLE_SANITIZERS "Enable ASan and other sanitizers.")
-
-# contact email, other info
-include(cmake/info.cmake)
 
 # so we can use our bundled finders
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake/Modules")

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -68,10 +68,6 @@ function(determine_version source_dir var_prefix)
   if (IS_DIRECTORY "${source_dir}/.git/")
     # for GIT_EXECUTABLE
     find_package(Git REQUIRED)
-    # this should really only be in snapshots
-    if (EXISTS "${source_dir}/version.txt")
-      message(AUTHOR_WARNING "version.txt should not exist in the repository.")
-    endif()
     # get a description of the version, something like:
     #   v1.9.1-0-g38ffe82        (a tagged release)
     #   v1.9.1-0-g38ffe82-dirty  (a tagged release with local modifications)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -135,8 +135,8 @@ add_library(librnp
 
 set_target_properties(librnp
   PROPERTIES
-    VERSION "${VERSION}"
-    SOVERSION 0
+    VERSION "${RNP_VERSION}"
+    SOVERSION "${RNP_VERSION_MAJOR}"
     PREFIX ""
 )
 


### PR DESCRIPTION
Apparently I made some last-minute changes and broke this.
This is broken in our tagged release too :( so currently an RPM of 0.9.0 will have libs like:
```
/usr/lib64/librnp.so
/usr/lib64/librnp.so.
/usr/lib64/librnp.so.0
```

After this change, we are back to normal:
```
/usr/lib64/librnp.so
/usr/lib64/librnp.so.0
/usr/lib64/librnp.so.0.9.0
```