### PR TITLE
Allow to set per-signature parameters

### DIFF
--- a/include/rnp/rnp2.h
+++ b/include/rnp/rnp2.h
@@ -517,14 +517,16 @@ rnp_result_t rnp_op_sign_add_signature(rnp_op_sign_t            op,
                                        rnp_key_handle_t         key,
                                        rnp_op_sign_signature_t *sig);
 
-/** @brief Set hash algorithm used during signature calculation. Not implemented yet.
+/** @brief Set hash algorithm used during signature calculation instead of default one, or one
+ *         set by rnp_op_encrypt_set_hash/rnp_op_sign_set_hash
  *  @param sig opaque signature context, returned via rnp_op_sign_add_signature
  *  @param hash hash algorithm to be used
  *  @return RNP_SUCCESS or error code if failed
  */
 rnp_result_t rnp_op_sign_signature_set_hash(rnp_op_sign_signature_t sig, const char *hash);
 
-/** @brief Set signature creation time. Not implemented yet.
+/** @brief Set signature creation time. By default current time is used or value set by
+ *         rnp_op_encrypt_set_creation_time/rnp_op_sign_set_creation_time
  *  @param sig opaque signature context, returned via rnp_op_sign_add_signature
  *  @param create creation time in seconds since Jan, 1 1970 UTC
  *  @return RNP_SUCCESS or error code if failed
@@ -532,7 +534,8 @@ rnp_result_t rnp_op_sign_signature_set_hash(rnp_op_sign_signature_t sig, const c
 rnp_result_t rnp_op_sign_signature_set_creation_time(rnp_op_sign_signature_t sig,
                                                      uint32_t                create);
 
-/** @brief Set signature expiration time. Not implemented yet.
+/** @brief Set signature expiration time. By default is set to never expire or to value set by
+ *         rnp_op_encrypt_set_expiration_time/rnp_op_sign_set_expiration_time
  *  @param sig opaque signature context, returned via rnp_op_sign_add_signature
  *  @param expire expiration time in seconds since the creation time. 0 value is used to mark
  *         signature as non-expiring (default value)

--- a/include/rnp/rnp_types.h
+++ b/include/rnp/rnp_types.h
@@ -100,6 +100,14 @@ typedef enum rnp_operation_t {
     RNP_OP_ARMOR = 3
 } rnp_operation_t;
 
+/* signature info structure */
+typedef struct rnp_signer_info_t {
+    pgp_key_t *    key;
+    pgp_hash_alg_t halg;
+    int64_t        sigcreate;
+    uint64_t       sigexpire;
+} rnp_signer_info_t;
+
 /** rnp operation context : contains configuration data about the currently ongoing operation.
  *
  *  Common fields which make sense for every operation:
@@ -125,8 +133,8 @@ typedef enum rnp_operation_t {
  *  - clearsign, detached : controls kind of the signed data. Both are mutually-exclusive.
  *    If both are false then attached signing is used.
  *  - halg : hash algorithm used to calculate signature(s)
- *  - signers : list of key pointers used to sign data
- *  - sigcreate, sigexpire : signature(s) creation and expiration times
+ *  - signers : list of rnp_signer_info_t structures describing signing key and parameters
+ *  - sigcreate, sigexpire : default signature(s) creation and expiration times
  *  - filename, filemtime, zalg, zlevel : only for attached signatures, see previous
  *
  *  For data decryption and/or verification there is not much of fields:
@@ -138,6 +146,7 @@ typedef enum rnp_operation_t {
  *  For enarmor/dearmor:
  *  - armortype: type of the armor headers (message, key, whatever else)
  */
+
 typedef struct rnp_ctx_t {
     rnp_t *         rnp;           /* Pointer to initialized rnp_t (temporary solution) */
     char *          filename;      /* name of the input file to store in literal data packet */
@@ -156,7 +165,7 @@ typedef struct rnp_ctx_t {
     bool            armor;         /* whether to use ASCII armor on output */
     list            recipients;    /* recipients of the encrypted message */
     list            passwords;     /* list of rnp_symmetric_pass_info_t */
-    list            signers;       /* list of signer key ids/user ids */
+    list            signers;       /* list of rnp_signer_info_t structures */
     unsigned        armortype;     /* type of the armored message, used in enarmor command */
     bool            discard;       /* discard the output */
     void *          on_signatures; /* handler for signed messages */

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -1944,12 +1944,10 @@ rnp_op_sign_destroy(rnp_op_sign_t op)
 }
 
 static void
-rnp_op_verify_on_signatures(pgp_parse_handler_t * handler,
-                            pgp_signature_info_t *sigs,
-                            int                   count)
+rnp_op_verify_on_signatures(pgp_signature_info_t *sigs, int count, void *param)
 {
     struct rnp_op_verify_signature_st res;
-    rnp_op_verify_t                   op = (rnp_op_verify_t) handler->param;
+    rnp_op_verify_t                   op = (rnp_op_verify_t) param;
 
     op->signatures = (rnp_op_verify_signature_t) calloc(count, sizeof(*op->signatures));
     if (!op->signatures) {

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -959,7 +959,7 @@ signed_src_finish(pgp_source_t *src)
 
     /* call the callback with signature infos */
     if (param->ctx->handler.on_signatures) {
-        param->ctx->handler.on_signatures(&param->ctx->handler, sinfos, sinfoc);
+        param->ctx->handler.on_signatures(sinfos, sinfoc, param->ctx->handler.param);
     }
 
     free(sinfos);

--- a/src/librepgp/stream-parse.h
+++ b/src/librepgp/stream-parse.h
@@ -41,9 +41,7 @@ typedef bool                        pgp_destination_func_t(pgp_parse_handler_t *
                                                            bool *               closedst,
                                                            const char *         filename);
 typedef bool pgp_source_func_t(pgp_parse_handler_t *handler, pgp_source_t *src);
-typedef void pgp_signatures_func_t(pgp_parse_handler_t * handler,
-                                   pgp_signature_info_t *sigs,
-                                   int                   count);
+typedef void pgp_signatures_func_t(pgp_signature_info_t *sigs, int count, void *param);
 
 /* handler used to return needed information during pgp source processing */
 typedef struct pgp_parse_handler_t {

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -110,9 +110,11 @@ rnpkeys_generatekey_testSignature(void **state)
                 ctx.filename = strdup("dummyfile.dat");
                 ctx.clearsign = cleartext;
                 rnp_assert_int_not_equal(rstate, ctx.halg, PGP_HASH_UNKNOWN);
-                pgp_key_t *key = rnp_key_store_get_key_by_name(rnp.secring, userId, NULL);
-                assert_non_null(key);
-                rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
+                rnp_signer_info_t sinfo = {};
+                sinfo.key = rnp_key_store_get_key_by_name(rnp.secring, userId, NULL);
+                sinfo.halg = ctx.halg;
+                assert_non_null(sinfo.key);
+                rnp_assert_non_null(rstate, list_append(&ctx.signers, &sinfo, sizeof(sinfo)));
 
                 /* Signing the memory */
                 ret = rnp_protect_mem(&ctx,

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -40,6 +40,7 @@ test_key_unlock_pgp(void **state)
     rnp_t                   rnp;
     pgp_key_t *             key = NULL;
     rnp_ctx_t               ctx;
+    rnp_signer_info_t       signer = {};
     rnp_result_t            ret;
     const char *            data = "my test data";
     char                    signature[512] = {0};
@@ -76,7 +77,9 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
     assert_non_null(key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
-    rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
+    signer.key = key;
+    signer.halg = ctx.halg;
+    rnp_assert_non_null(rstate, list_append(&ctx.signers, &signer, sizeof(signer)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
     rnp_assert_int_not_equal(rstate, ret, RNP_SUCCESS);
@@ -127,7 +130,9 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
     assert_non_null(key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
-    rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
+    signer.halg = ctx.halg;
+    signer.key = key;
+    rnp_assert_non_null(rstate, list_append(&ctx.signers, &signer, sizeof(signer)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
     rnp_assert_int_equal(rstate, ret, RNP_SUCCESS);
@@ -157,7 +162,9 @@ test_key_unlock_pgp(void **state)
     rnp_ctx_init(&ctx, &rnp);
     ctx.halg = pgp_str_to_hash_alg("SHA1");
     assert_non_null(key = rnp_key_store_get_key_by_name(rnp.secring, keyids[0], NULL));
-    rnp_assert_non_null(rstate, list_append(&ctx.signers, &key, sizeof(key)));
+    signer.key = key;
+    signer.halg = ctx.halg;
+    rnp_assert_non_null(rstate, list_append(&ctx.signers, &signer, sizeof(signer)));
     memset(signature, 0, sizeof(signature));
     ret = rnp_protect_mem(&ctx, data, strlen(data), signature, sizeof(signature), &siglen);
     rnp_assert_int_not_equal(rstate, ret, RNP_SUCCESS);


### PR DESCRIPTION
This PR improves control over signatures:
- allows to send custom param to on_signatures handler
- adds structure to set per-signer info (hash algorithm, signature expiration, creation, later on may be extended with other parameters like additional subpackets and so on)
- implements corresponding functions for FFI
- extends FFI tests

Fixes #651
Fixes #774 