### PR TITLE
Display key id/fingerprint/grip in packet listing

### DIFF
--- a/src/apps/packet-dumper/redumper.cpp
+++ b/src/apps/packet-dumper/redumper.cpp
@@ -18,6 +18,7 @@ print_usage(char *program_name)
             "\t%s [-d|-h] [input.pgp]\n"
             "\t  -d : indicates whether to print packet content. Data is represented as hex\n"
             "\t  -m : dump mpi values\n"
+            "\t  -g : dump key fingerprints and grips\n"
             "\t  -h : prints help and exists\n",
             basename(program_name));
 }
@@ -35,16 +36,20 @@ main(int argc, char *const argv[])
         -i input_file [mandatory]: specifies name of the file with PGP packets
         -d : indicates wether to dump whole packet content
         -m : dump mpi contents
+        -g : dump key grips and fingerprints
         -h : prints help and exists
     */
     int opt = 0;
-    while ((opt = getopt(argc, argv, "dmh")) != -1) {
+    while ((opt = getopt(argc, argv, "dmgh")) != -1) {
         switch (opt) {
         case 'd':
             ctx.dump_packets = true;
             break;
         case 'm':
             ctx.dump_mpi = true;
+            break;
+        case 'g':
+            ctx.dump_grips = true;
             break;
         default:
             print_usage(argv[0]);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1296,6 +1296,7 @@ rnp_dump_file(rnp_ctx_t *ctx, const char *in, const char *out)
     }
 
     /* process source */
+    dumpctx.dump_grips = true;
     if ((result = stream_dump_packets(&dumpctx, &src, &dst))) {
         RNP_LOG("error 0x%x", result);
     }

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -414,8 +414,8 @@ dst_print_s2k(pgp_dest_t *dst, pgp_s2k_t *s2k)
         dst_print_hex(dst, "s2k salt", s2k->salt, PGP_SALT_SIZE, false);
     }
     if (s2k->specifier == PGP_S2KS_ITERATED_AND_SALTED) {
-        int real_iter = pgp_s2k_decode_iterations(s2k->iterations);
-        dst_printf(dst, "s2k iterations: %d (%d)\n", (int) s2k->iterations, real_iter);
+        size_t real_iter = pgp_s2k_decode_iterations(s2k->iterations);
+        dst_printf(dst, "s2k iterations: %d (%zu)\n", (int) s2k->iterations, real_iter);
     }
 }
 
@@ -429,7 +429,7 @@ dst_print_time(pgp_dest_t *dst, const char *name, uint32_t time)
     }
     strncpy(buf, ctime(&_time), sizeof(buf));
     buf[24] = '\0';
-    dst_printf(dst, "%s: %d (%s)\n", name, (int) time, buf);
+    dst_printf(dst, "%s: %zu (%s)\n", name, (size_t) time, buf);
 }
 
 static void
@@ -440,7 +440,7 @@ dst_print_expiration(pgp_dest_t *dst, const char *name, uint32_t seconds)
     }
     if (seconds) {
         int days = seconds / (24 * 60 * 60);
-        dst_printf(dst, "%s: %d seconds (%d days)\n", name, (int) seconds, days);
+        dst_printf(dst, "%s: %zu seconds (%d days)\n", name, (size_t) seconds, days);
     } else {
         dst_printf(dst, "%s: 0 (never)\n", name);
     }

--- a/src/librepgp/stream-dump.h
+++ b/src/librepgp/stream-dump.h
@@ -37,6 +37,7 @@
 typedef struct rnp_dump_ctx_t {
     bool dump_mpi;
     bool dump_packets;
+    bool dump_grips;
 } rnp_dump_ctx_t;
 
 rnp_result_t stream_dump_packets(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -981,6 +981,8 @@ test_stream_dumper(void **state)
     pgp_dest_t     dst;
     rnp_dump_ctx_t ctx = {0};
 
+    ctx.dump_mpi = false;
+    ctx.dump_grips = false;
     assert_rnp_success(init_file_src(&src, "data/keyrings/1/pubring.gpg"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
@@ -999,6 +1001,16 @@ test_stream_dumper(void **state)
     src_close(&src);
     dst_close(&dst, false);
 
+    ctx.dump_mpi = true;
+    ctx.dump_grips = true;
+    assert_rnp_success(init_file_src(&src, "data/keyrings/4/rsav3-p.asc"));
+    assert_rnp_success(init_mem_dest(&dst, NULL, 0));
+    assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
+    src_close(&src);
+    dst_close(&dst, false);
+
+    ctx.dump_mpi = true;
+    ctx.dump_grips = false;
     assert_rnp_success(init_file_src(&src, "data/keyrings/4/rsav3-s.asc"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));
@@ -1017,6 +1029,8 @@ test_stream_dumper(void **state)
     src_close(&src);
     dst_close(&dst, false);
 
+    ctx.dump_mpi = true;
+    ctx.dump_grips = true;
     assert_rnp_success(init_file_src(&src, "data/test_stream_key_load/dsa-eg-pub.asc"));
     assert_rnp_success(init_mem_dest(&dst, NULL, 0));
     assert_rnp_success(stream_dump_packets(&ctx, &src, &dst));


### PR DESCRIPTION
Just needed this functionality within other task (correcting key grip calculation).
Also now times/s2k iterations are printed as unsigned.