### PR TITLE
ci: Fail with uninitialized and unused CMake vars.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_definitions(-D_GNU_SOURCE)
 
 if (ENABLE_COVERAGE OR ENABLE_SANITIZERS)
-  message(WARNING "Forcing build type to Debug (for code coverage or sanitizers).")
+  message("Forcing build type to Debug (for code coverage or sanitizers).")
   set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type. Forced to Debug." FORCE)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ option(ENABLE_COVERAGE "Enable code coverage testing.")
 option(ENABLE_SANITIZERS "Enable ASan and other sanitizers.")
 
 # so we can use our bundled finders
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake/Modules")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")
 
 # required modules
 include(CTest)

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -6,6 +6,13 @@ set -eux
 : "${CORES:=2}"
 : "${RNP_TESTS:=all}"
 
+# check for use of uninitialized or unused vars in CMake
+function cmake {
+  log=$(mktemp)
+  command cmake --warn-uninitialized --warn-unused "$@" 2>&1 | tee "$log"
+  if grep -Fqi 'cmake warning' "$log"; then exit 1; fi
+}
+
 cmakeopts=(
   "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
   "-DBUILD_SHARED_LIBS=yes"


### PR DESCRIPTION
This only tests the cmake code paths used in travis, so it's far from foolproof but it's better than nothing.