### PR TITLE
Fix signing/encryption with default key

### DIFF
--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -828,7 +828,7 @@ parse_option(rnp_cfg_t *cfg, const char *s)
 }
 
 int
-#ifndef RNP_TESTS
+#ifndef RNP_RUN_TESTS
 main(int argc, char **argv)
 #else
 rnp_main(int argc, char **argv)

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -347,6 +347,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
 
             list signers = NULL;
             if (!rnp_cfg_copylist_str(cfg, &signers, CFG_SIGNERS)) {
+                fprintf(stderr, "Failed to copy signers list\n");
                 return false;
             }
             for (list_item *signer = list_front(signers); signer; signer = list_next(signer)) {
@@ -412,6 +413,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
             if (rnp_cfg_getbool(cfg, CFG_ENCRYPT_PK)) {
                 list recipients = NULL;
                 if (!rnp_cfg_copylist_str(cfg, &recipients, CFG_RECIPIENTS)) {
+                    fprintf(stderr, "Failed to copy recipients list\n");
                     return false;
                 }
                 for (list_item *recipient = list_front(recipients); recipient;
@@ -426,6 +428,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                         return false;
                     }
                     if (!list_append(&ctx->recipients, &key, sizeof(key))) {
+                        fprintf(stderr, "Failed to add key to recipient list\n");
                         list_destroy(&recipients);
                         return false;
                     }

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -397,7 +397,12 @@ rnp_cfg_copylist_str(rnp_cfg_t *cfg, list *dst, const char *key)
 {
     rnp_cfg_item_t *it = rnp_cfg_find(cfg, key);
 
-    if (!it || (it->val.type != RNP_CFG_VAL_LIST)) {
+    if (!it) {
+        /* copy empty list is okay */
+        return true;
+    }
+
+    if (it->val.type != RNP_CFG_VAL_LIST) {
         goto fail;
     }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -28,9 +28,11 @@ find_package(JSON-C 0.11 REQUIRED)
 
 add_executable(rnp_tests
   ../rnp/rnpcfg.cpp
+  ../rnp/rnp.cpp
   ../rnpkeys/rnpkeys.cpp
   ../rnpkeys/tui.cpp
   cipher.cpp
+  cli.cpp
   exportkey.cpp
   ffi.cpp
   generatekey.cpp
@@ -60,6 +62,11 @@ target_link_libraries(rnp_tests
     librnp
     JSON-C::JSON-C
     cmocka::cmocka
+)
+
+target_compile_definitions(rnp_tests
+  PRIVATE
+    RNP_RUN_TESTS
 )
 
 # fixture to copy the test data directory

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rnp_tests.h"
+#include "support.h"
+#include "utils.h"
+
+int rnp_main(int argc, char **argv);
+
+int
+call_rnp(const char *cmd, ...)
+{
+    int     argc = 0;
+    int     res;
+    char ** argv = (char **) calloc(32, sizeof(char *));
+    va_list args;
+    va_start(args, cmd);
+    while (cmd) {
+        argv[argc++] = (char *) cmd;
+        cmd = va_arg(args, char *);
+    }
+    va_end(args);
+    /* reset state of getopt_long used in rnp */
+    optind = 1;
+
+    res = rnp_main(argc, argv);
+    free(argv);
+
+    return res;
+}
+
+#define KEYS "data/keyrings"
+#define FILES "data/test_cli"
+
+void
+test_cli_rnp(void **state)
+{
+    int ret;
+    assert_int_equal(0, call_rnp("rnp", "--version", NULL));
+
+    /* sign with default key */
+    ret = call_rnp("rnp",
+                   "--homedir",
+                   KEYS "/1",
+                   "--password",
+                   "password",
+                   "--sign",
+                   FILES "/hello.txt",
+                   NULL);
+    assert_int_equal(ret, 0);
+
+    /* encrypt with default key */
+    ret = call_rnp(
+      "rnp", "--homedir", KEYS "/1", "--encrypt", FILES "/hello.txt", "--overwrite", NULL);
+    assert_int_equal(ret, 0);
+}

--- a/src/tests/data/test_cli/hello.txt
+++ b/src/tests/data/test_cli/hello.txt
@@ -1,0 +1,2 @@
+Hello world!
+This is a sample file to use for signing.

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -203,6 +203,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_save_keys),
       cmocka_unit_test(test_ffi_key_to_json),
       cmocka_unit_test(test_ffi_key_iter),
+      cmocka_unit_test(test_cli_rnp),
     };
 
     /* Each test entry will invoke setup_test before running

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -179,6 +179,8 @@ void test_stream_verify_no_key(void **state);
 
 void test_stream_key_signature_validate(void **state);
 
+void test_cli_rnp(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \


### PR DESCRIPTION
Recently signing/encryption with not specified signer/recipient was broken so this PR fixes it.
Also, in order to cover updated code, I added cmocka CLI test and some overhead to allow call rnp.cpp:main from the rnp_tests.
It uses define `RNP_TESTS`, which is set in `CMakeLists.txt` for `rnp_tests` target.
@dewyatt , @ronaldtse what do you think about such approach?
It would allow to add more tests later on and improve coverage and static analysis on rnp/rnpkeys

Fixes #682 