### PR TITLE
ECDSA: pass expected hash length via "Raw(hashname)" param

### DIFF
--- a/src/lib/crypto/ecdsa.h
+++ b/src/lib/crypto/ecdsa.h
@@ -33,11 +33,13 @@ rnp_result_t ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret
 
 rnp_result_t ecdsa_sign(rng_t *             rng,
                         pgp_ec_signature_t *sig,
+                        pgp_hash_alg_t      hash_alg,
                         const uint8_t *     hash,
                         size_t              hash_len,
                         const pgp_ec_key_t *key);
 
 rnp_result_t ecdsa_verify(const pgp_ec_signature_t *sig,
+                          pgp_hash_alg_t            hash_alg,
                           const uint8_t *           hash,
                           size_t                    hash_len,
                           const pgp_ec_key_t *      key);

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1027,6 +1027,8 @@ signature_validate(const pgp_signature_t *   sig,
     size_t       len;
     rnp_result_t ret = RNP_ERROR_GENERIC;
 
+    pgp_hash_alg_t hash_alg = pgp_hash_alg_type(hash);
+
     /* Finalize hash */
     if (!signature_hash_finish(sig, hash, hval, &len)) {
         return RNP_ERROR_BAD_FORMAT;
@@ -1058,7 +1060,7 @@ signature_validate(const pgp_signature_t *   sig,
         ret = rsa_verify_pkcs1(rng, &sig->material.rsa, sig->halg, hval, len, &key->rsa);
         break;
     case PGP_PKA_ECDSA:
-        ret = ecdsa_verify(&sig->material.ecc, hval, len, &key->ec);
+        ret = ecdsa_verify(&sig->material.ecc, hash_alg, hval, len, &key->ec);
         break;
     default:
         RNP_LOG("Unknown algorithm");
@@ -1348,6 +1350,7 @@ signature_calculate(pgp_signature_t *         sig,
     uint8_t      hval[PGP_MAX_HASH_SIZE];
     size_t       hlen;
     rnp_result_t ret = RNP_ERROR_GENERIC;
+    pgp_hash_alg_t hash_alg = pgp_hash_alg_type(hash);
 
     /* Finalize hash first, since function is required to do this */
     if (!signature_hash_finish(sig, hash, hval, &hlen)) {
@@ -1425,7 +1428,7 @@ signature_calculate(pgp_signature_t *         sig,
             ret = RNP_ERROR_BAD_PARAMETERS;
             break;
         }
-        ret = ecdsa_sign(rng, &sig->material.ecc, hval, hlen, &seckey->ec);
+        ret = ecdsa_sign(rng, &sig->material.ecc, hash_alg, hval, hlen, &seckey->ec);
         if (ret) {
             RNP_LOG("ECDSA signing failed");
             break;

--- a/src/tests/cipher.cpp
+++ b/src/tests/cipher.cpp
@@ -297,6 +297,7 @@ ecdsa_signverify_success(void **state)
 {
     rnp_test_state_t *rstate = (rnp_test_state_t *) *state;
     uint8_t           message[64];
+    const pgp_hash_alg_t hash_alg = PGP_HASH_SHA512;
 
     struct curve {
         pgp_curve_t id;
@@ -311,7 +312,7 @@ ecdsa_signverify_success(void **state)
         pgp_ec_signature_t         sig = {{{0}}};
         rnp_keygen_crypto_params_t key_desc;
         key_desc.key_alg = PGP_PKA_ECDSA;
-        key_desc.hash_alg = PGP_HASH_SHA512;
+        key_desc.hash_alg = hash_alg;
         key_desc.ecc.curve = curves[i].id;
         key_desc.rng = &global_rng;
 
@@ -324,16 +325,16 @@ ecdsa_signverify_success(void **state)
         const pgp_ec_key_t *key1 = &seckey1.material.ec;
         const pgp_ec_key_t *key2 = &seckey2.material.ec;
 
-        assert_rnp_success(ecdsa_sign(&global_rng, &sig, message, curves[i].size, key1));
+        assert_rnp_success(ecdsa_sign(&global_rng, &sig, hash_alg, message, sizeof(message), key1));
 
-        assert_rnp_success(ecdsa_verify(&sig, message, curves[i].size, key1));
+        assert_rnp_success(ecdsa_verify(&sig, hash_alg, message, sizeof(message), key1));
 
         // Fails because of different key used
-        assert_rnp_failure(ecdsa_verify(&sig, message, curves[i].size, key2));
+        assert_rnp_failure(ecdsa_verify(&sig, hash_alg, message, sizeof(message), key2));
 
         // Fails because message won't verify
         message[0] = ~message[0];
-        assert_rnp_failure(ecdsa_verify(&sig, message, sizeof(message), key1));
+        assert_rnp_failure(ecdsa_verify(&sig, hash_alg, message, sizeof(message), key1));
 
         free_key_pkt(&seckey1);
         free_key_pkt(&seckey2);


### PR DESCRIPTION
This causes the matching hash to be used for the deterministic nonce generation. It also checks that the input is of the expected length.

This removes the code to truncate the ECDSA input as since the merge of https://github.com/randombit/botan/pull/1502/ Botan handles it already. This patch was included in Botan 2.5 which is already the minimum required version for rnp.

GH #367