### PR TITLE
Support SM2 with arbitrary hashes

### DIFF
--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -336,7 +336,7 @@ setup_ctx(rnp_cfg_t *cfg, rnp_t *rnp, rnp_ctx_t *ctx)
 
         /* setting signing parameters if needed */
         if (rnp_cfg_getbool(cfg, CFG_SIGN_NEEDED)) {
-            ctx->halg = pgp_str_to_hash_alg(rnp_cfg_getstr(cfg, CFG_HASH));
+            ctx->halg = pgp_str_to_hash_alg(rnp_cfg_gethashalg(cfg));
 
             if (ctx->halg == PGP_HASH_UNKNOWN) {
                 fprintf(stderr, "Unknown hash algorithm: %s\n", rnp_cfg_getstr(cfg, CFG_HASH));

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -74,7 +74,6 @@ rnp_cfg_load_defaults(rnp_cfg_t *cfg)
 {
     rnp_cfg_setbool(cfg, CFG_OVERWRITE, false);
     rnp_cfg_setstr(cfg, CFG_OUTFILE, NULL);
-    rnp_cfg_setstr(cfg, CFG_HASH, DEFAULT_HASH_ALG);
     rnp_cfg_setint(cfg, CFG_ZALG, DEFAULT_Z_ALG);
     rnp_cfg_setint(cfg, CFG_ZLEVEL, DEFAULT_Z_LEVEL);
     rnp_cfg_setstr(cfg, CFG_CIPHER, DEFAULT_SYMM_ALG);
@@ -247,6 +246,12 @@ rnp_cfg_unset(rnp_cfg_t *cfg, const char *key)
 }
 
 bool
+rnp_cfg_hasval(const rnp_cfg_t *cfg, const char *key)
+{
+    return rnp_cfg_find(cfg, key) != NULL;
+}
+
+bool
 rnp_cfg_setint(rnp_cfg_t *cfg, const char *key, int val)
 {
     rnp_cfg_val_t _val = {.type = RNP_CFG_VAL_INT, .val = {._int = val}};
@@ -317,6 +322,10 @@ rnp_cfg_getstr(const rnp_cfg_t *cfg, const char *key)
 
     if (it && (it->val.type == RNP_CFG_VAL_STRING)) {
         return it->val.val._string;
+    }
+
+    if (strcmp(key, CFG_HASH) == 0) {
+        return DEFAULT_HASH_ALG;
     }
 
     return NULL;

--- a/src/rnp/rnpcfg.cpp
+++ b/src/rnp/rnpcfg.cpp
@@ -324,11 +324,16 @@ rnp_cfg_getstr(const rnp_cfg_t *cfg, const char *key)
         return it->val.val._string;
     }
 
-    if (strcmp(key, CFG_HASH) == 0) {
-        return DEFAULT_HASH_ALG;
-    }
-
     return NULL;
+}
+
+const char* rnp_cfg_gethashalg(rnp_cfg_t* cfg)
+{
+    const char* hash_alg = rnp_cfg_getstr(cfg, CFG_HASH);
+    if(hash_alg) {
+        return hash_alg;
+    }
+    return DEFAULT_HASH_ALG;
 }
 
 int

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -231,6 +231,12 @@ int rnp_cfg_getint_default(rnp_cfg_t *cfg, const char *key, int def);
  **/
 void rnp_cfg_copy(rnp_cfg_t *dst, const rnp_cfg_t *src);
 
+/** @brief Return the desired hash algorithm.
+ *  @param cfg [in] rnp config, must be allocated and initialized
+ *  @return desired hash algorithm, or default value if not set by user
+ */
+const char* rnp_cfg_gethashalg(rnp_cfg_t* cfg);
+
 /** @brief Fill the keyring pathes according to user-specified settings
  *  @param cfg [in] rnp config, must be allocated and initialized
  *  @param params [out] in this structure public and secret keyring pathes  will be filled

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -151,6 +151,14 @@ bool rnp_cfg_addstr(rnp_cfg_t *cfg, const char *key, const char *str);
  **/
 bool rnp_cfg_unset(rnp_cfg_t *cfg, const char *key);
 
+/** @brief return true if key is set in the configuration
+ *  @param cfg rnp config, must be allocated and initialized
+ *  @param key must be null-terminated string
+ *
+ *  @return if the key exists within the configuration or not
+ **/
+bool rnp_cfg_hasval(const rnp_cfg_t *cfg, const char *key);
+
 /** @brief return string value for the key if there is one
  *  @param cfg rnp config, must be allocated and initialized
  *  @param key must be null-terminated string

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -232,7 +232,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
             // copy keygen crypto and protection from primary to subkey
             action->subkey.keygen.crypto = primary_desc->crypto;
             action->subkey.protection = *protection;
-        } else if (rnp_generate_key_expert_mode(rnp) != RNP_SUCCESS) {
+        } else if (rnp_generate_key_expert_mode(rnp, cfg) != RNP_SUCCESS) {
             RNP_LOG("Critical error: Key generation failed");
             return false;
         }

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -213,7 +213,13 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         if (key) {
             strcpy((char *) primary_desc->cert.userid, key);
         }
-        primary_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_getstr(cfg, CFG_HASH));
+        primary_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_gethashalg(cfg));
+
+        if (primary_desc->crypto.hash_alg == PGP_HASH_UNKNOWN) {
+           fprintf(stderr, "Unknown hash algorithm: %s\n", rnp_cfg_getstr(cfg, CFG_HASH));
+           return false;
+        }
+
         primary_desc->crypto.rng = &rnp->rng;
         protection->hash_alg = primary_desc->crypto.hash_alg;
         protection->symm_alg = pgp_str_to_cipher(rnp_cfg_getstr(cfg, CFG_CIPHER));

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -44,7 +44,7 @@ typedef enum {
     OPT_DEBUG
 } optdefs_t;
 
-rnp_result_t rnp_generate_key_expert_mode(rnp_t *rnp);
+rnp_result_t rnp_generate_key_expert_mode(rnp_t *rnp, rnp_cfg_t *cfg);
 bool         rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f);
 int          setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg);
 void         print_praise(void);

--- a/src/rnpkeys/tui.cpp
+++ b/src/rnpkeys/tui.cpp
@@ -171,7 +171,7 @@ ask_dsa_bitlen(FILE *input_fp)
  *
 -------------------------------------------------------------------------------- */
 rnp_result_t
-rnp_generate_key_expert_mode(rnp_t *rnp)
+rnp_generate_key_expert_mode(rnp_t *rnp, rnp_cfg_t* cfg)
 {
     FILE *                      input_fd = rnp->user_input_fp ? rnp->user_input_fp : stdin;
     rnp_action_keygen_t *       action = &rnp->action.generate_key_ctx;
@@ -207,7 +207,10 @@ rnp_generate_key_expert_mode(rnp_t *rnp)
         break;
 
     case PGP_PKA_SM2:
-        crypto->hash_alg = PGP_HASH_SM3;
+        if(rnp_cfg_hasval(cfg, CFG_HASH) == false) {
+            crypto->hash_alg = PGP_HASH_SM3;
+        }
+
         crypto->ecc.curve = PGP_CURVE_SM2_P_256;
         action->subkey.keygen.crypto = *crypto;
         break;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -781,7 +781,7 @@ generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state)
 }
 
 void
-generatekeyECDSA_explicitlySetWrongDigest_ShouldSuceed(void **state)
+generatekeyECDSA_explicitlySetUnknownDigest_ShouldFail(void **state)
 {
     rnp_test_state_t *rstate = (rnp_test_state_t *) *state;
     rnp_t             rnp;
@@ -793,9 +793,8 @@ generatekeyECDSA_explicitlySetWrongDigest_ShouldSuceed(void **state)
     rnp_assert_true(rstate, rnp_cfg_setstr(&ops, CFG_HASH, "WRONG_DIGEST_ALGORITHM"));
     rnp_assert_true(rstate, rnp_cfg_setint(&ops, CFG_S2K_ITER, 1));
 
-    // Finds out that hash doesn't exist and uses
-    // hash which generates output that's long enough
-    rnp_assert_true(rstate,
+    // Finds out that hash doesn't exist and returns an error
+    rnp_assert_false(rstate,
                     ask_expert_details(&rnp, &ops, test_ecdsa_384, strlen(test_ecdsa_384)));
     rnp_cfg_free(&ops);
     rnp_end(&rnp);

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(rnpkeys_generatekey_testExpertMode),
       cmocka_unit_test(generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted),
       cmocka_unit_test(generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed),
-      cmocka_unit_test(generatekeyECDSA_explicitlySetWrongDigest_ShouldSuceed),
+      cmocka_unit_test(generatekeyECDSA_explicitlySetUnknownDigest_ShouldFail),
       cmocka_unit_test(test_utils_list),
       cmocka_unit_test(test_rnpcfg),
       cmocka_unit_test(test_load_user_prefs),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -69,7 +69,7 @@ void generatekeyECDSA_explicitlySetSmallOutputDigest_DigestAlgAdjusted(void **st
 
 void generatekeyECDSA_explicitlySetBiggerThanNeededDigest_ShouldSuceed(void **state);
 
-void generatekeyECDSA_explicitlySetWrongDigest_ShouldSuceed(void **state);
+void generatekeyECDSA_explicitlySetUnknownDigest_ShouldFail(void **state);
 
 void s2k_iteration_tuning(void **state);
 


### PR DESCRIPTION
Mostly done in #761, this adds support for setting the hash in `rnpkeys`

Required some changes to rnpcfg as there was no way to distinguish between the user having set the hash to SHA-256 on the command line, vs that just having been the default. Now hash defaults to SHA256 as before, except SM2 which still uses SM3 by default. But in all cases an alternative can be set with `--hash`.

Closes #436 
