### PR TITLE
Fix rnp_op_add_signature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - GPG_INSTALL="${LOCAL_BUILDS}/gpg-install"
     - RNP_INSTALL="${LOCAL_BUILDS}/rnp-install"
     - RUBY_RNP_INSTALL="${LOCAL_BUILDS}/ruby-rnp"
-    - RUBY_RNP_VERSION="v1.0.0"
+    - RUBY_RNP_VERSION="master"
     - LOGNAME="Travis"
     - CLANG_FORMAT_DIFF="clang-format-diff-4.0"
 


### PR DESCRIPTION
This fixes the issue in https://github.com/riboseinc/enmail/issues/53#issuecomment-403798923 and is basically what I meant in https://github.com/riboseinc/rnp/issues/496.

The reason we never encountered this issue before is because it only affects G10 secrings and we don't have any tests using `rnp_op_add_signature` in that case (I'll work on adding that too, but wanted to get this fix in).