### PR TITLE
Switch armor to use PRIVATE KEY instead of SECRET KEY.

### DIFF
--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -628,7 +628,7 @@ armor_message_header(pgp_armored_msg_t type, bool finish, char *buf)
         str = "PUBLIC KEY BLOCK";
         break;
     case PGP_ARMORED_SECRET_KEY:
-        str = "SECRET KEY BLOCK";
+        str = "PRIVATE KEY BLOCK";
         break;
     case PGP_ARMORED_SIGNATURE:
         str = "SIGNATURE";


### PR DESCRIPTION
The RFC seems to indicate that PRIVATE is the most correct form, and
that only PGP 2.x used SECRET. RFC 4880 section 6.2 only mentions
PRIVATE.