### PR TITLE
Correctly copy all parsed pgp_key_t fields during load

### DIFF
--- a/src/lib/defs.h
+++ b/src/lib/defs.h
@@ -136,24 +136,24 @@
         }                                                                            \
     } while (/*CONSTCOND*/ 0)
 
-#define EXPAND_ARRAY_EX(str, arr, num)                                                \
-    do {                                                                              \
-        if (str->arr##c == str->arr##vsize) {                                         \
-            void *   __newarr;                                                        \
-            char *   __newarrc;                                                       \
-            unsigned __newsize;                                                       \
-            __newsize = str->arr##vsize + num;                                        \
-            if ((__newarrc = __newarr =                                               \
-                   realloc(str->arr##s, __newsize * sizeof(*str->arr##s))) == NULL) { \
-                (void) fprintf(stderr, "EXPAND_ARRAY - bad realloc\n");               \
-            } else {                                                                  \
-                (void) memset(&__newarrc[str->arr##vsize * sizeof(*str->arr##s)],     \
-                              0x0,                                                    \
-                              (__newsize - str->arr##vsize) * sizeof(*str->arr##s));  \
-                str->arr##s = __newarr;                                               \
-                str->arr##vsize = __newsize;                                          \
-            }                                                                         \
-        }                                                                             \
+#define EXPAND_ARRAY_EX(str, arr, num)                                               \
+    do {                                                                             \
+        if (str->arr##c == str->arr##vsize) {                                        \
+            void *   __newarr;                                                       \
+            char *   __newarrc;                                                      \
+            unsigned __newsize;                                                      \
+            __newsize = str->arr##vsize + num;                                       \
+            if ((__newarr = __newarrc = (char *) realloc(                            \
+                   str->arr##s, __newsize * sizeof(*str->arr##s))) == NULL) {        \
+                (void) fprintf(stderr, "EXPAND_ARRAY - bad realloc\n");              \
+            } else {                                                                 \
+                (void) memset(&__newarrc[str->arr##vsize * sizeof(*str->arr##s)],    \
+                              0x0,                                                   \
+                              (__newsize - str->arr##vsize) * sizeof(*str->arr##s)); \
+                str->arr##s = static_cast<decltype(str->arr##s)>(__newarr);          \
+                str->arr##vsize = __newsize;                                         \
+            }                                                                        \
+        }                                                                            \
     } while (/*CONSTCOND*/ 0)
 
 #define FREE_ARRAY(str, arr) \

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -66,7 +66,7 @@
 struct pgp_key_t {
     DYNARRAY(uint8_t *, uid);          /* array of user ids */
     DYNARRAY(pgp_rawpacket_t, packet); /* array of raw packets */
-    DYNARRAY(pgp_subsig_t, subsig);    /* array of signature subkeys */
+    DYNARRAY(pgp_subsig_t, subsig);    /* array of signatures */
     DYNARRAY(pgp_revoke_t, revoke);    /* array of signature revocations */
     list               subkey_grips;   /* list of subkey grips (for primary keys) */
     uint8_t *          primary_grip;   /* grip of primary key (for subkeys) */
@@ -117,6 +117,16 @@ void pgp_key_free_data(pgp_key_t *);
  * @return RNP_SUCCESS if operation succeeded or error code otherwise
  */
 rnp_result_t pgp_key_copy(pgp_key_t *dst, const pgp_key_t *src, bool pubonly);
+
+/**
+ * @brief Copy calculated key fields (grip, userid list, etc). Does not copy key packet/raw
+ *        packets. Zeroes dst so should not be used with pre-filled objects.
+ *
+ * @param dst destination of copying
+ * @param src source key
+ * @return RNP_SUCCESS if operation succeeded or error code otherwise
+ */
+rnp_result_t pgp_key_copy_fields(pgp_key_t *dst, const pgp_key_t *src);
 
 void pgp_free_user_prefs(pgp_user_prefs_t *prefs);
 

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -358,14 +358,14 @@ typedef struct pgp_user_prefs_t {
     uint8_t *key_server;
 } pgp_user_prefs_t;
 
-/** signature subpackets */
+/** information about the signature */
 typedef struct pgp_subsig_t {
-    uint32_t         uid;         /* index in userid array in key */
-    pgp_signature_t  sig;         /* trust signature */
+    uint32_t         uid;         /* index in userid array in key for certification sig */
+    pgp_signature_t  sig;         /* signature packet */
     uint8_t          trustlevel;  /* level of trust */
     uint8_t          trustamount; /* amount of trust */
-    uint8_t          key_flags;   /* key flags */
-    pgp_user_prefs_t prefs;       /* user preferences */
+    uint8_t          key_flags;   /* key flags for certification/direct key sig */
+    pgp_user_prefs_t prefs;       /* user preferences for certification sig */
 } pgp_subsig_t;
 
 struct rnp_keygen_ecc_params_t {

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -92,7 +92,30 @@ rnp_key_add_stream_rawpacket(pgp_key_t *key, int tag, pgp_dest_t *memdst)
     return true;
 }
 
-static bool
+bool
+rnp_key_add_rawpacket(pgp_key_t *key, const pgp_rawpacket_t *packet)
+{
+    pgp_rawpacket_t rawpkt = {};
+    EXPAND_ARRAY(key, packet);
+    if (!key->packets) {
+        RNP_LOG("Failed to expand packet array.");
+        return false;
+    }
+
+    rawpkt.tag = packet->tag;
+    rawpkt.length = packet->length;
+    rawpkt.raw = (uint8_t *) malloc(packet->length);
+    if (!rawpkt.raw) {
+        RNP_LOG("alloc failed");
+        return false;
+    }
+    memcpy(rawpkt.raw, packet->raw, packet->length);
+    key->packets[key->packetc++] = rawpkt;
+
+    return true;
+}
+
+bool
 rnp_key_add_key_rawpacket(pgp_key_t *key, pgp_key_pkt_t *pkt)
 {
     pgp_dest_t dst = {};

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -87,6 +87,10 @@ bool rnp_key_add_transferable_userid(pgp_key_t *key, pgp_transferable_userid_t *
 
 bool rnp_key_write_packets_stream(const pgp_key_t *key, pgp_dest_t *dst);
 
+bool rnp_key_add_key_rawpacket(pgp_key_t *key, pgp_key_pkt_t *pkt);
+
+bool rnp_key_add_rawpacket(pgp_key_t *key, const pgp_rawpacket_t *packet);
+
 bool rnp_key_to_src(const pgp_key_t *key, pgp_source_t *src);
 
 bool rnp_key_add_subkey_grip(pgp_key_t *key, uint8_t *grip);


### PR DESCRIPTION
This PR was aimed to fix #763.
As the side effect it changed the way keys are copied - now all fields are copied instead of reparsing to/from transferable key.

Fixes #763 

Now travis will fail - need to wait till #770 is merged.