### PR TITLE
Fix usage of g10 secret keys and corresponding tests.

### DIFF
--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -559,6 +559,7 @@ decrypt_protected_section(const uint8_t *      encrypted_data,
         goto done;
     }
     decrypted_data_len = output_written;
+    s_exp_len = decrypted_data_len;
     decrypted_bytes = (const char *) decrypted_data;
     if (rnp_get_debug(__FILE__)) {
         hexdump(stderr, "decrypted data", decrypted_data, decrypted_data_len);
@@ -955,10 +956,10 @@ g10_decrypt_seckey(const uint8_t *      data,
     }
 
     seckey = (pgp_key_pkt_t *) calloc(1, sizeof(*seckey));
-    if (!g10_parse_seckey(&io, seckey, data, data_len, password, NULL)) {
+    if (pubkey && !copy_key_pkt(seckey, pubkey, false)) {
         goto done;
     }
-    if (pubkey && !copy_key_pkt(seckey, pubkey, false)) {
+    if (!g10_parse_seckey(&io, seckey, data, data_len, password, NULL)) {
         goto done;
     }
     ok = true;

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -76,4 +76,41 @@ test_cli_rnp(void **state)
     ret = call_rnp(
       "rnp", "--homedir", KEYS "/1", "--encrypt", FILES "/hello.txt", "--overwrite", NULL);
     assert_int_equal(ret, 0);
+
+    /* sign and verify back with g10 key */
+    ret = call_rnp("rnp",
+                   "--homedir",
+                   KEYS "/3",
+                   "-u",
+                   "4BE147BB22DF1E60",
+                   "--password",
+                   "password",
+                   "--sign",
+                   FILES "/hello.txt",
+                   "--overwrite",
+                   NULL);
+    assert_int_equal(ret, 0);
+    ret = call_rnp("rnp", "--homedir", KEYS "/3", "--verify", FILES "/hello.txt.pgp", NULL);
+    assert_int_equal(ret, 0);
+
+    /* encrypt and decrypt back with g10 key */
+    ret = call_rnp("rnp",
+                   "--homedir",
+                   KEYS "/3",
+                   "-r",
+                   "4BE147BB22DF1E60",
+                   "--encrypt",
+                   FILES "/hello.txt",
+                   "--overwrite",
+                   NULL);
+    assert_int_equal(ret, 0);
+    ret = call_rnp("rnp",
+                   "--homedir",
+                   KEYS "/3",
+                   "--password",
+                   "password",
+                   "--decrypt",
+                   FILES "/hello.txt.pgp",
+                   NULL);
+    assert_int_equal(ret, 0);
 }


### PR DESCRIPTION
This is mostly @dewyatt's fixes from https://github.com/riboseinc/rnp/issues/715#issuecomment-405060732 within addition of cli cmocka test for the g10 secret keys usage.

Fixes #715 