### PR TITLE
Add issuer fingerprint to certifications and subkey bindings.

### DIFF
--- a/src/lib/fingerprint.cpp
+++ b/src/lib/fingerprint.cpp
@@ -152,3 +152,9 @@ pgp_keyid(uint8_t *keyid, const size_t idlen, const pgp_key_pkt_t *key)
     (void) memcpy(keyid, fp.fingerprint + fp.length - idlen, idlen);
     return RNP_SUCCESS;
 }
+
+bool
+fingerprint_equal(pgp_fingerprint_t *fp1, pgp_fingerprint_t *fp2)
+{
+    return (fp1->length == fp2->length) && (!memcmp(fp1->fingerprint, fp2->fingerprint, fp1->length));
+}

--- a/src/lib/fingerprint.h
+++ b/src/lib/fingerprint.h
@@ -39,4 +39,6 @@ rnp_result_t pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_key_pkt_t *key);
 
 rnp_result_t pgp_keyid(uint8_t *out, const size_t len, const pgp_key_pkt_t *key);
 
+bool fingerprint_equal(pgp_fingerprint_t *fp1, pgp_fingerprint_t *fp2);
+
 #endif


### PR DESCRIPTION
This PR adds issuer fingerprint subpacket to certifications and subkey bindings.
Also it extends tests with some more sig subpacket checks.

Fixes #513 