### PR TITLE
Remove pgp_io_t

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -150,7 +150,7 @@ bool rnp_key_store_write_to_mem(rnp_key_store_t *, const unsigned, pgp_memory_t 
 void rnp_key_store_clear(rnp_key_store_t *);
 void rnp_key_store_free(rnp_key_store_t *);
 
-bool rnp_key_store_list(const rnp_key_store_t *, const int);
+bool rnp_key_store_list(FILE *fp, const rnp_key_store_t *, const int);
 bool rnp_key_store_json(const rnp_key_store_t *, json_object *, const int);
 
 pgp_key_t *rnp_key_store_add_key(rnp_key_store_t *, pgp_key_t *);

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -41,7 +41,6 @@
 
 typedef struct rnp_t     rnp_t;
 typedef struct pgp_key_t pgp_key_t;
-typedef struct pgp_io_t  pgp_io_t;
 
 typedef enum {
     KBX_EMPTY_BLOB = 0,

--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -140,59 +140,38 @@ rnp_key_store_t *rnp_key_store_new(const char *format, const char *path);
 
 bool rnp_key_store_load_keys(rnp_t *rnp, bool loadsecret);
 
-int  rnp_key_store_load_from_file(pgp_io_t *io,
-                                  rnp_key_store_t *,
-                                  const pgp_key_provider_t *key_provider);
-bool rnp_key_store_load_from_mem(pgp_io_t *io,
-                                 rnp_key_store_t *,
+int  rnp_key_store_load_from_file(rnp_key_store_t *, const pgp_key_provider_t *key_provider);
+bool rnp_key_store_load_from_mem(rnp_key_store_t *,
                                  pgp_memory_t *,
                                  const pgp_key_provider_t *key_provider);
 
-bool rnp_key_store_write_to_file(pgp_io_t *io, rnp_key_store_t *, const unsigned);
-bool rnp_key_store_write_to_mem(pgp_io_t *io,
-                                rnp_key_store_t *,
-                                const unsigned,
-                                pgp_memory_t *);
+bool rnp_key_store_write_to_file(rnp_key_store_t *, const unsigned);
+bool rnp_key_store_write_to_mem(rnp_key_store_t *, const unsigned, pgp_memory_t *);
 
 void rnp_key_store_clear(rnp_key_store_t *);
 void rnp_key_store_free(rnp_key_store_t *);
 
-bool rnp_key_store_list(pgp_io_t *, const rnp_key_store_t *, const int);
-bool rnp_key_store_json(pgp_io_t *, const rnp_key_store_t *, json_object *, const int);
+bool rnp_key_store_list(const rnp_key_store_t *, const int);
+bool rnp_key_store_json(const rnp_key_store_t *, json_object *, const int);
 
-pgp_key_t *rnp_key_store_add_key(pgp_io_t *, rnp_key_store_t *, pgp_key_t *);
+pgp_key_t *rnp_key_store_add_key(rnp_key_store_t *, pgp_key_t *);
 
-bool rnp_key_store_remove_key(pgp_io_t *, rnp_key_store_t *, const pgp_key_t *);
-bool rnp_key_store_remove_key_by_id(pgp_io_t *, rnp_key_store_t *, const uint8_t *);
+bool rnp_key_store_remove_key(rnp_key_store_t *, const pgp_key_t *);
+bool rnp_key_store_remove_key_by_id(rnp_key_store_t *, const uint8_t *);
 
-pgp_key_t *rnp_key_store_get_key_by_id(pgp_io_t *,
-                                       const rnp_key_store_t *,
+pgp_key_t *rnp_key_store_get_key_by_id(const rnp_key_store_t *,
                                        const unsigned char *,
                                        pgp_key_t *);
 
-pgp_key_t *rnp_key_store_get_key_by_name(pgp_io_t *,
-                                         const rnp_key_store_t *,
-                                         const char *,
-                                         pgp_key_t *);
+pgp_key_t *rnp_key_store_get_key_by_name(const rnp_key_store_t *, const char *, pgp_key_t *);
 
-pgp_key_t *rnp_key_store_get_key_by_userid(pgp_io_t *,
-                                           const rnp_key_store_t *,
-                                           const char *,
-                                           pgp_key_t *);
+pgp_key_t *rnp_key_store_get_key_by_userid(const rnp_key_store_t *, const char *, pgp_key_t *);
 
 bool rnp_key_store_get_key_grip(const pgp_key_material_t *, uint8_t *);
 
-pgp_key_t *rnp_key_store_get_key_by_grip(pgp_io_t *, const rnp_key_store_t *, const uint8_t *);
-
-pgp_key_t *rnp_key_store_get_key_by_fpr(pgp_io_t *,
-                                        const rnp_key_store_t *,
-                                        const pgp_fingerprint_t *fpr);
-
+pgp_key_t *rnp_key_store_get_key_by_grip(const rnp_key_store_t *, const uint8_t *);
+pgp_key_t *rnp_key_store_get_key_by_fpr(const rnp_key_store_t *, const pgp_fingerprint_t *fpr);
 pgp_key_t *rnp_key_store_get_primary_key(const rnp_key_store_t *, const pgp_key_t *);
-
-pgp_key_t *rnp_key_store_search(pgp_io_t *,
-                                const rnp_key_store_t *,
-                                const pgp_key_search_t *,
-                                pgp_key_t *);
+pgp_key_t *rnp_key_store_search(const rnp_key_store_t *, const pgp_key_search_t *, pgp_key_t *);
 
 #endif /* KEY_STORE_H_ */

--- a/src/lib/crypto/s2k.cpp
+++ b/src/lib/crypto/s2k.cpp
@@ -63,7 +63,7 @@ pgp_s2k_derive_key(pgp_s2k_t *s2k, const char *password, uint8_t *key, int keysi
     }
 
     if (pgp_s2k_iterated(s2k->hash_alg, key, keysize, password, saltptr, iterations)) {
-        (void) fprintf(stderr, "s2k_derive_key: s2k failed\n");
+        RNP_LOG("s2k failed");
         return false;
     }
 

--- a/src/lib/crypto/s2k.cpp
+++ b/src/lib/crypto/s2k.cpp
@@ -189,15 +189,13 @@ pgp_s2k_compute_iters(pgp_hash_alg_t alg, size_t desired_msec, size_t trial_msec
     const double  bytes_for_target = bytes_per_usec * desired_usec;
     const uint8_t iters = pgp_s2k_encode_iterations(bytes_for_target);
 
-    if (rnp_get_debug(__FILE__)) {
-        RNP_LOG("PGP S2K hash %d tuned bytes/usec=%f desired_usec=%f "
-                "bytes_for_target=%f iters %d\n",
-                alg,
-                bytes_per_usec,
-                desired_usec,
-                bytes_for_target,
-                iters);
-    }
+    RNP_DLOG(
+      "PGP S2K hash %d tuned bytes/usec=%f desired_usec=%f bytes_for_target=%f iters %d",
+      alg,
+      bytes_per_usec,
+      desired_usec,
+      bytes_for_target,
+      iters);
 
     return pgp_s2k_decode_iterations((iters > MIN_ITERS) ? iters : MIN_ITERS);
 }

--- a/src/lib/crypto/symmetric.cpp
+++ b/src/lib/crypto/symmetric.cpp
@@ -449,9 +449,7 @@ pgp_block_size(pgp_symm_alg_t alg)
         return 16;
 
     default:
-        if (rnp_get_debug(__FILE__)) {
-            RNP_LOG("Unknown PGP symmetric alg %d", (int) alg);
-        }
+        RNP_DLOG("Unknown PGP symmetric alg %d", (int) alg);
         return 0;
     }
 }

--- a/src/lib/crypto/symmetric.cpp
+++ b/src/lib/crypto/symmetric.cpp
@@ -115,7 +115,7 @@ pgp_sa_to_botan_string(pgp_symm_alg_t alg)
     case PGP_SA_PLAINTEXT:
         return NULL; // ???
     default:
-        fprintf(stderr, "Unsupported PGP symmetric alg %d", (int) alg);
+        RNP_LOG("Unsupported PGP symmetric alg %d", (int) alg);
         return NULL;
     }
 }
@@ -164,7 +164,7 @@ pgp_cipher_cfb_start(pgp_crypt_t *  crypt,
 
     const char *cipher_name = pgp_sa_to_botan_string(alg);
     if (cipher_name == NULL) {
-        fprintf(stderr, "Unsupported algorithm: %d\n", alg);
+        RNP_LOG("Unsupported algorithm: %d", alg);
         return false;
     }
 
@@ -173,14 +173,14 @@ pgp_cipher_cfb_start(pgp_crypt_t *  crypt,
 
     // This shouldn't happen if pgp_sa_to_botan_string returned a ptr
     if (botan_block_cipher_init(&(crypt->cfb.obj), cipher_name) != 0) {
-        (void) fprintf(stderr, "Block cipher '%s' not available\n", cipher_name);
+        RNP_LOG("Block cipher '%s' not available", cipher_name);
         return false;
     }
 
     const size_t keysize = pgp_key_size(alg);
 
     if (botan_block_cipher_set_key(crypt->cfb.obj, key, keysize) != 0) {
-        (void) fprintf(stderr, "Failure setting key on block cipher object\n");
+        RNP_LOG("Failure setting key on block cipher object");
         return false;
     }
 
@@ -501,7 +501,7 @@ pgp_is_sa_supported(pgp_symm_alg_t alg)
     if (cipher_name != NULL)
         return true;
 
-    fprintf(stderr, "\nWarning: cipher %d not supported", (int) alg);
+    RNP_LOG("Warning: cipher %d not supported", (int) alg);
     return false;
 }
 

--- a/src/lib/fingerprint.cpp
+++ b/src/lib/fingerprint.cpp
@@ -54,9 +54,7 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_key_pkt_t *key)
         (void) mpi_hash(&key->material.rsa.n, &hash);
         (void) mpi_hash(&key->material.rsa.e, &hash);
         fp->length = pgp_hash_finish(&hash, fp->fingerprint);
-        if (rnp_get_debug(__FILE__)) {
-            hexdump(stderr, "v2/v3 fingerprint", fp->fingerprint, fp->length);
-        }
+        RNP_DHEX("v2/v3 fingerprint", fp->fingerprint, fp->length);
         return RNP_SUCCESS;
     }
 
@@ -69,9 +67,7 @@ pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_key_pkt_t *key)
             return RNP_ERROR_GENERIC;
         }
         fp->length = pgp_hash_finish(&hash, fp->fingerprint);
-        if (rnp_get_debug(__FILE__)) {
-            hexdump(stderr, "sha1 fingerprint", fp->fingerprint, fp->length);
-        }
+        RNP_DHEX("sha1 fingerprint", fp->fingerprint, fp->length);
         return RNP_SUCCESS;
     }
 

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -57,7 +57,6 @@ load_generated_g10_key(pgp_key_t *    dst,
     rnp_key_store_t *  key_store = NULL;
     list               key_ptrs = NULL; /* holds primary and pubkey, when used */
     pgp_key_provider_t prov = {};
-    pgp_io_t           io = pgp_io_from_fp(stderr, stdout, stdout);
 
     // this should generally be zeroed
     assert(pgp_get_key_type(dst) == 0);
@@ -97,7 +96,7 @@ load_generated_g10_key(pgp_key_t *    dst,
 
     pgp_memory_ref(&mem, (uint8_t *) mem_dest_get_memory(&memdst), memdst.writeb);
 
-    if (!rnp_key_store_g10_from_mem(&io, key_store, &mem, &prov)) {
+    if (!rnp_key_store_g10_from_mem(key_store, &mem, &prov)) {
         goto end;
     }
     // if a primary key is provided, it should match the sub with regards to type
@@ -108,7 +107,7 @@ load_generated_g10_key(pgp_key_t *    dst,
     }
     memcpy(dst, (pgp_key_t *) list_front(key_store->keys), sizeof(*dst));
     // we don't want the key store to free the internal key data
-    rnp_key_store_remove_key(&io, key_store, (pgp_key_t *) list_front(key_store->keys));
+    rnp_key_store_remove_key(key_store, (pgp_key_t *) list_front(key_store->keys));
     ok = true;
 
 end:

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -125,8 +125,8 @@ rnp_key_provider_store(const pgp_key_request_ctx_t *ctx, void *userdata)
 {
     rnp_key_store_t *ks = (rnp_key_store_t *) userdata;
 
-    for (pgp_key_t *key = rnp_key_store_search(NULL, ks, &ctx->search, NULL); key;
-         key = rnp_key_store_search(NULL, ks, &ctx->search, key)) {
+    for (pgp_key_t *key = rnp_key_store_search(ks, &ctx->search, NULL); key;
+         key = rnp_key_store_search(ks, &ctx->search, key)) {
         if (pgp_is_key_secret(key) == ctx->secret) {
             return key;
         }

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -461,6 +461,10 @@ rnp_get_debug(const char *f)
     const char *name;
     int         i;
 
+    if (!debugc) {
+        return 0;
+    }
+
     if ((name = strrchr(f, '/')) == NULL) {
         name = f;
     } else {

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -149,21 +149,21 @@ pgp_memory_pad(pgp_memory_t *mem, size_t length)
     uint8_t *temp;
 
     if (mem->allocated < mem->length) {
-        (void) fprintf(stderr, "pgp_memory_pad: bad alloc in\n");
+        RNP_LOG("bad alloc in");
         return false;
     }
     if (mem->allocated < mem->length + length) {
         mem->allocated = mem->allocated * 2 + length;
         temp = (uint8_t *) realloc(mem->buf, mem->allocated);
         if (temp == NULL) {
-            (void) fprintf(stderr, "pgp_memory_pad: bad alloc\n");
+            RNP_LOG("bad realloc");
             return false;
         } else {
             mem->buf = temp;
         }
     }
     if (mem->allocated < mem->length + length) {
-        (void) fprintf(stderr, "pgp_memory_pad: bad alloc out\n");
+        RNP_LOG("bad alloc out");
         return false;
     }
 
@@ -323,18 +323,18 @@ pgp_mem_writefile(pgp_memory_t *mem, const char *f)
 
     fd = mkstemp(tmp);
     if (fd < 0) {
-        fprintf(stderr, "pgp_mem_writefile: can't open temp file: %s\n", strerror(errno));
+        RNP_LOG("pgp_mem_writefile: can't open temp file: %s", strerror(errno));
         return false;
     }
 
     if ((fp = fdopen(fd, "wb")) == NULL) {
-        fprintf(stderr, "pgp_mem_writefile: can't open \"%s\"\n", strerror(errno));
+        RNP_LOG("pgp_mem_writefile: can't open \"%s\"", strerror(errno));
         return false;
     }
 
     fwrite(mem->buf, mem->length, 1, fp);
     if (ferror(fp)) {
-        fprintf(stderr, "pgp_mem_writefile: can't write to file\n");
+        RNP_LOG("pgp_mem_writefile: can't write to file");
         fclose(fp);
         return false;
     }
@@ -342,8 +342,7 @@ pgp_mem_writefile(pgp_memory_t *mem, const char *f)
     fclose(fp);
 
     if (rename(tmp, f)) {
-        fprintf(
-          stderr, "pgp_mem_writefile: can't rename to target file: %s\n", strerror(errno));
+        RNP_LOG("pgp_mem_writefile: can't rename to target file: %s", strerror(errno));
         return false;
     }
 

--- a/src/lib/packet-create.cpp
+++ b/src/lib/packet-create.cpp
@@ -126,10 +126,8 @@ write_matching_packets(pgp_dest_t *           dst,
     }
 
     // Export subkeys
-    pgp_io_t io = pgp_io_from_fp(stderr, stdout, stdout);
     for (list_item *grip = list_front(key->subkey_grips); grip; grip = list_next(grip)) {
-        const pgp_key_t *subkey =
-          rnp_key_store_get_key_by_grip(&io, keyring, (uint8_t *) grip);
+        const pgp_key_t *subkey = rnp_key_store_get_key_by_grip(keyring, (uint8_t *) grip);
         if (!write_matching_packets(dst, subkey, NULL, tags, tag_count)) {
             RNP_LOG("Error occured when exporting a subkey");
             return false;

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -636,7 +636,7 @@ copy_userid(uint8_t **dst, const uint8_t *src)
         free(*dst);
     }
     if ((*dst = (uint8_t *) calloc(1, len + 1)) == NULL) {
-        (void) fprintf(stderr, "copy_userid: bad alloc\n");
+        RNP_LOG("bad alloc");
     } else {
         (void) memcpy(*dst, src, len);
     }

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1144,8 +1144,7 @@ get_subkey_binding(const pgp_key_t *subkey)
 }
 
 static pgp_key_t *
-find_signer(pgp_io_t *                io,
-            const pgp_signature_t *   sig,
+find_signer(const pgp_signature_t *   sig,
             const rnp_key_store_t *   store,
             const pgp_key_provider_t *key_provider,
             bool                      secret)
@@ -1158,7 +1157,7 @@ find_signer(pgp_io_t *                io,
         search.type = PGP_KEY_SEARCH_FINGERPRINT;
         signature_get_keyfp(sig, &search.by.fingerprint);
         // search the store, if provided
-        if (store && (key = rnp_key_store_search(io, store, &search, NULL)) &&
+        if (store && (key = rnp_key_store_search(store, &search, NULL)) &&
             pgp_is_key_secret(key) == secret) {
             return key;
         }
@@ -1177,7 +1176,7 @@ find_signer(pgp_io_t *                io,
     if (signature_get_keyid(sig, search.by.keyid)) {
         search.type = PGP_KEY_SEARCH_KEYID;
         // search the store, if provided
-        if (store && (key = rnp_key_store_search(io, store, &search, NULL)) &&
+        if (store && (key = rnp_key_store_search(store, &search, NULL)) &&
             pgp_is_key_secret(key) == secret) {
             return key;
         }
@@ -1210,8 +1209,7 @@ find_signer(pgp_io_t *                io,
  * Rather than requiring it to be loaded first, we just use the key provider.
  */
 pgp_key_t *
-pgp_get_primary_key_for(pgp_io_t *                io,
-                        const pgp_key_t *         subkey,
+pgp_get_primary_key_for(const pgp_key_t *         subkey,
                         const rnp_key_store_t *   store,
                         const pgp_key_provider_t *key_provider)
 {
@@ -1220,14 +1218,14 @@ pgp_get_primary_key_for(pgp_io_t *                io,
     // find the subkey binding signature
     binding_sig = get_subkey_binding(subkey);
     if (!binding_sig) {
-        RNP_LOG_FD(io->errs, "Missing subkey binding signature for key.");
+        RNP_LOG("Missing subkey binding signature for key.");
         return NULL;
     }
     if (!signature_has_keyfp(binding_sig) && !signature_has_keyid(binding_sig)) {
-        RNP_LOG_FD(io->errs, "No issuer information in subkey binding signature.");
+        RNP_LOG("No issuer information in subkey binding signature.");
         return NULL;
     }
-    return find_signer(io, binding_sig, store, key_provider, pgp_is_key_secret(subkey));
+    return find_signer(binding_sig, store, key_provider, pgp_is_key_secret(subkey));
 }
 
 pgp_hash_alg_t

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -276,8 +276,7 @@ pgp_key_t *find_suitable_key(pgp_op_t            op,
                              pgp_key_provider_t *key_provider,
                              uint8_t             desired_usage);
 
-pgp_key_t *pgp_get_primary_key_for(pgp_io_t *                io,
-                                   const pgp_key_t *         subkey,
+pgp_key_t *pgp_get_primary_key_for(const pgp_key_t *         subkey,
                                    const rnp_key_store_t *   store,
                                    const pgp_key_provider_t *key_provider);
 

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -123,7 +123,7 @@ pobj(FILE *fp, json_object *obj, int depth)
     unsigned i;
 
     if (obj == NULL) {
-        (void) fprintf(stderr, "No object found\n");
+        RNP_LOG("No object found");
         return;
     }
     for (i = 0; i < (unsigned) depth; i++) {
@@ -376,7 +376,7 @@ init_io(rnp_t *rnp, pgp_io_t *io, const char *outs, const char *errs, const char
         io->res = stderr;
     } else {
         if ((io->res = fopen(ress, "w")) == NULL) {
-            fprintf(io->errs, "cannot open results %s for writing\n", ress);
+            fprintf(stderr, "cannot open results %s for writing\n", ress);
             return false;
         }
     }
@@ -573,7 +573,7 @@ bool
 rnp_list_keys(rnp_t *rnp, const int psigs)
 {
     if (rnp->pubring == NULL) {
-        (void) fprintf(stderr, "No keyring\n");
+        RNP_LOG("No keyring");
         return false;
     }
     return rnp_key_store_list(rnp->pubring, psigs);
@@ -589,11 +589,11 @@ rnp_list_keys_json(rnp_t *rnp, char **json, const int psigs)
         return false;
     }
     if (rnp->pubring == NULL) {
-        (void) fprintf(stderr, "No keyring\n");
+        RNP_LOG("No keyring");
         return false;
     }
     if (!rnp_key_store_json(rnp->pubring, obj, psigs)) {
-        (void) fprintf(stderr, "No keys in keyring\n");
+        RNP_LOG("No keys in keyring");
         return false;
     }
     const char *j = json_object_to_json_string(obj);
@@ -731,7 +731,7 @@ rnp_find_key(rnp_t *rnp, const char *id)
     pgp_key_t *key;
 
     if (id == NULL) {
-        (void) fprintf(stderr, "NULL id to search for\n");
+        RNP_LOG("NULL id to search for");
         return false;
     }
     key = rnp_key_store_get_key_by_name(rnp->pubring, id, NULL);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -189,9 +189,7 @@ format_json_key(FILE *fp, json_object *obj, const int psigs)
     time_t  now;
     char    tbuf[32];
 
-    if (rnp_get_debug(__FILE__)) {
-        (void) fprintf(stderr, "formatobj: json is '%s'\n", json_object_to_json_string(obj));
-    }
+    RNP_DLOG("json is '%s'", json_object_to_json_string(obj));
 #if 0 //?
     if (obj->c == 2 && obj->value.v[1].type == MJ_STRING &&
         strcmp(obj->value.v[1].value.s, "[REVOKED]") == 0) {
@@ -414,14 +412,14 @@ rnp_init(rnp_t *rnp, const rnp_params_t *params)
     if (params->pubpath) {
         rnp->pubring = rnp_key_store_new(params->ks_pub_format, params->pubpath);
         if (rnp->pubring == NULL) {
-            fprintf(stderr, "rnp: can't create empty pubring keystore\n");
+            RNP_LOG("can't create empty pubring keystore");
             return RNP_ERROR_BAD_PARAMETERS;
         }
     }
     if (params->secpath) {
         rnp->secring = rnp_key_store_new(params->ks_sec_format, params->secpath);
         if (rnp->secring == NULL) {
-            fprintf(stderr, "rnp: can't create empty secring keystore\n");
+            RNP_LOG("can't create empty secring keystore");
             return RNP_ERROR_BAD_PARAMETERS;
         }
     }
@@ -523,7 +521,7 @@ rnp_list_keys(rnp_t *rnp, const int psigs)
         RNP_LOG("No keyring");
         return false;
     }
-    return rnp_key_store_list(rnp->pubring, psigs);
+    return rnp_key_store_list(rnp->resfp, rnp->pubring, psigs);
 }
 
 /* list the keys in a keyring, returning a JSON encoded string */
@@ -789,7 +787,7 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
         /* add secret key if there is one */
         if (!pgp_is_key_secret(imported)) {
             if (changed && print) {
-                repgp_print_key(rnp->pubring, exkey, "pub", 0);
+                repgp_print_key(rnp->resfp, rnp->pubring, exkey, "pub", 0);
             }
             continue;
         }
@@ -807,7 +805,7 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
         }
 
         if (print && (changed || (exkey->packetc > expackets))) {
-            repgp_print_key(rnp->pubring, exkey, "sec", 0);
+            repgp_print_key(rnp->resfp, rnp->pubring, exkey, "sec", 0);
         }
     }
 

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -74,16 +74,6 @@ typedef struct pgp_io_t {
     FILE *res;  /* file stream to put results */
 } pgp_io_t;
 
-inline pgp_io_t
-pgp_io_from_fp(FILE *outs, FILE *errs, FILE *res)
-{
-    pgp_io_t io;
-    io.outs = outs;
-    io.errs = errs;
-    io.res = res;
-    return io;
-}
-
 /** pgp_map_t
  */
 typedef struct {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -68,12 +68,6 @@
 /* Maximum length of the packet header */
 #define PGP_MAX_HEADER_SIZE 6
 
-typedef struct pgp_io_t {
-    FILE *outs; /* output file stream */
-    FILE *errs; /* file stream to put error messages */
-    FILE *res;  /* file stream to put results */
-} pgp_io_t;
-
 /** pgp_map_t
  */
 typedef struct {

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -39,6 +39,16 @@
 
 #define RNP_LOG(...) RNP_LOG_FD(stderr, __VA_ARGS__)
 
+#define RNP_DLOG(...)                    \
+    if (rnp_get_debug(__FILE__)) {       \
+        RNP_LOG_FD(stderr, __VA_ARGS__); \
+    }
+
+#define RNP_DHEX(msg, mem, len)         \
+    if (rnp_get_debug(__FILE__)) {      \
+        hexdump(stderr, msg, mem, len); \
+    }
+
 /* number of elements in an array */
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(*(a)))
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -526,11 +526,9 @@ decrypt_protected_section(const uint8_t *      encrypted_data,
         RNP_LOG("pgp_s2k_iterated failed");
         goto done;
     }
-    if (rnp_get_debug(__FILE__)) {
-        hexdump(stderr, "input iv", prot->iv, G10_CBC_IV_SIZE);
-        hexdump(stderr, "key", derived_key, keysize);
-        hexdump(stderr, "encrypted", encrypted_data, encrypted_data_len);
-    }
+    RNP_DHEX("input iv", prot->iv, G10_CBC_IV_SIZE);
+    RNP_DHEX("key", derived_key, keysize);
+    RNP_DHEX("encrypted", encrypted_data, encrypted_data_len);
 
     // decrypt
     decrypted_data = (uint8_t *) malloc(encrypted_data_len);
@@ -560,9 +558,7 @@ decrypt_protected_section(const uint8_t *      encrypted_data,
     decrypted_data_len = output_written;
     s_exp_len = decrypted_data_len;
     decrypted_bytes = (const char *) decrypted_data;
-    if (rnp_get_debug(__FILE__)) {
-        hexdump(stderr, "decrypted data", decrypted_data, decrypted_data_len);
-    }
+    RNP_DHEX("decrypted data", decrypted_data, decrypted_data_len);
 
     // parse and validate the decrypted s-exp
     if (!parse_sexp(r_s_exp, &decrypted_bytes, &s_exp_len)) {
@@ -749,13 +745,10 @@ parse_protected_seckey(pgp_key_pkt_t *seckey, s_exp_t *s_exp, const char *passwo
             memcmp(checkhash,
                    decrypted_s_exp.sub_elements[1].s_exp.sub_elements[2].block.bytes,
                    G10_SHA1_HASH_SIZE) != 0) {
-            if (rnp_get_debug(__FILE__)) {
-                hexdump(stderr, "Expected hash", checkhash, G10_SHA1_HASH_SIZE);
-                hexdump(stderr,
-                        "Has hash",
-                        decrypted_s_exp.sub_elements[1].s_exp.sub_elements[2].block.bytes,
-                        decrypted_s_exp.sub_elements[1].s_exp.sub_elements[2].block.len);
-            }
+            RNP_DHEX("Expected hash", checkhash, G10_SHA1_HASH_SIZE);
+            RNP_DHEX("Has hash",
+                     decrypted_s_exp.sub_elements[1].s_exp.sub_elements[2].block.bytes,
+                     decrypted_s_exp.sub_elements[1].s_exp.sub_elements[2].block.len);
             RNP_LOG("Incorrect hash at encrypted private key.");
             goto done;
         }
@@ -780,9 +773,7 @@ g10_parse_seckey(pgp_key_pkt_t *           seckey,
     pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
     s_exp_t *        algorithm_s_exp = NULL;
 
-    if (rnp_get_debug(__FILE__)) {
-        hexdump(stderr, "S-exp", (const uint8_t *) data, data_len);
-    }
+    RNP_DHEX("S-exp", (const uint8_t *) data, data_len);
 
     const char *bytes = (const char *) data;
     if (!parse_sexp(&s_exp, &bytes, &data_len)) {
@@ -1219,11 +1210,9 @@ write_protected_seckey(s_exp_t *s_exp, pgp_key_pkt_t *seckey, const char *passwo
         goto done;
     }
 
-    if (rnp_get_debug(__FILE__)) {
-        hexdump(stderr, "input iv", prot->iv, G10_CBC_IV_SIZE);
-        hexdump(stderr, "key", derived_key, keysize);
-        hexdump(stderr, "raw data", raw.buf, raw.length);
-    }
+    RNP_DHEX("input iv", prot->iv, G10_CBC_IV_SIZE);
+    RNP_DHEX("key", derived_key, keysize);
+    RNP_DHEX("raw data", raw.buf, raw.length);
 
     if (botan_cipher_init(
           &encrypt, format->botan_cipher_name, BOTAN_CIPHER_INIT_FLAG_ENCRYPT) ||
@@ -1363,9 +1352,7 @@ g10_calculated_hash(const pgp_key_pkt_t *key, const char *protected_at, uint8_t 
 
     destroy_s_exp(&s_exp);
 
-    if (rnp_get_debug(__FILE__)) {
-        hexdump(stderr, "data for hashing", mem.buf, mem.length);
-    }
+    RNP_DHEX("data for hashing", mem.buf, mem.length);
 
     pgp_hash_add(&hash, mem.buf, mem.length);
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -770,8 +770,7 @@ done:
 }
 
 static bool
-g10_parse_seckey(pgp_io_t *                io,
-                 pgp_key_pkt_t *           seckey,
+g10_parse_seckey(pgp_key_pkt_t *           seckey,
                  const uint8_t *           data,
                  size_t                    data_len,
                  const char *              password,
@@ -948,7 +947,6 @@ g10_decrypt_seckey(const uint8_t *      data,
                    const char *         password)
 {
     pgp_key_pkt_t *seckey = NULL;
-    pgp_io_t       io = pgp_io_from_fp(stderr, stdout, stdout);
     bool           ok = false;
 
     if (!password) {
@@ -959,7 +957,7 @@ g10_decrypt_seckey(const uint8_t *      data,
     if (pubkey && !copy_key_pkt(seckey, pubkey, false)) {
         goto done;
     }
-    if (!g10_parse_seckey(&io, seckey, data, data_len, password, NULL)) {
+    if (!g10_parse_seckey(seckey, data, data_len, password, NULL)) {
         goto done;
     }
     ok = true;
@@ -973,8 +971,7 @@ done:
 }
 
 bool
-rnp_key_store_g10_from_mem(pgp_io_t *                io,
-                           rnp_key_store_t *         key_store,
+rnp_key_store_g10_from_mem(rnp_key_store_t *         key_store,
                            pgp_memory_t *            memory,
                            const pgp_key_provider_t *key_provider)
 {
@@ -982,7 +979,7 @@ rnp_key_store_g10_from_mem(pgp_io_t *                io,
     pgp_key_pkt_t keypkt = {0};
     bool          ret = false;
 
-    if (!g10_parse_seckey(io, &keypkt, memory->buf, memory->length, NULL, key_provider)) {
+    if (!g10_parse_seckey(&keypkt, memory->buf, memory->length, NULL, key_provider)) {
         goto done;
     }
     if (!pgp_key_from_keypkt(&key, &keypkt, PGP_PTAG_CT_SECRET_KEY)) {
@@ -1002,7 +999,7 @@ rnp_key_store_g10_from_mem(pgp_io_t *                io,
     memcpy(key.packets[0].raw, memory->buf, memory->length);
     key.packetc++;
     key.format = G10_KEY_STORE;
-    if (!rnp_key_store_add_key(io, key_store, &key)) {
+    if (!rnp_key_store_add_key(key_store, &key)) {
         goto done;
     }
     ret = true;
@@ -1393,7 +1390,7 @@ error:
 }
 
 bool
-rnp_key_store_g10_key_to_mem(pgp_io_t *io, pgp_key_t *key, pgp_memory_t *memory)
+rnp_key_store_g10_key_to_mem(pgp_key_t *key, pgp_memory_t *memory)
 {
     if (DYNARRAY_IS_EMPTY(key, packet)) {
         return false;

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -775,9 +775,8 @@ g10_parse_seckey(pgp_key_pkt_t *           seckey,
                  const char *              password,
                  const pgp_key_provider_t *key_provider)
 {
-    s_exp_t s_exp = {0};
-    bool    ret = false;
-    // pgp_io_t    io = {.outs = stdout, .errs = stderr, .res = stdout};
+    s_exp_t          s_exp = {0};
+    bool             ret = false;
     pgp_pubkey_alg_t alg = PGP_PKA_NOTHING;
     s_exp_t *        algorithm_s_exp = NULL;
 

--- a/src/librekey/key_store_g10.h
+++ b/src/librekey/key_store_g10.h
@@ -31,12 +31,9 @@
 #include <rekey/rnp_key_store.h>
 #include <librepgp/stream-common.h>
 
-bool           rnp_key_store_g10_from_mem(pgp_io_t *,
-                                          rnp_key_store_t *,
-                                          pgp_memory_t *,
-                                          const pgp_key_provider_t *);
-bool           rnp_key_store_g10_key_to_mem(pgp_io_t *, pgp_key_t *, pgp_memory_t *);
-bool           g10_write_seckey(pgp_dest_t *dst, pgp_key_pkt_t *seckey, const char *password);
+bool rnp_key_store_g10_from_mem(rnp_key_store_t *, pgp_memory_t *, const pgp_key_provider_t *);
+bool rnp_key_store_g10_key_to_mem(pgp_key_t *, pgp_memory_t *);
+bool g10_write_seckey(pgp_dest_t *dst, pgp_key_pkt_t *seckey, const char *password);
 pgp_key_pkt_t *g10_decrypt_seckey(const uint8_t *      data,
                                   size_t               data_len,
                                   const pgp_key_pkt_t *pubkey,

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -309,7 +309,7 @@ rnp_key_store_kbx_parse_blob(uint8_t *image, uint32_t image_len)
 
     // a blob shouldn't be less of length + type
     if (image_len < BLOB_HEADER_SIZE) {
-        fprintf(stderr, "Blob size is %u but it shouldn't be less of header\n", image_len);
+        RNP_LOG("Blob size is %u but it shouldn't be less of header", image_len);
         return NULL;
     }
 
@@ -336,12 +336,12 @@ rnp_key_store_kbx_parse_blob(uint8_t *image, uint32_t image_len)
 
     // unsuported blob type
     default:
-        fprintf(stderr, "Unsupported blob type: %d\n", type);
+        RNP_LOG("Unsupported blob type: %d", type);
         return NULL;
     }
 
     if (blob == NULL) {
-        fprintf(stderr, "Can't allocate memory\n");
+        RNP_LOG("Can't allocate memory");
         return NULL;
     }
 
@@ -389,15 +389,12 @@ rnp_key_store_kbx_from_mem(rnp_key_store_t *         key_store,
     while (has_bytes > 0) {
         blob_length = ru32(buf);
         if (blob_length > BLOB_SIZE_LIMIT) {
-            fprintf(stderr,
-                    "Blob size is %d bytes but limit is %d bytes\n",
-                    blob_length,
-                    BLOB_SIZE_LIMIT);
+            RNP_LOG(
+              "Blob size is %d bytes but limit is %d bytes", blob_length, BLOB_SIZE_LIMIT);
             return false;
         }
         if (has_bytes < blob_length) {
-            fprintf(stderr,
-                    "Blob have size %d bytes but file contains only %zu bytes\n",
+            RNP_LOG("Blob have size %d bytes but file contains only %zu bytes",
                     blob_length,
                     has_bytes);
             return false;
@@ -421,7 +418,7 @@ rnp_key_store_kbx_from_mem(rnp_key_store_t *         key_store,
             mem.allocated = 0;
 
             if (pgp_blob->keyblock_length == 0) {
-                fprintf(stderr, "PGP blob have zero size\n");
+                RNP_LOG("PGP blob have zero size");
                 return false;
             }
 
@@ -679,7 +676,7 @@ rnp_key_store_kbx_to_mem(rnp_key_store_t *key_store, pgp_memory_t *memory)
     pgp_memory_clear(memory);
 
     if (!rnp_key_store_kbx_write_header(key_store, memory)) {
-        fprintf(stderr, "Can't write KBX header\n");
+        RNP_LOG("Can't write KBX header");
         return false;
     }
 
@@ -696,7 +693,7 @@ rnp_key_store_kbx_to_mem(rnp_key_store_t *key_store, pgp_memory_t *memory)
     }
 
     if (!rnp_key_store_kbx_write_x509(key_store, memory)) {
-        fprintf(stderr, "Can't write X509 blobs\n");
+        RNP_LOG("Can't write X509 blobs");
         return false;
     }
 

--- a/src/librekey/key_store_kbx.h
+++ b/src/librekey/key_store_kbx.h
@@ -30,10 +30,7 @@
 #include <rnp/rnp.h>
 #include <rekey/rnp_key_store.h>
 
-bool rnp_key_store_kbx_from_mem(pgp_io_t *,
-                                rnp_key_store_t *,
-                                pgp_memory_t *,
-                                const pgp_key_provider_t *);
-bool rnp_key_store_kbx_to_mem(pgp_io_t *, rnp_key_store_t *, pgp_memory_t *);
+bool rnp_key_store_kbx_from_mem(rnp_key_store_t *, pgp_memory_t *, const pgp_key_provider_t *);
+bool rnp_key_store_kbx_to_mem(rnp_key_store_t *, pgp_memory_t *);
 
 #endif // RNP_KEY_STORE_KBX_H

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -326,7 +326,6 @@ rnp_key_store_add_transferable_subkey(rnp_key_store_t *          keyring,
                                       pgp_key_t *                pkey)
 {
     pgp_key_t skey = {};
-    pgp_io_t  io = {.outs = stdout, .errs = stderr, .res = stdout};
 
     /* create subkey */
     if (!rnp_key_from_transferable_subkey(&skey, tskey, pkey)) {
@@ -335,7 +334,7 @@ rnp_key_store_add_transferable_subkey(rnp_key_store_t *          keyring,
     }
 
     /* add it to the storage */
-    if (!rnp_key_store_add_key(&io, keyring, &skey)) {
+    if (!rnp_key_store_add_key(keyring, &skey)) {
         RNP_LOG("Failed to add subkey to key store.");
         goto error;
     }
@@ -380,7 +379,6 @@ rnp_key_store_add_transferable_key(rnp_key_store_t *keyring, pgp_transferable_ke
 {
     pgp_key_t  key = {};
     pgp_key_t *addkey = NULL;
-    pgp_io_t   io = {.outs = stdout, .errs = stderr, .res = stdout};
 
     /* create key from transferable key */
     if (!rnp_key_from_transferable_key(&key, tkey)) {
@@ -389,7 +387,7 @@ rnp_key_store_add_transferable_key(rnp_key_store_t *keyring, pgp_transferable_ke
     }
 
     /* add key to the storage before subkeys */
-    if (!(addkey = rnp_key_store_add_key(&io, keyring, &key))) {
+    if (!(addkey = rnp_key_store_add_key(keyring, &key))) {
         RNP_LOG("Failed to add key to key store.");
         goto error;
     }
@@ -406,7 +404,7 @@ rnp_key_store_add_transferable_key(rnp_key_store_t *keyring, pgp_transferable_ke
 error:
     if (addkey) {
         /* during key addition all fields are copied so will be cleaned below */
-        rnp_key_store_remove_key(&io, keyring, addkey);
+        rnp_key_store_remove_key(keyring, addkey);
         pgp_key_free_data(addkey);
     } else {
         pgp_key_free_data(&key);
@@ -517,8 +515,7 @@ done:
 }
 
 bool
-rnp_key_store_pgp_read_from_mem(pgp_io_t *                io,
-                                rnp_key_store_t *         keyring,
+rnp_key_store_pgp_read_from_mem(rnp_key_store_t *         keyring,
                                 pgp_memory_t *            mem,
                                 const pgp_key_provider_t *key_provider)
 {
@@ -645,10 +642,7 @@ rnp_key_store_pgp_write_to_dst(rnp_key_store_t *key_store, bool armor, pgp_dest_
 }
 
 bool
-rnp_key_store_pgp_write_to_mem(pgp_io_t *       io,
-                               rnp_key_store_t *key_store,
-                               bool             armor,
-                               pgp_memory_t *   mem)
+rnp_key_store_pgp_write_to_mem(rnp_key_store_t *key_store, bool armor, pgp_memory_t *mem)
 {
     pgp_dest_t dst = {};
     bool       res = false;

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -62,12 +62,11 @@
 
 rnp_result_t rnp_key_store_pgp_read_from_src(rnp_key_store_t *keyring, pgp_source_t *src);
 
-bool rnp_key_store_pgp_read_from_mem(pgp_io_t *,
-                                     rnp_key_store_t *,
+bool rnp_key_store_pgp_read_from_mem(rnp_key_store_t *,
                                      pgp_memory_t *,
                                      const pgp_key_provider_t *);
 
-bool rnp_key_store_pgp_write_to_mem(pgp_io_t *, rnp_key_store_t *, bool, pgp_memory_t *);
+bool rnp_key_store_pgp_write_to_mem(rnp_key_store_t *, bool, pgp_memory_t *);
 
 bool rnp_key_store_pgp_write_to_dst(rnp_key_store_t *key_store, bool armor, pgp_dest_t *dst);
 

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -753,7 +753,7 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         break;
     }
     default:
-        (void) fprintf(stderr, "pgp_print_pubkey: Unusual algorithm\n");
+        RNP_LOG("pgp_print_pubkey: Unusual algorithm: %d", (int) pkt->alg);
     }
     return cc;
 }

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -577,12 +577,8 @@ repgp_sprint_json(const struct rnp_key_store_t *keyring,
         json_object_array_add(uid_arr, uidobj);
     } // for uidc
     json_object_object_add(keyjson, "user ids", uid_arr);
-    if (rnp_get_debug(__FILE__)) {
-        printf("%s,%d: The json object created: %s\n",
-               __FILE__,
-               __LINE__,
-               json_object_to_json_string_ext(keyjson, JSON_C_TO_STRING_PRETTY));
-    }
+    RNP_DLOG("The json object created: %s",
+             json_object_to_json_string_ext(keyjson, JSON_C_TO_STRING_PRETTY));
     return 1;
 }
 
@@ -670,7 +666,8 @@ pgp_hkp_sprint_key(const struct rnp_key_store_t *keyring,
 
 /* print the key data for a pub or sec key */
 void
-repgp_print_key(const rnp_key_store_t *keyring,
+repgp_print_key(FILE *                 fp,
+                const rnp_key_store_t *keyring,
                 const pgp_key_t *      key,
                 const char *           header,
                 const int              psigs)
@@ -678,7 +675,7 @@ repgp_print_key(const rnp_key_store_t *keyring,
     char *cp;
 
     if (pgp_sprint_key(keyring, key, &cp, header, psigs) >= 0) {
-        (void) fprintf(stdout, "%s", cp);
+        (void) fprintf(fp, "%s", cp);
         free(cp);
     }
 }

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -291,7 +291,6 @@ format_subsig_line(char *              buffer,
 
 static int
 format_uid_notice(char *                 buffer,
-                  pgp_io_t *             io,
                   const rnp_key_store_t *keyring,
                   const pgp_key_t *      key,
                   unsigned               uid,
@@ -326,7 +325,7 @@ format_uid_notice(char *                 buffer,
 
         uint8_t signer[PGP_KEY_ID_SIZE] = {0};
         signature_get_keyid(&subsig->sig, signer);
-        trustkey = rnp_key_store_get_key_by_id(io, keyring, signer, NULL);
+        trustkey = rnp_key_store_get_key_by_id(keyring, signer, NULL);
 
         n += format_subsig_line(buffer + n, key, trustkey, subsig, size - n);
     }
@@ -390,8 +389,7 @@ format_key_usage_json(json_object *arr, uint8_t flags)
 
 /* print into a string (malloc'ed) the pubkeydata */
 int
-pgp_sprint_key(pgp_io_t *             io,
-               const rnp_key_store_t *keyring,
+pgp_sprint_key(const rnp_key_store_t *keyring,
                const pgp_key_t *      key,
                char **                buf,
                const char *           header,
@@ -442,7 +440,6 @@ pgp_sprint_key(pgp_io_t *             io,
         }
 
         uid_notices_offset += format_uid_notice(uid_notices + uid_notices_offset,
-                                                io,
                                                 keyring,
                                                 key,
                                                 i,
@@ -493,8 +490,7 @@ pgp_sprint_key(pgp_io_t *             io,
 
 /* return the key info as a JSON encoded string */
 int
-repgp_sprint_json(pgp_io_t *                    io,
-                  const struct rnp_key_store_t *keyring,
+repgp_sprint_json(const struct rnp_key_store_t *keyring,
                   const pgp_key_t *             key,
                   json_object *                 keyjson,
                   const char *                  header,
@@ -569,7 +565,7 @@ repgp_sprint_json(pgp_io_t *                    io,
               "creation time",
               json_object_new_int((int64_t) signature_get_creation(&key->subsigs[j].sig)));
 
-            const pgp_key_t *trustkey = rnp_key_store_get_key_by_id(io, keyring, signer, NULL);
+            const pgp_key_t *trustkey = rnp_key_store_get_key_by_id(keyring, signer, NULL);
 
             json_object_object_add(
               subsigc,
@@ -591,8 +587,7 @@ repgp_sprint_json(pgp_io_t *                    io,
 }
 
 int
-pgp_hkp_sprint_key(pgp_io_t *                    io,
-                   const struct rnp_key_store_t *keyring,
+pgp_hkp_sprint_key(const struct rnp_key_store_t *keyring,
                    const pgp_key_t *             key,
                    char **                       buf,
                    const int                     psigs)
@@ -628,7 +623,7 @@ pgp_hkp_sprint_key(pgp_io_t *                    io,
             }
             uint8_t signer[PGP_KEY_ID_SIZE] = {0};
             signature_get_keyid(&key->subsigs[j].sig, signer);
-            trustkey = rnp_key_store_get_key_by_id(io, keyring, signer, NULL);
+            trustkey = rnp_key_store_get_key_by_id(keyring, signer, NULL);
             if (key->subsigs[j].sig.version == 4 &&
                 key->subsigs[j].sig.type == PGP_SIG_SUBKEY) {
                 n += snprintf(&uidbuf[n],
@@ -675,16 +670,15 @@ pgp_hkp_sprint_key(pgp_io_t *                    io,
 
 /* print the key data for a pub or sec key */
 void
-repgp_print_key(pgp_io_t *             io,
-                const rnp_key_store_t *keyring,
+repgp_print_key(const rnp_key_store_t *keyring,
                 const pgp_key_t *      key,
                 const char *           header,
                 const int              psigs)
 {
     char *cp;
 
-    if (pgp_sprint_key(io, keyring, key, &cp, header, psigs) >= 0) {
-        (void) fprintf(io->res, "%s", cp);
+    if (pgp_sprint_key(keyring, key, &cp, header, psigs) >= 0) {
+        (void) fprintf(stdout, "%s", cp);
         free(cp);
     }
 }

--- a/src/librepgp/packet-print.h
+++ b/src/librepgp/packet-print.h
@@ -59,26 +59,19 @@
 typedef struct pgp_io_t  pgp_io_t;
 typedef struct pgp_key_t pgp_key_t;
 
-void repgp_print_key(
-  pgp_io_t *, const struct rnp_key_store_t *, const pgp_key_t *, const char *, const int);
+void repgp_print_key(const struct rnp_key_store_t *,
+                     const pgp_key_t *,
+                     const char *,
+                     const int);
 
-int repgp_sprint_json(pgp_io_t *,
-                      const struct rnp_key_store_t *,
-                      const pgp_key_t *,
-                      json_object *,
-                      const char *,
-                      const int);
+int repgp_sprint_json(
+  const struct rnp_key_store_t *, const pgp_key_t *, json_object *, const char *, const int);
 
 int pgp_sprint_key(
-  pgp_io_t *, const rnp_key_store_t *, const pgp_key_t *, char **, const char *, const int);
-int pgp_sprint_json(pgp_io_t *,
-                    const rnp_key_store_t *,
-                    const pgp_key_t *,
-                    json_object *,
-                    const char *,
-                    const int);
-int pgp_hkp_sprint_key(
-  pgp_io_t *, const rnp_key_store_t *, const pgp_key_t *, char **, const int);
+  const rnp_key_store_t *, const pgp_key_t *, char **, const char *, const int);
+int pgp_sprint_json(
+  const rnp_key_store_t *, const pgp_key_t *, json_object *, const char *, const int);
+int pgp_hkp_sprint_key(const rnp_key_store_t *, const pgp_key_t *, char **, const int);
 int pgp_sprint_pubkey(const pgp_key_t *, char *, size_t);
 
 #endif /* PACKET_PRINT_H_ */

--- a/src/librepgp/packet-print.h
+++ b/src/librepgp/packet-print.h
@@ -56,7 +56,6 @@
 
 #include <rekey/rnp_key_store.h>
 
-typedef struct pgp_io_t  pgp_io_t;
 typedef struct pgp_key_t pgp_key_t;
 
 void repgp_print_key(const struct rnp_key_store_t *,

--- a/src/librepgp/packet-print.h
+++ b/src/librepgp/packet-print.h
@@ -58,10 +58,8 @@
 
 typedef struct pgp_key_t pgp_key_t;
 
-void repgp_print_key(const struct rnp_key_store_t *,
-                     const pgp_key_t *,
-                     const char *,
-                     const int);
+void repgp_print_key(
+  FILE *fp, const struct rnp_key_store_t *, const pgp_key_t *, const char *, const int);
 
 int repgp_sprint_json(
   const struct rnp_key_store_t *, const pgp_key_t *, json_object *, const char *, const int);

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1476,7 +1476,6 @@ validate_pgp_key_signature(const pgp_signature_t *sig, validate_info_t *info)
 {
     rnp_result_t         res = RNP_ERROR_GENERIC;
     uint8_t              signer_id[PGP_KEY_ID_SIZE] = {0};
-    pgp_io_t             io = {.outs = stdout, .errs = stderr, .res = stdout};
     pgp_signature_info_t sinfo = {};
 
     if (!(sinfo.sig = (pgp_signature_t *) calloc(1, sizeof(*sig)))) {
@@ -1490,7 +1489,7 @@ validate_pgp_key_signature(const pgp_signature_t *sig, validate_info_t *info)
     if (!signature_get_keyid(sinfo.sig, signer_id)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    sinfo.signer = rnp_key_store_get_key_by_id(&io, info->keystore, signer_id, NULL);
+    sinfo.signer = rnp_key_store_get_key_by_id(info->keystore, signer_id, NULL);
     if (!sinfo.signer) {
         sinfo.no_signer = true;
         goto done;
@@ -1596,7 +1595,6 @@ validate_pgp_key_signatures(pgp_signatures_info_t *result,
     rnp_result_t              res = RNP_ERROR_GENERIC;
     validate_info_t           info = {};
     rng_t                     rng = {};
-    pgp_io_t                  io = {.outs = stdout, .errs = stderr, .res = stdout};
 
     /* no signatures in g10 secret keys */
     if (pgp_is_key_secret(key) && (key->format == G10_KEY_STORE)) {
@@ -1630,7 +1628,7 @@ validate_pgp_key_signatures(pgp_signatures_info_t *result,
 
     /* subkey may have only binding signatures */
     if (pgp_key_is_subkey(key)) {
-        pgp_key_t *primary = rnp_key_store_get_key_by_grip(&io, keyring, key->primary_grip);
+        pgp_key_t *primary = rnp_key_store_get_key_by_grip(keyring, key->primary_grip);
         if (!primary) {
             res = RNP_ERROR_BAD_STATE;
             goto done;

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -287,7 +287,7 @@ rnp_on_signatures(pgp_parse_handler_t *handler, pgp_signature_info_t *sigs, int 
 
         if (!sigs[i].no_signer) {
             key = rnp_key_store_get_key_by_id(handler->ctx->rnp->pubring, keyid, NULL);
-            repgp_print_key(handler->ctx->rnp->pubring, key, "signature ", 0);
+            repgp_print_key(resfp, handler->ctx->rnp->pubring, key, "signature ", 0);
         }
     }
 

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -242,7 +242,7 @@ rnp_on_signatures(pgp_parse_handler_t *handler, pgp_signature_info_t *sigs, int 
     char             id[MAX_ID_LENGTH + 1];
     const pgp_key_t *key;
     const char *     title = "UNKNOWN signature";
-    pgp_io_t *       io = handler->ctx->rnp->io;
+    FILE *           resfp = handler->ctx->rnp->resfp;
 
     for (int i = 0; i < count; i++) {
         if (sigs[i].unknown || sigs[i].no_signer) {
@@ -270,17 +270,17 @@ rnp_on_signatures(pgp_parse_handler_t *handler, pgp_signature_info_t *sigs, int 
         expiry = signature_get_expiration(sigs[i].sig);
 
         if (create > 0) {
-            fprintf(io->res, "%s made %s", title, ctime(&create));
+            fprintf(resfp, "%s made %s", title, ctime(&create));
             if (expiry > 0) {
                 create += expiry;
-                fprintf(io->res, "Valid until %s\n", ctime(&create));
+                fprintf(resfp, "Valid until %s\n", ctime(&create));
             }
         } else {
-            fprintf(io->res, "%s\n", title);
+            fprintf(resfp, "%s\n", title);
         }
 
         signature_get_keyid(sigs[i].sig, keyid);
-        fprintf(io->res,
+        fprintf(resfp,
                 "using %s key %s\n",
                 pgp_show_pka(sigs[i].sig->palg),
                 userid_to_id(keyid, id));
@@ -292,15 +292,15 @@ rnp_on_signatures(pgp_parse_handler_t *handler, pgp_signature_info_t *sigs, int 
     }
 
     if (count == 0) {
-        fprintf(stdout, "No signature(s) found - is this a signed file?\n");
+        fprintf(stderr, "No signature(s) found - is this a signed file?\n");
     } else if (invalidc > 0 || unknownc > 0) {
         fprintf(
-          stdout,
+          stderr,
           "Signature verification failure: %u invalid signature(s), %u unknown signature(s)\n",
           invalidc,
           unknownc);
     } else {
-        fprintf(stdout, "Signature(s) verified successfully\n");
+        fprintf(stderr, "Signature(s) verified successfully\n");
     }
 }
 

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -286,21 +286,21 @@ rnp_on_signatures(pgp_parse_handler_t *handler, pgp_signature_info_t *sigs, int 
                 userid_to_id(keyid, id));
 
         if (!sigs[i].no_signer) {
-            key = rnp_key_store_get_key_by_id(io, handler->ctx->rnp->pubring, keyid, NULL);
-            repgp_print_key(io, handler->ctx->rnp->pubring, key, "signature ", 0);
+            key = rnp_key_store_get_key_by_id(handler->ctx->rnp->pubring, keyid, NULL);
+            repgp_print_key(handler->ctx->rnp->pubring, key, "signature ", 0);
         }
     }
 
     if (count == 0) {
-        fprintf(io->res, "No signature(s) found - is this a signed file?\n");
+        fprintf(stdout, "No signature(s) found - is this a signed file?\n");
     } else if (invalidc > 0 || unknownc > 0) {
         fprintf(
-          io->res,
+          stdout,
           "Signature verification failure: %u invalid signature(s), %u unknown signature(s)\n",
           invalidc,
           unknownc);
     } else {
-        fprintf(io->res, "Signature(s) verified successfully\n");
+        fprintf(stdout, "Signature(s) verified successfully\n");
     }
 }
 
@@ -349,8 +349,8 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                 return false;
             }
             for (list_item *signer = list_front(signers); signer; signer = list_next(signer)) {
-                pgp_key_t *key = rnp_key_store_get_key_by_name(
-                  rnp->io, rnp->secring, (const char *) signer, NULL);
+                pgp_key_t *key =
+                  rnp_key_store_get_key_by_name(rnp->secring, (const char *) signer, NULL);
                 if (!key) {
                     fprintf(
                       stderr, "Invalid or unavailable signer: %s\n", (const char *) signer);
@@ -370,7 +370,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                     return false;
                 }
                 pgp_key_t *key =
-                  rnp_key_store_get_key_by_name(rnp->io, rnp->secring, rnp->defkey, NULL);
+                  rnp_key_store_get_key_by_name(rnp->secring, rnp->defkey, NULL);
                 if (!key) {
                     return false;
                 }
@@ -417,7 +417,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                 for (list_item *recipient = list_front(recipients); recipient;
                      recipient = list_next(recipient)) {
                     pgp_key_t *key = rnp_key_store_get_key_by_name(
-                      rnp->io, rnp->pubring, (const char *) recipient, NULL);
+                      rnp->pubring, (const char *) recipient, NULL);
                     if (!key) {
                         fprintf(stderr,
                                 "Invalid or unavailable recipient: %s\n",
@@ -439,7 +439,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                         return false;
                     }
                     pgp_key_t *key = rnp_key_store_get_key_by_name(
-                      rnp->io, rnp->pubring, (const char *) rnp->defkey, NULL);
+                      rnp->pubring, (const char *) rnp->defkey, NULL);
                     if (!key) {
                         fprintf(stderr,
                                 "Invalid or unavailable recipient: %s\n",

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -411,7 +411,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
             if (rnp_cfg_getbool(cfg, CFG_ENCRYPT_PK)) {
                 list recipients = NULL;
                 if (!rnp_cfg_copylist_str(cfg, &recipients, CFG_RECIPIENTS)) {
-                    fprintf(stderr, "Failed to copy recipients list\n");
+                    RNP_LOG("Failed to copy recipients list");
                     return false;
                 }
                 for (list_item *recipient = list_front(recipients); recipient;
@@ -426,7 +426,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
                         return false;
                     }
                     if (!list_append(&ctx->recipients, &key, sizeof(key))) {
-                        fprintf(stderr, "Failed to add key to recipient list\n");
+                        RNP_LOG("Failed to add key to recipient list");
                         list_destroy(&recipients);
                         return false;
                     }

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -104,15 +104,6 @@ rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params)
         params->userinputfd = fd;
     }
 
-    /* stdout/stderr and results redirection */
-    if ((stream = rnp_cfg_getstr(cfg, CFG_IO_OUTS))) {
-        params->outs = stream;
-    }
-
-    if ((stream = rnp_cfg_getstr(cfg, CFG_IO_ERRS))) {
-        params->errs = stream;
-    }
-
     if ((stream = rnp_cfg_getstr(cfg, CFG_IO_RESS))) {
         params->ress = stream;
     }

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -119,7 +119,7 @@ rnp_cfg_apply(rnp_cfg_t *cfg, rnp_params_t *params)
 
     /* detecting keystore pathes and format */
     if (!rnp_cfg_get_ks_info(cfg, params)) {
-        fprintf(stderr, "rnp_cfg_apply: cannot obtain keystore path(es) \n");
+        RNP_LOG("cannot obtain keystore path(es)");
         return false;
     }
 
@@ -470,15 +470,15 @@ rnp_cfg_check_homedir(rnp_cfg_t *cfg, char *homedir)
         return false;
     } else if ((ret = stat(homedir, &st)) == 0 && !S_ISDIR(st.st_mode)) {
         /* file exists in place of homedir */
-        fprintf(stderr, "rnp: homedir \"%s\" is not a dir\n", homedir);
+        RNP_LOG("homedir \"%s\" is not a dir", homedir);
         return false;
     } else if (ret != 0 && errno == ENOENT) {
         /* If the path doesn't exist then fail. */
-        fprintf(stderr, "rnp: warning homedir \"%s\" not found\n", homedir);
+        RNP_LOG("warning homedir \"%s\" not found", homedir);
         return false;
     } else if (ret != 0) {
         /* If any other occurred then fail. */
-        fprintf(stderr, "rnp: an unspecified error occurred\n");
+        RNP_LOG("an unspecified error occurred");
         return false;
     }
 
@@ -501,7 +501,7 @@ conffile(const char *homedir, char *userid, size_t length)
     }
     (void) memset(&keyre, 0x0, sizeof(keyre));
     if (regcomp(&keyre, "^[ \t]*default-key[ \t]+([0-9a-zA-F]+)", REG_EXTENDED) != 0) {
-        (void) fprintf(stderr, "conffile: failed to compile regular expression");
+        RNP_LOG("failed to compile regular expression");
         fclose(fp);
         return false;
     }
@@ -654,7 +654,7 @@ rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params)
     if (defhomedir && subdir) {
         rnp_path_compose(homedir, NULL, subdir, pubpath, sizeof(pubpath));
         if (mkdir(pubpath, 0700) == -1 && errno != EEXIST) {
-            fprintf(stderr, "cannot mkdir '%s' errno = %d \n", pubpath, errno);
+            RNP_LOG("cannot mkdir '%s' errno = %d", pubpath, errno);
             return false;
         }
     }
@@ -696,7 +696,7 @@ rnp_cfg_get_ks_info(rnp_cfg_t *cfg, rnp_params_t *params)
         params->ks_pub_format = RNP_KEYSTORE_G10;
         params->ks_sec_format = RNP_KEYSTORE_G10;
     } else {
-        fprintf(stderr, "rnp: unsupported keystore format: \"%s\"\n", ks_format);
+        RNP_LOG("unsupported keystore format: \"%s\"", ks_format);
         return false;
     }
 
@@ -754,7 +754,7 @@ grabdate(const char *s, int64_t *t)
         if (regcomp(&r,
                     "([0-9][0-9][0-9][0-9])[-/]([0-9][0-9])[-/]([0-9][0-9])",
                     REG_EXTENDED) != 0) {
-            fprintf(stderr, "grabdate: failed to compile regexp");
+            RNP_LOG("failed to compile regexp");
             return false;
         }
     }

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -66,8 +66,6 @@
 #define CFG_S2K_MSEC "s2k-msec"         /* number of milliseconds S2K should target */
 #define CFG_ENCRYPT_PK "encrypt_pk"     /* public key should be used during encryption */
 #define CFG_ENCRYPT_SK "encrypt_sk"     /* password encryption should be used */
-#define CFG_IO_OUTS "outs"              /* output stream */
-#define CFG_IO_ERRS "errs"              /* error stream */
 #define CFG_IO_RESS "ress"              /* results stream */
 #define CFG_NUMBITS "numbits"           /* number of bits in generated key */
 #define CFG_KEYFORMAT "format"          /* key format : "human" for human-readable or ... */

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -110,8 +110,7 @@ rnpkeys_generatekey_testSignature(void **state)
                 ctx.filename = strdup("dummyfile.dat");
                 ctx.clearsign = cleartext;
                 rnp_assert_int_not_equal(rstate, ctx.halg, PGP_HASH_UNKNOWN);
-                pgp_key_t *key =
-                  rnp_key_store_get_key_by_name(rnp.io, rnp.secring, userId, NULL);
+                pgp_key_t *key = rnp_key_store_get_key_by_name(rnp.secring, userId, NULL);
                 assert_non_null(key);
                 rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
 
@@ -220,7 +219,7 @@ rnpkeys_generatekey_testEncryption(void **state)
                               (strcmp(cipherAlg[i], "AES256") == 0));
             pgp_key_t *key;
             rnp_assert_non_null(
-              rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userId, NULL));
+              rstate, key = rnp_key_store_get_key_by_name(rnp.pubring, userId, NULL));
             rnp_assert_non_null(rstate, list_append(&ctx.recipients, &key, sizeof(key)));
             /* Encrypting the memory */
             size_t       reslen = 0;
@@ -811,7 +810,6 @@ test_generated_key_sigs(void **state)
     rnp_test_state_t *rstate = (rnp_test_state_t *) *state;
     rnp_key_store_t * pubring = NULL;
     rnp_key_store_t * secring = NULL;
-    pgp_io_t          io = pgp_io_from_fp(stderr, stdout, stdout);
     pgp_key_t *       primary_pub = NULL, *primary_sec = NULL;
     pgp_key_t *       sub_pub = NULL, *sub_sec = NULL;
     pgp_userid_pkt_t  uid = {0};
@@ -849,11 +847,11 @@ test_generated_key_sigs(void **state)
         assert_true(pgp_generate_primary_key(&desc, true, &sec, &pub, GPG_KEY_STORE));
 
         // add to our rings
-        assert_true(rnp_key_store_add_key(&io, pubring, &pub));
-        assert_true(rnp_key_store_add_key(&io, secring, &sec));
+        assert_true(rnp_key_store_add_key(pubring, &pub));
+        assert_true(rnp_key_store_add_key(secring, &sec));
         // retrieve back from our rings (for later)
-        primary_pub = rnp_key_store_get_key_by_grip(&io, pubring, pub.grip);
-        primary_sec = rnp_key_store_get_key_by_grip(&io, secring, pub.grip);
+        primary_pub = rnp_key_store_get_key_by_grip(pubring, pub.grip);
+        primary_sec = rnp_key_store_get_key_by_grip(secring, pub.grip);
         assert_non_null(primary_pub);
         assert_non_null(primary_sec);
 
@@ -1014,11 +1012,11 @@ test_generated_key_sigs(void **state)
         sec.subsigs[0].sig.hashed_data[10] ^= 0xff;
 
         // add to our rings
-        assert_true(rnp_key_store_add_key(&io, pubring, &pub));
-        assert_true(rnp_key_store_add_key(&io, secring, &sec));
+        assert_true(rnp_key_store_add_key(pubring, &pub));
+        assert_true(rnp_key_store_add_key(secring, &sec));
         // retrieve back from our rings
-        sub_pub = rnp_key_store_get_key_by_grip(&io, pubring, pub.grip);
-        sub_sec = rnp_key_store_get_key_by_grip(&io, secring, pub.grip);
+        sub_pub = rnp_key_store_get_key_by_grip(pubring, pub.grip);
+        sub_sec = rnp_key_store_get_key_by_grip(secring, pub.grip);
         assert_non_null(sub_pub);
         assert_non_null(sub_sec);
 

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -39,7 +39,6 @@ test_key_add_userid(void **state)
 {
     rnp_test_state_t * rstate = (rnp_test_state_t *) *state;
     char               path[PATH_MAX];
-    pgp_io_t           io = pgp_io_from_fp(stderr, stdout, stdout);
     pgp_key_t *        key = NULL;
     static const char *keyids[] = {"7bc6709b15c23a4a", // primary
                                    "1ed63ee56fadc34d",
@@ -55,11 +54,11 @@ test_key_add_userid(void **state)
     pgp_memory_t mem = {0};
     paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/secring.gpg", NULL);
     assert_true(pgp_mem_readfile(&mem, path));
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, &mem, NULL));
+    assert_true(rnp_key_store_pgp_read_from_mem(ks, &mem, NULL));
     pgp_memory_release(&mem);
 
     // locate our key
-    assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
     assert_non_null(key);
 
     // unlock the key
@@ -132,9 +131,9 @@ test_key_add_userid(void **state)
     ks = (rnp_key_store_t *) calloc(1, sizeof(*ks));
     assert_non_null(ks);
     // read from the saved packets
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, &mem, NULL));
+    assert_true(rnp_key_store_pgp_read_from_mem(ks, &mem, NULL));
     pgp_memory_release(&mem);
-    assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
 
     // confirm that the counts have increased as expected
     assert_int_equal(key->uidc, uidc + 2);

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -47,7 +47,6 @@ test_key_protect_load_pgp(void **state)
 {
     rnp_test_state_t * rstate = (rnp_test_state_t *) *state;
     char               path[PATH_MAX];
-    pgp_io_t           io = pgp_io_from_fp(stderr, stdout, stdout);
     pgp_key_t *        key = NULL;
     static const char *keyids[] = {"7bc6709b15c23a4a", // primary
                                    "1ed63ee56fadc34d",
@@ -65,13 +64,13 @@ test_key_protect_load_pgp(void **state)
         pgp_memory_t mem = {0};
         paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/secring.gpg", NULL);
         assert_true(pgp_mem_readfile(&mem, path));
-        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, &mem, NULL));
+        assert_true(rnp_key_store_pgp_read_from_mem(ks, &mem, NULL));
         pgp_memory_release(&mem);
 
         for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
             pgp_key_t * key = NULL;
             const char *keyid = keyids[i];
-            assert_non_null(key = rnp_key_store_get_key_by_name(&io, ks, keyid, NULL));
+            assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyid, NULL));
             assert_non_null(key);
             // all keys in this keyring are encrypted and thus should be both protected and
             // locked initially
@@ -80,14 +79,14 @@ test_key_protect_load_pgp(void **state)
         }
 
         pgp_key_t *tmp = NULL;
-        assert_non_null(tmp = rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
+        assert_non_null(tmp = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
         assert_non_null(tmp);
 
         // steal this key from the store
         key = (pgp_key_t *) calloc(1, sizeof(*key));
         assert_non_null(key);
         memcpy(key, tmp, sizeof(*key));
-        assert_true(rnp_key_store_remove_key(&io, ks, tmp));
+        assert_true(rnp_key_store_remove_key(ks, tmp));
         rnp_key_store_free(ks);
     }
 
@@ -147,12 +146,11 @@ test_key_protect_load_pgp(void **state)
         pgp_memory_t mem = {0};
         mem.buf = key->packets[0].raw;
         mem.length = key->packets[0].length;
-        assert_true(rnp_key_store_pgp_read_from_mem(&io, ks, &mem, NULL));
+        assert_true(rnp_key_store_pgp_read_from_mem(ks, &mem, NULL));
 
         // grab the first key
         pgp_key_t *reloaded_key = NULL;
-        assert_non_null(reloaded_key =
-                          rnp_key_store_get_key_by_name(&io, ks, keyids[0], NULL));
+        assert_non_null(reloaded_key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
         assert_non_null(reloaded_key);
 
         // should not be locked, nor protected

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -63,8 +63,8 @@ test_key_unlock_pgp(void **state)
 
     for (size_t i = 0; i < ARRAY_SIZE(keyids); i++) {
         const char *keyid = keyids[i];
-        rnp_assert_non_null(
-          rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyid, NULL));
+        rnp_assert_non_null(rstate,
+                            key = rnp_key_store_get_key_by_name(rnp.secring, keyid, NULL));
         assert_non_null(key);
         // all keys in this keyring are encrypted and thus should be locked initially
         rnp_assert_true(rstate, pgp_key_is_locked(key));
@@ -75,7 +75,7 @@ test_key_unlock_pgp(void **state)
       (pgp_password_provider_t){.callback = failing_password_callback, .userdata = NULL};
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
-    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
     rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
@@ -83,8 +83,8 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_free(&ctx);
 
     // grab the signing key to unlock
-    rnp_assert_non_null(
-      rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    rnp_assert_non_null(rstate,
+                        key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
     rnp_assert_non_null(rstate, key);
 
     // confirm that this key is indeed RSA first
@@ -126,7 +126,7 @@ test_key_unlock_pgp(void **state)
     // sign, with no password
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
-    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
     rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
@@ -156,7 +156,7 @@ test_key_unlock_pgp(void **state)
     // sign, with no password (should now fail)
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
-    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[0], NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
     rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
@@ -166,7 +166,7 @@ test_key_unlock_pgp(void **state)
     // encrypt
     rnp_ctx_init(&ctx, &rnp);
     ctx.ealg = PGP_SA_AES_256;
-    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, keyids[1], NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(rnp.pubring, keyids[1], NULL));
     list_append(&ctx.recipients, &key, sizeof(key));
     // Note: keyids[1] is an encrypting subkey
     ret = rnp_protect_mem(&ctx, data, strlen(data), encrypted, sizeof(encrypted), &enclen);
@@ -182,8 +182,8 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_free(&ctx);
 
     // grab the encrypting key to unlock
-    rnp_assert_non_null(
-      rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.secring, keyids[1], NULL));
+    rnp_assert_non_null(rstate,
+                        key = rnp_key_store_get_key_by_name(rnp.secring, keyids[1], NULL));
 
     // unlock the encrypting key
     provider = (pgp_password_provider_t){.callback = string_copy_password_callback,

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -52,16 +52,15 @@ all_keys_valid(const rnp_key_store_t *keyring)
 void
 test_key_validate(void **state)
 {
-    pgp_io_t         io = pgp_io_from_fp(stderr, stdout, stdout);
     rnp_key_store_t *pubring;
     rnp_key_store_t *secring;
-    pgp_key_t       *key = NULL;
+    pgp_key_t *      key = NULL;
 
     pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/pubring.gpg");
     assert_non_null(pubring);
-    assert_true(rnp_key_store_load_from_file(&io, pubring, NULL));
+    assert_true(rnp_key_store_load_from_file(pubring, NULL));
     /* this keyring has one expired subkey */
-    assert_non_null(key = rnp_key_store_get_key_by_name(&io, pubring, "1d7e8a5393c997a8", NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(pubring, "1d7e8a5393c997a8", NULL));
     assert_false(key->valid);
     key->valid = true;
     assert_true(all_keys_valid(pubring));
@@ -69,8 +68,8 @@ test_key_validate(void **state)
 
     secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/1/secring.gpg");
     assert_non_null(secring);
-    assert_true(rnp_key_store_load_from_file(&io, secring, NULL));
-    assert_non_null(key = rnp_key_store_get_key_by_name(&io, secring, "1d7e8a5393c997a8", NULL));
+    assert_true(rnp_key_store_load_from_file(secring, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_name(secring, "1d7e8a5393c997a8", NULL));
     assert_false(key->valid);
     key->valid = true;
     assert_true(all_keys_valid(secring));
@@ -78,51 +77,51 @@ test_key_validate(void **state)
 
     pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/2/pubring.gpg");
     assert_non_null(pubring);
-    assert_true(rnp_key_store_load_from_file(&io, pubring, NULL));
+    assert_true(rnp_key_store_load_from_file(pubring, NULL));
     assert_true(all_keys_valid(pubring));
     rnp_key_store_free(pubring);
 
     secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/2/secring.gpg");
     assert_non_null(secring);
-    assert_true(rnp_key_store_load_from_file(&io, secring, NULL));
+    assert_true(rnp_key_store_load_from_file(secring, NULL));
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(secring);
 
     pubring = rnp_key_store_new(RNP_KEYSTORE_KBX, "data/keyrings/3/pubring.kbx");
     assert_non_null(pubring);
-    assert_true(rnp_key_store_load_from_file(&io, pubring, NULL));
+    assert_true(rnp_key_store_load_from_file(pubring, NULL));
     assert_true(all_keys_valid(pubring));
 
     secring = rnp_key_store_new(RNP_KEYSTORE_G10, "data/keyrings/3/private-keys-v1.d");
     assert_non_null(secring);
     pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store,
                                        .userdata = pubring};
-    assert_true(rnp_key_store_load_from_file(&io, secring, &key_provider));
+    assert_true(rnp_key_store_load_from_file(secring, &key_provider));
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(pubring);
     rnp_key_store_free(secring);
 
     pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/4/pubring.pgp");
     assert_non_null(pubring);
-    assert_true(rnp_key_store_load_from_file(&io, pubring, NULL));
+    assert_true(rnp_key_store_load_from_file(pubring, NULL));
     assert_true(all_keys_valid(pubring));
     rnp_key_store_free(pubring);
 
     secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/4/secring.pgp");
     assert_non_null(secring);
-    assert_true(rnp_key_store_load_from_file(&io, secring, NULL));
+    assert_true(rnp_key_store_load_from_file(secring, NULL));
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(secring);
 
     pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/5/pubring.gpg");
     assert_non_null(pubring);
-    assert_true(rnp_key_store_load_from_file(&io, pubring, NULL));
+    assert_true(rnp_key_store_load_from_file(pubring, NULL));
     assert_true(all_keys_valid(pubring));
     rnp_key_store_free(pubring);
 
     secring = rnp_key_store_new(RNP_KEYSTORE_GPG, "data/keyrings/5/secring.gpg");
     assert_non_null(secring);
-    assert_true(rnp_key_store_load_from_file(&io, secring, NULL));
+    assert_true(rnp_key_store_load_from_file(secring, NULL));
     assert_true(all_keys_valid(secring));
     rnp_key_store_free(secring);
 }
@@ -147,208 +146,207 @@ test_forged_key_validate(void **state)
 {
     rnp_key_store_t *pubring;
     pgp_key_t *      key = NULL;
-    pgp_io_t         io = pgp_io_from_fp(stderr, stdout, stdout);
 
     pubring = rnp_key_store_new(RNP_KEYSTORE_GPG, "");
     assert_non_null(pubring);
 
     /* load valid dsa-eg key */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load dsa-eg key with forged self-signature. Subkey will not be valid as well. */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "02A5715C3537717E", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "02A5715C3537717E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load dsa-eg key with forged key material */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
     assert_null(key);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "dsa-eg", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "dsa-eg", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load dsa-eg keypair with forged subkey binding signature */
     key_store_add(pubring, DATA_PATH "dsa-eg-pub-forged-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "02A5715C3537717E", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "02A5715C3537717E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "C8A10A7D78273E10", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "C8A10A7D78273E10", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load valid eddsa key */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "CC786278981B0728", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "CC786278981B0728", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load eddsa key with forged self-signature */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "CC786278981B0728", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "CC786278981B0728", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load eddsa key with forged key material */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "ecc-25519", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "ecc-25519", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load valid ecdsa/ecdh p-256 keypair */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "23674F21B2441527", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "37E285E9E9851491", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh key with forged self-signature. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "23674F21B2441527", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "37E285E9E9851491", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh key with forged key material. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "23674F21B2441527", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
     assert_null(key);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "ecc-p256", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "ecc-p256", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "37E285E9E9851491", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair with forged subkey binding signature */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-forged-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "37E285E9E9851491", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "23674F21B2441527", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair without certification */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-no-certification.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "23674F21B2441527", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "37E285E9E9851491", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair without subkey binding */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-no-binding.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "23674F21B2441527", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "23674F21B2441527", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "37E285E9E9851491", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "37E285E9E9851491", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load valid rsa/rsa keypair */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "2FB9179118898E8B", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa key with forged self-signature. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-key.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "2FB9179118898E8B", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa key with forged key material. Subkey is not valid as well. */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-material.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "2FB9179118898E8B", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
     assert_null(key);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "rsa-rsa", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "rsa-rsa", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa keypair with forged subkey binding signature */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-forged-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "6E2F73008F8B8D6E", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "6E2F73008F8B8D6E", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "2FB9179118898E8B", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "2FB9179118898E8B", NULL);
     assert_non_null(key);
     assert_true(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load rsa/rsa keypair with future creation date */
     key_store_add(pubring, DATA_PATH "rsa-rsa-pub-future-key.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "3D032D00EE1EC3F5", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "3D032D00EE1EC3F5", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "021085B640CE8DCE", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "021085B640CE8DCE", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load eddsa/rsa keypair with certification with future creation date */
     key_store_add(pubring, DATA_PATH "ecc-25519-pub-future-cert.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "D3B746FA852C2BE8", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "D3B746FA852C2BE8", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "EB8C21ACDC15CA14", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "EB8C21ACDC15CA14", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/rsa keypair with expired subkey */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-expired-subkey.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "1E4526C06A6D482B", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "1E4526C06A6D482B", NULL);
     assert_non_null(key);
     assert_true(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "B20D0A7D37200BEB", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "B20D0A7D37200BEB", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);
 
     /* load ecdsa/ecdh keypair with expired key */
     key_store_add(pubring, DATA_PATH "ecc-p256-pub-expired-key.pgp");
-    key = rnp_key_store_get_key_by_name(&io, pubring, "1CBED48ED08792BB", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "1CBED48ED08792BB", NULL);
     assert_non_null(key);
     assert_false(key->valid);
-    key = rnp_key_store_get_key_by_name(&io, pubring, "F4CA7C5CDD74AB81", NULL);
+    key = rnp_key_store_get_key_by_name(pubring, "F4CA7C5CDD74AB81", NULL);
     assert_non_null(key);
     assert_false(key->valid);
     rnp_key_store_clear(pubring);

--- a/src/tests/load-g10.cpp
+++ b/src/tests/load-g10.cpp
@@ -36,25 +36,24 @@
 void
 test_load_g10(void **state)
 {
-    pgp_io_t         io = pgp_io_from_fp(stderr, stdout, stdout);
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     const pgp_key_t *key;
 
     // load pubring
     rnp_key_store_t *pub_store = rnp_key_store_new("KBX", "data/keyrings/3/pubring.kbx");
     assert_non_null(pub_store);
-    assert_true(rnp_key_store_load_from_file(&io, pub_store, NULL));
+    assert_true(rnp_key_store_load_from_file(pub_store, NULL));
     // load secring
     rnp_key_store_t *sec_store = rnp_key_store_new("G10", "data/keyrings/3/private-keys-v1.d");
     assert_non_null(sec_store);
     pgp_key_provider_t key_provider = {.callback = rnp_key_provider_store,
                                        .userdata = pub_store};
-    assert_true(rnp_key_store_load_from_file(&io, sec_store, &key_provider));
+    assert_true(rnp_key_store_load_from_file(sec_store, &key_provider));
 
     // find (primary)
     key = NULL;
     assert_true(rnp_hex_decode("4BE147BB22DF1E60", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, sec_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(sec_store, keyid, NULL);
     assert_non_null(key);
     // check properties
     assert_true(pgp_key_is_protected(key));
@@ -62,7 +61,7 @@ test_load_g10(void **state)
     // find (sub)
     key = NULL;
     assert_true(rnp_hex_decode("A49BAE05C16E8BC8", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, sec_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(sec_store, keyid, NULL);
     assert_non_null(key);
     // check properties
     assert_true(pgp_key_is_protected(key));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -40,7 +40,6 @@ test_load_v3_keyring_pgp(void **state)
 {
     rnp_test_state_t *rstate = (rnp_test_state_t *) *state;
     char              path[PATH_MAX];
-    pgp_io_t          io = pgp_io_from_fp(stderr, stdout, stdout);
     pgp_memory_t      mem = {0};
 
     paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/2/pubring.gpg", NULL);
@@ -51,12 +50,12 @@ test_load_v3_keyring_pgp(void **state)
     assert_non_null(key_store);
 
     // load it in to the key store
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, &mem, NULL));
+    assert_true(rnp_key_store_pgp_read_from_mem(key_store, &mem, NULL));
     assert_int_equal(1, list_length(key_store->keys));
 
     // find the key by keyid
     static const uint8_t keyid[] = {0xDC, 0x70, 0xC1, 0x24, 0xA5, 0x02, 0x83, 0xF1};
-    const pgp_key_t *    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    const pgp_key_t *    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
 
     // confirm the key flags are correct
@@ -74,11 +73,11 @@ test_load_v3_keyring_pgp(void **state)
     key_store = (rnp_key_store_t *) calloc(1, sizeof(*key_store));
     assert_non_null(key_store);
 
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, &mem, NULL));
+    assert_true(rnp_key_store_pgp_read_from_mem(key_store, &mem, NULL));
     assert_int_equal(1, list_length(key_store->keys));
 
     static const uint8_t keyid2[] = {0x7D, 0x0B, 0xC1, 0x0E, 0x93, 0x34, 0x04, 0xC9};
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid2, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid2, NULL);
     assert_non_null(key);
 
     // confirm the key flags are correct
@@ -110,7 +109,6 @@ test_load_v4_keyring_pgp(void **state)
 {
     rnp_test_state_t *rstate = (rnp_test_state_t *) *state;
     char              path[PATH_MAX];
-    pgp_io_t          io = pgp_io_from_fp(stderr, stdout, stdout);
     pgp_memory_t      mem = {0};
 
     paths_concat(path, sizeof(path), rstate->data_dir, "keyrings/1/pubring.gpg", NULL);
@@ -121,12 +119,12 @@ test_load_v4_keyring_pgp(void **state)
     assert_non_null(key_store);
 
     // load it in to the key store
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, &mem, NULL));
+    assert_true(rnp_key_store_pgp_read_from_mem(key_store, &mem, NULL));
     assert_int_equal(7, list_length(key_store->keys));
 
     // find the key by keyid
     static const uint8_t keyid[] = {0x8a, 0x05, 0xb8, 0x9f, 0xad, 0x5a, 0xde, 0xd1};
-    const pgp_key_t *    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    const pgp_key_t *    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
 
     // confirm the key flags are correct
@@ -143,7 +141,6 @@ check_pgp_keyring_counts(const char *   path,
                          unsigned       primary_count,
                          const unsigned subkey_counts[])
 {
-    pgp_io_t     io = pgp_io_from_fp(stderr, stdout, stdout);
     pgp_memory_t mem = {0};
 
     // read the keyring into memory
@@ -153,7 +150,7 @@ check_pgp_keyring_counts(const char *   path,
     assert_non_null(key_store);
 
     // load it in to the key store
-    assert_true(rnp_key_store_pgp_read_from_mem(&io, key_store, &mem, NULL));
+    assert_true(rnp_key_store_pgp_read_from_mem(key_store, &mem, NULL));
 
     // count primary keys first
     unsigned total_primary_count = 0;
@@ -216,7 +213,6 @@ test_load_keyring_and_count_pgp(void **state)
 void
 test_load_check_bitfields_and_times(void **state)
 {
-    pgp_io_t         io = pgp_io_from_fp(stderr, stdout, stdout);
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     uint8_t          signer_id[PGP_KEY_ID_SIZE] = {0};
     const pgp_key_t *key;
@@ -224,12 +220,12 @@ test_load_check_bitfields_and_times(void **state)
     // load keyring
     rnp_key_store_t *key_store = rnp_key_store_new("GPG", "data/keyrings/1/pubring.gpg");
     assert_non_null(key_store);
-    assert_true(rnp_key_store_load_from_file(&io, key_store, NULL));
+    assert_true(rnp_key_store_load_from_file(key_store, NULL));
 
     // find
     key = NULL;
     assert_true(rnp_hex_decode("7BC6709B15C23A4A", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 3);
@@ -251,7 +247,7 @@ test_load_check_bitfields_and_times(void **state)
     // find
     key = NULL;
     assert_true(rnp_hex_decode("1ED63EE56FADC34D", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 1);
@@ -271,7 +267,7 @@ test_load_check_bitfields_and_times(void **state)
     // find
     key = NULL;
     assert_true(rnp_hex_decode("1D7E8A5393C997A8", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 1);
@@ -291,7 +287,7 @@ test_load_check_bitfields_and_times(void **state)
     // find
     key = NULL;
     assert_true(rnp_hex_decode("8A05B89FAD5ADED1", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 1);
@@ -311,7 +307,7 @@ test_load_check_bitfields_and_times(void **state)
     // find
     key = NULL;
     assert_true(rnp_hex_decode("2FCADF05FFA501BB", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 3);
@@ -334,7 +330,7 @@ test_load_check_bitfields_and_times(void **state)
     // find
     key = NULL;
     assert_true(rnp_hex_decode("54505A936A4A970E", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 1);
@@ -354,7 +350,7 @@ test_load_check_bitfields_and_times(void **state)
     // find
     key = NULL;
     assert_true(rnp_hex_decode("326EF111425D14A5", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check subsig count
     assert_int_equal(key->subsigc, 1);
@@ -381,7 +377,6 @@ test_load_check_bitfields_and_times(void **state)
 void
 test_load_check_bitfields_and_times_v3(void **state)
 {
-    pgp_io_t         io = pgp_io_from_fp(stderr, stdout, stdout);
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     uint8_t          signer_id[PGP_KEY_ID_SIZE];
     const pgp_key_t *key;
@@ -389,12 +384,12 @@ test_load_check_bitfields_and_times_v3(void **state)
     // load keyring
     rnp_key_store_t *key_store = rnp_key_store_new("GPG", "data/keyrings/2/pubring.gpg");
     assert_non_null(key_store);
-    assert_true(rnp_key_store_load_from_file(&io, key_store, NULL));
+    assert_true(rnp_key_store_load_from_file(key_store, NULL));
 
     // find
     key = NULL;
     assert_true(rnp_hex_decode("DC70C124A50283F1", keyid, sizeof(keyid)));
-    key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL);
+    key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check key version
     assert_int_equal(pgp_get_key_pkt(key)->version, PGP_V3);
@@ -425,20 +420,19 @@ test_load_check_bitfields_and_times_v3(void **state)
 void
 test_load_armored_pub_sec(void **state)
 {
-    pgp_io_t         io = {.outs = stdout, .errs = stderr, .res = stdout};
     pgp_key_t *      key;
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     rnp_key_store_t *key_store;
 
     key_store = rnp_key_store_new("GPG", MERGE_PATH "key-both.asc");
     assert_non_null(key_store);
-    assert_true(rnp_key_store_load_from_file(&io, key_store, NULL));
+    assert_true(rnp_key_store_load_from_file(key_store, NULL));
 
     /* we must have 1 main key and 2 subkeys */
     assert_int_equal(list_length(key_store->keys), 3);
 
     assert_true(rnp_hex_decode("9747D2A6B3A63124", keyid, sizeof(keyid)));
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_true(pgp_key_is_primary_key(key));
     assert_true(pgp_is_key_secret(key));
@@ -450,7 +444,7 @@ test_load_armored_pub_sec(void **state)
     assert_int_equal(key->packets[4].tag, PGP_PTAG_CT_SIGNATURE);
 
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", keyid, sizeof(keyid)));
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_true(pgp_key_is_subkey(key));
     assert_true(pgp_is_key_secret(key));
@@ -459,7 +453,7 @@ test_load_armored_pub_sec(void **state)
     assert_int_equal(key->packets[1].tag, PGP_PTAG_CT_SIGNATURE);
 
     assert_true(rnp_hex_decode("16CD16F267CCDD4F", keyid, sizeof(keyid)));
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_true(pgp_key_is_subkey(key));
     assert_true(pgp_is_key_secret(key));
@@ -468,8 +462,8 @@ test_load_armored_pub_sec(void **state)
     assert_int_equal(key->packets[1].tag, PGP_PTAG_CT_SIGNATURE);
 
     /* both user ids should be present */
-    assert_non_null(rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-1", NULL));
-    assert_non_null(rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-2", NULL));
+    assert_non_null(rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
+    assert_non_null(rnp_key_store_get_key_by_name(key_store, "key-merge-uid-2", NULL));
 
     rnp_key_store_free(key_store);
 }
@@ -504,7 +498,6 @@ load_keystore(rnp_key_store_t *keystore, const char *fname)
 void
 test_load_merge(void **state)
 {
-    pgp_io_t                  io = {.outs = stdout, .errs = stderr, .res = stdout};
     pgp_key_t *               key, *skey1, *skey2;
     uint8_t                   keyid[PGP_KEY_ID_SIZE];
     uint8_t                   sub1id[PGP_KEY_ID_SIZE];
@@ -526,7 +519,7 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 1);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_false(key->valid);
     assert_int_equal(key->packetc, 1);
     assert_int_equal(key->packets[0].tag, PGP_PTAG_CT_PUBLIC_KEY);
@@ -536,27 +529,27 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 1);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_false(key->valid);
     assert_int_equal(key->uidc, 1);
     assert_int_equal(key->packetc, 2);
     assert_int_equal(key->packets[0].tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(key->packets[1].tag, PGP_PTAG_CT_USER_ID);
-    assert_true(key == rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
 
     /* load key + user id 1 with sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-1.pgp"));
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 1);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_int_equal(key->uidc, 1);
     assert_int_equal(key->packetc, 3);
     assert_int_equal(key->packets[0].tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(key->packets[1].tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(key->packets[2].tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
 
     /* load key + user id 2 with sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-uid-2.pgp"));
@@ -565,7 +558,7 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 1);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_int_equal(key->uidc, 2);
     assert_int_equal(key->packetc, 5);
@@ -574,16 +567,16 @@ test_load_merge(void **state)
     assert_int_equal(key->packets[2].tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(key->packets[3].tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(key->packets[4].tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-1", NULL));
-    assert_true(key == rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-2", NULL));
+    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-2", NULL));
 
     /* load key + subkey 1 without sigs */
     assert_true(load_transferable_key(&tkey, MERGE_PATH "key-pub-subkey-1-no-sigs.pgp"));
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 2);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(key->valid);
     assert_false(skey1->valid);
     assert_int_equal(key->uidc, 2);
@@ -607,8 +600,8 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_subkey(key_store, &tskey, key));
     transferable_subkey_destroy(&tskey);
     assert_int_equal(list_length(key_store->keys), 2);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_int_equal(key->uidc, 2);
@@ -633,9 +626,9 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 3);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
-    assert_non_null(skey2 = rnp_key_store_get_key_by_id(&io, key_store, sub2id, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
+    assert_non_null(skey2 = rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_true(skey2->valid);
@@ -667,9 +660,9 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 3);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
-    assert_non_null(skey2 = rnp_key_store_get_key_by_id(&io, key_store, sub2id, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
+    assert_non_null(skey2 = rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_true(skey2->valid);
@@ -706,9 +699,9 @@ test_load_merge(void **state)
     assert_true(rnp_key_store_add_transferable_key(key_store, &tkey));
     transferable_key_destroy(&tkey);
     assert_int_equal(list_length(key_store->keys), 3);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
-    assert_non_null(skey2 = rnp_key_store_get_key_by_id(&io, key_store, sub2id, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
+    assert_non_null(skey2 = rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_true(skey2->valid);
@@ -732,8 +725,8 @@ test_load_merge(void **state)
     assert_int_equal(skey2->packetc, 2);
     assert_int_equal(skey2->packets[0].tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(skey2->packets[1].tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(key == rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-1", NULL));
-    assert_true(key == rnp_key_store_get_key_by_name(&io, key_store, "key-merge-uid-2", NULL));
+    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-1", NULL));
+    assert_true(key == rnp_key_store_get_key_by_name(key_store, "key-merge-uid-2", NULL));
 
     rnp_key_store_free(key_store);
 }
@@ -741,7 +734,6 @@ test_load_merge(void **state)
 void
 test_load_public_from_secret(void **state)
 {
-    pgp_io_t         io = {.outs = stdout, .errs = stderr, .res = stdout};
     pgp_key_t *      key, *skey1, *skey2, keycp;
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     uint8_t          sub1id[PGP_KEY_ID_SIZE];
@@ -749,16 +741,16 @@ test_load_public_from_secret(void **state)
     rnp_key_store_t *secstore, *pubstore;
 
     assert_non_null(secstore = rnp_key_store_new("GPG", MERGE_PATH "key-sec.asc"));
-    assert_true(rnp_key_store_load_from_file(&io, secstore, NULL));
+    assert_true(rnp_key_store_load_from_file(secstore, NULL));
     assert_non_null(pubstore = rnp_key_store_new("GPG", "pubring.gpg"));
 
     assert_true(rnp_hex_decode("9747D2A6B3A63124", keyid, sizeof(keyid)));
     assert_true(rnp_hex_decode("AF1114A47F5F5B28", sub1id, sizeof(sub1id)));
     assert_true(rnp_hex_decode("16CD16F267CCDD4F", sub2id, sizeof(sub2id)));
 
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, secstore, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, secstore, sub1id, NULL));
-    assert_non_null(skey2 = rnp_key_store_get_key_by_id(&io, secstore, sub2id, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(secstore, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(secstore, sub1id, NULL));
+    assert_non_null(skey2 = rnp_key_store_get_key_by_id(secstore, sub2id, NULL));
 
     /* copy the secret key */
     assert_rnp_success(pgp_key_copy(&keycp, key, false));
@@ -781,7 +773,7 @@ test_load_public_from_secret(void **state)
     assert_null(pgp_get_key_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_get_key_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_get_key_pkt(&keycp)->material.secret);
-    rnp_key_store_add_key(&io, pubstore, &keycp);
+    rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
     assert_false(pgp_is_key_secret(&keycp));
@@ -793,7 +785,7 @@ test_load_public_from_secret(void **state)
     assert_null(pgp_get_key_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_get_key_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_get_key_pkt(&keycp)->material.secret);
-    rnp_key_store_add_key(&io, pubstore, &keycp);
+    rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
     assert_false(pgp_is_key_secret(&keycp));
@@ -805,16 +797,16 @@ test_load_public_from_secret(void **state)
     assert_null(pgp_get_key_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_get_key_pkt(&keycp)->sec_len, 0);
     assert_false(pgp_get_key_pkt(&keycp)->material.secret);
-    rnp_key_store_add_key(&io, pubstore, &keycp);
+    rnp_key_store_add_key(pubstore, &keycp);
     /* save pubring */
-    assert_true(rnp_key_store_write_to_file(&io, pubstore, false));
+    assert_true(rnp_key_store_write_to_file(pubstore, false));
     rnp_key_store_free(pubstore);
     /* reload */
     assert_non_null(pubstore = rnp_key_store_new("GPG", "pubring.gpg"));
-    assert_true(rnp_key_store_load_from_file(&io, pubstore, NULL));
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, pubstore, keyid, NULL));
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, pubstore, sub1id, NULL));
-    assert_non_null(skey2 = rnp_key_store_get_key_by_id(&io, pubstore, sub2id, NULL));
+    assert_true(rnp_key_store_load_from_file(pubstore, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(pubstore, keyid, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(pubstore, sub1id, NULL));
+    assert_non_null(skey2 = rnp_key_store_get_key_by_id(pubstore, sub2id, NULL));
 
     rnp_key_store_free(pubstore);
     rnp_key_store_free(secstore);
@@ -986,7 +978,6 @@ test_key_import(void **state)
 void
 test_load_subkey(void **state)
 {
-    pgp_io_t         io = {.outs = stdout, .errs = stderr, .res = stdout};
     pgp_key_t *      key, *skey1, *skey2;
     uint8_t          keyid[PGP_KEY_ID_SIZE];
     uint8_t          sub1id[PGP_KEY_ID_SIZE];
@@ -1002,7 +993,7 @@ test_load_subkey(void **state)
     /* load first subkey with signature */
     assert_true(load_keystore(key_store, MERGE_PATH "key-pub-just-subkey-1.pgp"));
     assert_int_equal(list_length(key_store->keys), 1);
-    assert_non_null(skey1 = rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
+    assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_false(skey1->valid);
     assert_int_equal(skey1->packetc, 2);
     assert_int_equal(skey1->packets[0].tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -1012,7 +1003,7 @@ test_load_subkey(void **state)
     /* load second subkey, without signature */
     assert_true(load_keystore(key_store, MERGE_PATH "key-pub-just-subkey-2-no-sigs.pgp"));
     assert_int_equal(list_length(key_store->keys), 2);
-    assert_non_null(skey2 = rnp_key_store_get_key_by_id(&io, key_store, sub2id, NULL));
+    assert_non_null(skey2 = rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_false(skey2->valid);
     assert_int_equal(skey2->packetc, 1);
     assert_int_equal(skey2->packets[0].tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -1022,14 +1013,14 @@ test_load_subkey(void **state)
     /* load primary key without subkey signatures */
     assert_true(load_keystore(key_store, MERGE_PATH "key-pub-uid-1.pgp"));
     assert_int_equal(list_length(key_store->keys), 3);
-    assert_non_null(key = rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
+    assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_int_equal(key->packetc, 3);
     assert_int_equal(key->packets[0].tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(key->packets[1].tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(key->packets[2].tag, PGP_PTAG_CT_SIGNATURE);
-    assert_true(skey1 == rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
-    assert_true(skey2 == rnp_key_store_get_key_by_id(&io, key_store, sub2id, NULL));
+    assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
+    assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_non_null(skey1->primary_grip);
     assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(list_length(key->subkey_grips), 1);
@@ -1040,9 +1031,9 @@ test_load_subkey(void **state)
     /* load second subkey with signature */
     assert_true(load_keystore(key_store, MERGE_PATH "key-pub-just-subkey-2.pgp"));
     assert_int_equal(list_length(key_store->keys), 3);
-    assert_true(key == rnp_key_store_get_key_by_id(&io, key_store, keyid, NULL));
-    assert_true(skey1 == rnp_key_store_get_key_by_id(&io, key_store, sub1id, NULL));
-    assert_true(skey2 == rnp_key_store_get_key_by_id(&io, key_store, sub2id, NULL));
+    assert_true(key == rnp_key_store_get_key_by_id(key_store, keyid, NULL));
+    assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
+    assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_non_null(skey2->primary_grip);
     assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(list_length(key->subkey_grips), 2);

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -78,8 +78,8 @@ test_load_user_prefs(void **state)
 
         // find the key
         pgp_key_t *key = NULL;
-        rnp_assert_non_null(
-          rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, NULL));
+        rnp_assert_non_null(rstate,
+                            key = rnp_key_store_get_key_by_name(rnp.pubring, userid, NULL));
         assert_non_null(key);
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);
@@ -124,8 +124,8 @@ test_load_user_prefs(void **state)
 
         // find the key
         pgp_key_t *key = NULL;
-        rnp_assert_non_null(
-          rstate, key = rnp_key_store_get_key_by_name(rnp.io, rnp.pubring, userid, NULL));
+        rnp_assert_non_null(rstate,
+                            key = rnp_key_store_get_key_by_name(rnp.pubring, userid, NULL));
         assert_non_null(key);
 
         const pgp_subsig_t *subsig = find_subsig(key, userid);


### PR DESCRIPTION
Since we moved to RNP_LOG this structure is no longer needed (especially as input parameter to all key/keyring processing functions).
Also in CLI we used it only for res stream, and in FFI - for err stream, which were replaced with single stream variable.

Fixes #157 