### PR TITLE
Fix typo: Allistair -> Alistair

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ macOS as a replacement of GnuPG. It is maintained by Ribose after being
 forked from NetPGP, itself originally written for NetBSD.
 
 "librnp" is the library used by rnp for all OpenPGP functions, useful
-for developers to build against. Thanks to Allistair, it is a "real"
+for developers to build against. Thanks to Alistair, it is a "real"
 library, not a wrapper like GPGME of GnuPG.
 
-NetPGP was originally written (and still maintained) by Allistair Crooks
+NetPGP was originally written (and still maintained) by Alistair Crooks
 of NetBSD.
 
 # Status


### PR DESCRIPTION
After a Google search, it seems that Alistair is the right spelling
(and not Allistair) for NetBSD Foundation president Alistair G. Crooks.