### PR TITLE
Add primary key binding embedded signature

### DIFF
--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -191,6 +191,26 @@ typedef struct pgp_userid_pkt_t {
     size_t   uid_len;
 } pgp_userid_pkt_t;
 
+typedef struct pgp_signature_t {
+    pgp_version_t version;
+    /* common v3 and v4 fields */
+    pgp_sig_type_t   type;
+    pgp_pubkey_alg_t palg;
+    pgp_hash_alg_t   halg;
+    uint8_t          lbits[2];
+    uint8_t *        hashed_data;
+    size_t           hashed_len;
+
+    pgp_signature_material_t material;
+
+    /* v3 - only fields */
+    uint32_t creation_time;
+    uint8_t  signer[PGP_KEY_ID_SIZE];
+
+    /* v4 - only fields */
+    list subpkts;
+} pgp_signature_t;
+
 /* Signature subpacket, see 5.2.3.1 in RFC 4880 and RFC 4880 bis 02 */
 typedef struct pgp_sig_subpkt_t {
     pgp_sig_subpacket_type_t type;         /* type of the subpacket */
@@ -264,34 +284,15 @@ typedef struct pgp_sig_subpkt_t {
             pgp_hash_alg_t   halg;
             uint8_t *        hash;
             unsigned         hlen;
-        } sig_target; /* 5.2.3.25.  Signature Target */
+        } sig_target;        /* 5.2.3.25.  Signature Target */
+        pgp_signature_t sig; /* 5.2.3.27. Embedded Signature */
         struct {
             uint8_t  version;
             uint8_t *fp;
             unsigned len;
-        } issuer_fp; /* 5.2.3.27.  Issuer Fingerprint, RFC 4880 bis 02 */
+        } issuer_fp; /* 5.2.3.28.  Issuer Fingerprint, RFC 4880 bis 04 */
     } fields;        /* parsed contents of the subpacket */
 } pgp_sig_subpkt_t;
-
-typedef struct pgp_signature_t {
-    pgp_version_t version;
-    /* common v3 and v4 fields */
-    pgp_sig_type_t   type;
-    pgp_pubkey_alg_t palg;
-    pgp_hash_alg_t   halg;
-    uint8_t          lbits[2];
-    uint8_t *        hashed_data;
-    size_t           hashed_len;
-
-    pgp_signature_material_t material;
-
-    /* v3 - only fields */
-    uint32_t creation_time;
-    uint8_t  signer[PGP_KEY_ID_SIZE];
-
-    /* v4 - only fields */
-    list subpkts;
-} pgp_signature_t;
 
 /** pgp_rawpacket_t */
 typedef struct pgp_rawpacket_t {

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -297,12 +297,12 @@ transferable_subkey_bind(const pgp_key_pkt_t *             key,
                          pgp_hash_alg_t                    hash_alg,
                          const rnp_selfsig_binding_info_t *binding)
 {
-    pgp_signature_t  sig = {};
-    pgp_signature_t *res = NULL;
-    pgp_hash_t       hash = {};
-    uint8_t          keyid[PGP_KEY_ID_SIZE];
+    pgp_signature_t   sig = {};
+    pgp_signature_t * res = NULL;
+    pgp_hash_t        hash = {};
+    uint8_t           keyid[PGP_KEY_ID_SIZE];
     pgp_fingerprint_t keyfp;
-    rng_t            rng = {};
+    rng_t             rng = {};
 
     if (!key || !subkey || !binding) {
         RNP_LOG("invalid parameters");

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -255,6 +255,8 @@ bool stream_write_signature(pgp_signature_t *sig, pgp_dest_t *dst);
 
 bool signature_parse_subpacket(pgp_sig_subpkt_t *subpkt);
 
+rnp_result_t stream_parse_signature_body(pgp_packet_body_t *pkt, pgp_signature_t *sig);
+
 rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
 
 bool copy_signature_packet(pgp_signature_t *dst, const pgp_signature_t *src);

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -261,6 +261,8 @@ rnp_result_t stream_parse_signature(pgp_source_t *src, pgp_signature_t *sig);
 
 bool copy_signature_packet(pgp_signature_t *dst, const pgp_signature_t *src);
 
+void free_signature_subpkt(pgp_sig_subpkt_t *subpkt);
+
 void free_signature(pgp_signature_t *sig);
 
 /* Public/Private key or Subkey */

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -83,6 +83,13 @@ pgp_sig_subpkt_t *signature_add_subpkt(pgp_signature_t *        sig,
                                        bool                     reuse);
 
 /**
+ * @brief Remove signature's subpacket
+ * @param sig loaded or populated signature, could not be NULL
+ * @param subpkt subpacket to remove. If not in the subpackets list then no action is taken.
+ */
+void signature_remove_subpkt(pgp_signature_t *sig, pgp_sig_subpkt_t *subpkt);
+
+/**
  * @brief Check whether signature has signing key fingerprint
  * @param sig loaded or populated v4 signature, could not be NULL
  * @return true if fingerprint is available or false otherwise
@@ -264,7 +271,7 @@ bool signature_set_features(pgp_signature_t *sig, uint8_t features);
 
 bool signature_set_signer_uid(pgp_signature_t *sig, uint8_t *uid, size_t len);
 
-bool signature_set_embedded_sig(pgp_signature_t *sig, uint8_t *esig, size_t len);
+bool signature_set_embedded_sig(pgp_signature_t *sig, pgp_signature_t *esig);
 
 bool signature_add_notation_data(pgp_signature_t *sig,
                                  bool             readable,


### PR DESCRIPTION
This PR adds primary key binding signature for signing subkeys (which marked as MUST in RFC).
Tests already include validation of gpg/rnp key signatures so I didn't add new ones.
Also tests will be updated with upcoming code for validation of the key signatures before allowing usage of that key.

Fixes #373 