### PR TITLE
Keyfile mode of operation

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -64,7 +64,6 @@ struct rng_st_t *rnp_ctx_rng_handle(const rnp_ctx_t *ctx);
 int         rnp_set_debug(const char *);
 int         rnp_get_debug(const char *);
 const char *rnp_get_info(const char *);
-int         rnp_list_packets(rnp_t *, char *, int);
 
 /* set key store format information */
 int rnp_set_key_store_format(rnp_t *, const char *);
@@ -75,6 +74,7 @@ bool   rnp_list_keys_json(rnp_t *, char **, const int);
 bool   rnp_find_key(rnp_t *, const char *);
 char * rnp_get_key(rnp_t *, const char *, const char *);
 char * rnp_export_key(rnp_t *, const char *, bool);
+bool   rnp_add_key(rnp_t *rnp, const char *path, bool print);
 bool   rnp_import_key(rnp_t *, const char *);
 bool   rnp_generate_key(rnp_t *);
 size_t rnp_secret_count(rnp_t *);

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -61,10 +61,6 @@ The following functions are for debugging, reflection and information:
 .Fo rnp_get_info
 .Fa "const char *type"
 .Fc
-.Ft int
-.Fo rnp_list_packets
-.Fa "rnp_t *rnp" "char *filename" "int armor" "char *pubringname"
-.Fc
 .Pp
 The following functions are for variable management:
 .Ft int
@@ -255,10 +251,6 @@ is made up of
 .Dq packets
 which hold information pertaining to the signature,
 encryption method, and the data which is being protected.
-This information can be displayed in a verbose manner using
-the
-.Fn rnp_list_packets
-function.
 .Pp
 The
 .Fn rnp_setvar

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -343,7 +343,7 @@ pgp_mem_writefile(pgp_memory_t *mem, const char *f)
 
     if (rename(tmp, f)) {
         fprintf(
-          stderr, "pgp_mem_writefile: can't rename to traget file: %s\n", strerror(errno));
+          stderr, "pgp_mem_writefile: can't rename to target file: %s\n", strerror(errno));
         return false;
     }
 

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -608,6 +608,13 @@ rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params)
      * considered as the final path */
     params->keystore_disabled = rnp_cfg_getint_default(cfg, CFG_KEYSTORE_DISABLED, 0);
     if (params->keystore_disabled) {
+        if ((homedir = rnp_cfg_getstr(cfg, CFG_KEYFILE))) {
+            params->pubpath = strdup("");
+            params->secpath = strdup("");
+            params->ks_pub_format = RNP_KEYSTORE_GPG;
+            params->ks_sec_format = RNP_KEYSTORE_GPG;
+        }
+
         return true;
     }
 

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -52,6 +52,7 @@
 #define CFG_SIGNERS "signers"       /* list of signers */
 #define CFG_VERBOSE "verbose"       /* verbose logging */
 #define CFG_HOMEDIR "homedir"       /* home directory - folder with keyrings and so on */
+#define CFG_KEYFILE "keyfile"       /* path to the file with key(s), used instead of keyring */
 #define CFG_PASSFD "pass-fd"        /* password file descriptor */
 #define CFG_PASSWD "password"       /* password as command-line constant */
 #define CFG_PASSWORDC "passwordc"   /* number of passwords for symmetric encryption */

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -216,7 +216,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_version),
       cmocka_unit_test(test_ffi_key_export),
       cmocka_unit_test(test_cli_rnp),
-    };
+      cmocka_unit_test(test_cli_rnp_keyfile)};
 
     /* Each test entry will invoke setup_test before running
      * and teardown_test after running. */

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -205,6 +205,8 @@ void test_stream_key_signature_validate(void **state);
 
 void test_cli_rnp(void **state);
 
+void test_cli_rnp_keyfile(void **state);
+
 #define rnp_assert_int_equal(state, a, b)           \
     do {                                            \
         int _rnp_a = (a);                           \


### PR DESCRIPTION
This PR adds --keyfile/-f CLI parameter, which allows to use key(s) from the specified file instead of keyring(s). When this parameter is specified then keyrings are not loaded and only keys from the file are used.