### PR TITLE
Refactor pgp_key_t fields access

### DIFF
--- a/include/repgp/repgp_def.h
+++ b/include/repgp/repgp_def.h
@@ -88,8 +88,15 @@
 /* Salt size for hashing */
 #define PGP_SALT_SIZE 8
 
+/* Size of the keyid */
+#define PGP_KEY_ID_SIZE 8
+
 /* Size of the fingerprint */
 #define PGP_FINGERPRINT_SIZE 20
+#define PGP_FINGERPRINT_HEX_SIZE (PGP_FINGERPRINT_SIZE * 3) + 1
+
+/* Size of the key grip */
+#define PGP_KEY_GRIP_SIZE 20
 
 /** Old Packet Format Lengths.
  * Defines the meanings of the 2 bits for length type in the

--- a/src/lib/fingerprint.cpp
+++ b/src/lib/fingerprint.cpp
@@ -108,7 +108,7 @@ pgp_keyid(uint8_t *keyid, const size_t idlen, const pgp_key_pkt_t *key)
 }
 
 bool
-fingerprint_equal(pgp_fingerprint_t *fp1, pgp_fingerprint_t *fp2)
+fingerprint_equal(const pgp_fingerprint_t *fp1, const pgp_fingerprint_t *fp2)
 {
     return (fp1->length == fp2->length) &&
            (!memcmp(fp1->fingerprint, fp2->fingerprint, fp1->length));

--- a/src/lib/fingerprint.h
+++ b/src/lib/fingerprint.h
@@ -38,6 +38,6 @@ rnp_result_t pgp_fingerprint(pgp_fingerprint_t *fp, const pgp_key_pkt_t *key);
 
 rnp_result_t pgp_keyid(uint8_t *out, const size_t len, const pgp_key_pkt_t *key);
 
-bool fingerprint_equal(pgp_fingerprint_t *fp1, pgp_fingerprint_t *fp2);
+bool fingerprint_equal(const pgp_fingerprint_t *fp1, const pgp_fingerprint_t *fp2);
 
 #endif

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -59,7 +59,7 @@ load_generated_g10_key(pgp_key_t *    dst,
     pgp_key_provider_t prov = {};
 
     // this should generally be zeroed
-    assert(pgp_get_key_type(dst) == 0);
+    assert(pgp_key_get_type(dst) == 0);
     // if a primary is provided, make sure it's actually a primary key
     assert(!primary_key || pgp_key_is_primary_key(primary_key));
     // if a pubkey is provided, make sure it's actually a public key
@@ -315,7 +315,7 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
     if (!desc || !primary_pub || !primary_sec) {
         goto end;
     }
-    if (pgp_get_key_type(primary_sec) || pgp_get_key_type(primary_pub)) {
+    if (pgp_key_get_type(primary_sec) || pgp_key_get_type(primary_pub)) {
         RNP_LOG("invalid parameters (should be zeroed)");
         goto end;
     }
@@ -440,7 +440,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
         RNP_LOG("invalid parameters");
         goto end;
     }
-    if (pgp_get_key_type(subkey_sec) || pgp_get_key_type(subkey_pub)) {
+    if (pgp_key_get_type(subkey_sec) || pgp_key_get_type(subkey_pub)) {
         RNP_LOG("invalid parameters (should be zeroed)");
         goto end;
     }
@@ -465,7 +465,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
         }
         primary_seckey = decrypted_primary_seckey;
     } else {
-        primary_seckey = pgp_get_key_pkt(primary_sec);
+        primary_seckey = pgp_key_get_pkt(primary_sec);
     }
 
     // generate the raw key pair

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -63,7 +63,7 @@ load_generated_g10_key(pgp_key_t *    dst,
     // if a primary is provided, make sure it's actually a primary key
     assert(!primary_key || pgp_key_is_primary_key(primary_key));
     // if a pubkey is provided, make sure it's actually a public key
-    assert(!pubkey || pgp_is_key_public(pubkey));
+    assert(!pubkey || pgp_key_is_public(pubkey));
     // G10 always needs pubkey here
     assert(pubkey);
 
@@ -103,8 +103,8 @@ load_generated_g10_key(pgp_key_t *    dst,
     }
     // if a primary key is provided, it should match the sub with regards to type
     assert(!primary_key ||
-           (pgp_is_key_secret(primary_key) ==
-            pgp_is_key_secret((pgp_key_t *) list_back(rnp_key_store_get_keys(key_store)))));
+           (pgp_key_is_secret(primary_key) ==
+            pgp_key_is_secret((pgp_key_t *) list_back(rnp_key_store_get_keys(key_store)))));
     if (rnp_key_store_get_key_count(key_store) != 1) {
         goto end;
     }
@@ -458,7 +458,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
     ctx = {.op = PGP_OP_ADD_SUBKEY, .key = primary_sec};
 
     // decrypt the primary seckey if needed (for signatures)
-    if (pgp_is_key_encrypted(primary_sec)) {
+    if (pgp_key_is_encrypted(primary_sec)) {
         decrypted_primary_seckey = pgp_decrypt_seckey(primary_sec, password_provider, &ctx);
         if (!decrypted_primary_seckey) {
             goto end;

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -436,7 +436,7 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
         goto end;
     }
     if (!pgp_key_is_primary_key(primary_sec) || !pgp_key_is_primary_key(primary_pub) ||
-        !pgp_is_key_secret(primary_sec) || !pgp_is_key_public(primary_pub)) {
+        !pgp_key_is_secret(primary_sec) || !pgp_key_is_public(primary_pub)) {
         RNP_LOG("invalid parameters");
         goto end;
     }

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -45,7 +45,7 @@ rnp_key_matches_search(const pgp_key_t *key, const pgp_key_search_t *search)
     case PGP_KEY_SEARCH_FINGERPRINT:
         return fingerprint_equal(pgp_key_get_fp(key), &search->by.fingerprint);
     case PGP_KEY_SEARCH_GRIP:
-        return !memcmp(key->grip, search->by.grip, PGP_FINGERPRINT_SIZE);
+        return !memcmp(pgp_key_get_grip(key), search->by.grip, PGP_KEY_GRIP_SIZE);
     case PGP_KEY_SEARCH_USERID:
         if (pgp_key_has_userid(key, search->by.userid)) {
             return true;

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -41,7 +41,7 @@ rnp_key_matches_search(const pgp_key_t *key, const pgp_key_search_t *search)
     }
     switch (search->type) {
     case PGP_KEY_SEARCH_KEYID:
-        return memcmp(key->keyid, search->by.keyid, PGP_KEY_ID_SIZE) == 0;
+        return memcmp(pgp_key_get_keyid(key), search->by.keyid, PGP_KEY_ID_SIZE) == 0;
     case PGP_KEY_SEARCH_FINGERPRINT:
         return (key->fingerprint.length == search->by.fingerprint.length) &&
                !memcmp(key->fingerprint.fingerprint,

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -43,10 +43,7 @@ rnp_key_matches_search(const pgp_key_t *key, const pgp_key_search_t *search)
     case PGP_KEY_SEARCH_KEYID:
         return memcmp(pgp_key_get_keyid(key), search->by.keyid, PGP_KEY_ID_SIZE) == 0;
     case PGP_KEY_SEARCH_FINGERPRINT:
-        return (key->fingerprint.length == search->by.fingerprint.length) &&
-               !memcmp(key->fingerprint.fingerprint,
-                       search->by.fingerprint.fingerprint,
-                       key->fingerprint.length);
+        return fingerprint_equal(pgp_key_get_fp(key), &search->by.fingerprint);
     case PGP_KEY_SEARCH_GRIP:
         return !memcmp(key->grip, search->by.grip, PGP_FINGERPRINT_SIZE);
     case PGP_KEY_SEARCH_USERID:

--- a/src/lib/key-provider.cpp
+++ b/src/lib/key-provider.cpp
@@ -72,7 +72,7 @@ pgp_request_key(const pgp_key_provider_t *provider, const pgp_key_request_ctx_t 
         return NULL;
     }
     // confirm that the key actually matches the search criteria
-    if (!rnp_key_matches_search(key, &ctx->search) && pgp_is_key_secret(key) == ctx->secret) {
+    if (!rnp_key_matches_search(key, &ctx->search) && pgp_key_is_secret(key) == ctx->secret) {
         return NULL;
     }
     return key;
@@ -96,7 +96,7 @@ rnp_key_provider_key_ptr_list(const pgp_key_request_ctx_t *ctx, void *userdata)
     for (list_item *item = list_front(key_list); item; item = list_next(item)) {
         pgp_key_t *key = *(pgp_key_t **) item;
         if (rnp_key_matches_search(key, &ctx->search) &&
-            pgp_is_key_secret(key) == ctx->secret) {
+            pgp_key_is_secret(key) == ctx->secret) {
             return key;
         }
     }
@@ -125,7 +125,7 @@ rnp_key_provider_store(const pgp_key_request_ctx_t *ctx, void *userdata)
 
     for (pgp_key_t *key = rnp_key_store_search(ks, &ctx->search, NULL); key;
          key = rnp_key_store_search(ks, &ctx->search, key)) {
-        if (pgp_is_key_secret(key) == ctx->secret) {
+        if (pgp_key_is_secret(key) == ctx->secret) {
             return key;
         }
     }

--- a/src/lib/key-provider.h
+++ b/src/lib/key-provider.h
@@ -43,7 +43,7 @@ typedef struct pgp_key_search_t {
     pgp_key_search_type_t type;
     union {
         uint8_t           keyid[PGP_KEY_ID_SIZE];
-        uint8_t           grip[PGP_FINGERPRINT_SIZE];
+        uint8_t           grip[PGP_KEY_GRIP_SIZE];
         pgp_fingerprint_t fingerprint;
         char              userid[MAX_ID_LENGTH + 1];
     } by;

--- a/src/lib/packet-create.cpp
+++ b/src/lib/packet-create.cpp
@@ -152,7 +152,7 @@ pgp_write_xfer_key(pgp_dest_t *dst, const pgp_key_t *key, const rnp_key_store_t 
     if (!pgp_key_get_rawpacket_count(key)) {
         return false;
     }
-    if (pgp_is_key_public(key)) {
+    if (pgp_key_is_public(key)) {
         res = write_matching_packets(dst, key, keyring, pub_tags, ARRAY_SIZE(pub_tags));
     } else {
         res = write_matching_packets(dst, key, keyring, sec_tags, ARRAY_SIZE(sec_tags));

--- a/src/lib/pass-provider.cpp
+++ b/src/lib/pass-provider.cpp
@@ -99,7 +99,7 @@ rnp_password_provider_stdin(const pgp_password_ctx_t *ctx,
     }
 
     if ((ctx->op != PGP_OP_DECRYPT_SYM) && (ctx->op != PGP_OP_ENCRYPT_SYM)) {
-        rnp_strhexdump(keyidhex, ctx->key->keyid, PGP_KEY_ID_SIZE, "");
+        rnp_strhexdump(keyidhex, pgp_key_get_keyid(ctx->key), PGP_KEY_ID_SIZE, "");
         snprintf(target, sizeof(target), "key 0x%s", keyidhex);
     }
 start:

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -612,6 +612,18 @@ pgp_key_is_subkey(const pgp_key_t *key)
     return is_subkey_pkt(key->pkt.tag);
 }
 
+uint32_t
+pgp_key_get_expiration(const pgp_key_t *key)
+{
+    return (key->pkt.version >= 4) ? key->expiration : key->pkt.v3_days * 86400;
+}
+
+uint32_t
+pgp_key_get_creation(const pgp_key_t *key)
+{
+    return key->pkt.creation_time;
+}
+
 pgp_key_pkt_t *
 pgp_decrypt_seckey_pgp(const uint8_t *      data,
                        size_t               data_len,

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -576,22 +576,28 @@ pgp_key_is_encrypted(const pgp_key_t *key)
     return !pkt->material.secret;
 }
 
+uint8_t
+pgp_key_get_flags(const pgp_key_t *key)
+{
+    return key->key_flags;
+}
+
 bool
 pgp_key_can_sign(const pgp_key_t *key)
 {
-    return key->key_flags & PGP_KF_SIGN;
+    return pgp_key_get_flags(key) & PGP_KF_SIGN;
 }
 
 bool
 pgp_key_can_certify(const pgp_key_t *key)
 {
-    return key->key_flags & PGP_KF_CERTIFY;
+    return pgp_key_get_flags(key) & PGP_KF_CERTIFY;
 }
 
 bool
 pgp_key_can_encrypt(const pgp_key_t *key)
 {
-    return key->key_flags & PGP_KF_ENCRYPT;
+    return pgp_key_get_flags(key) & PGP_KF_ENCRYPT;
 }
 
 bool
@@ -1361,7 +1367,7 @@ find_suitable_key(pgp_op_t            op,
     if (!key) {
         return NULL;
     }
-    if (key->key_flags & desired_usage) {
+    if (pgp_key_get_flags(key) & desired_usage) {
         return key;
     }
     list_item *           subkey_grip = list_front(key->subkey_grips);
@@ -1371,7 +1377,7 @@ find_suitable_key(pgp_op_t            op,
     while (subkey_grip) {
         memcpy(ctx.search.by.grip, subkey_grip, PGP_KEY_GRIP_SIZE);
         pgp_key_t *subkey = pgp_request_key(key_provider, &ctx);
-        if (subkey && (subkey->key_flags & desired_usage)) {
+        if (subkey && (pgp_key_get_flags(subkey) & desired_usage)) {
             return subkey;
         }
         subkey_grip = list_next(subkey_grip);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -547,6 +547,12 @@ pgp_key_get_alg(const pgp_key_t *key)
     return key->pkt.alg;
 }
 
+pgp_version_t
+pgp_key_get_version(const pgp_key_t *key)
+{
+    return key->pkt.version;
+}
+
 int
 pgp_key_get_type(const pgp_key_t *key)
 {

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -474,18 +474,18 @@ pgp_key_copy_fields(pgp_key_t *dst, const pgp_key_t *src)
 
     /* subkey grips */
     for (list_item *grip = list_front(src->subkey_grips); grip; grip = list_next(grip)) {
-        if (!list_append(&dst->subkey_grips, grip, PGP_FINGERPRINT_SIZE)) {
+        if (!list_append(&dst->subkey_grips, grip, PGP_KEY_GRIP_SIZE)) {
             goto error;
         }
     }
 
     /* primary grip */
     if (src->primary_grip) {
-        dst->primary_grip = (uint8_t *) malloc(PGP_FINGERPRINT_SIZE);
+        dst->primary_grip = (uint8_t *) malloc(PGP_KEY_GRIP_SIZE);
         if (!dst->primary_grip) {
             goto error;
         }
-        memcpy(dst->primary_grip, src->primary_grip, PGP_FINGERPRINT_SIZE);
+        memcpy(dst->primary_grip, src->primary_grip, PGP_KEY_GRIP_SIZE);
     }
 
     /* expiration */
@@ -495,7 +495,7 @@ pgp_key_copy_fields(pgp_key_t *dst, const pgp_key_t *src)
     dst->key_flags = src->key_flags;
 
     /* key id / fingerprint / grip */
-    memcpy(dst->keyid, src->keyid, PGP_KEY_ID_SIZE);
+    memcpy(dst->keyid, src->keyid, sizeof(dst->keyid));
     memcpy(&dst->fingerprint, &src->fingerprint, sizeof(dst->fingerprint));
     memcpy(&dst->grip, &src->grip, sizeof(dst->grip));
 
@@ -711,6 +711,12 @@ const pgp_fingerprint_t *
 pgp_key_get_fp(const pgp_key_t *key)
 {
     return &key->fingerprint;
+}
+
+const uint8_t *
+pgp_key_get_grip(const pgp_key_t *key)
+{
+    return key->grip;
 }
 
 /**
@@ -1335,7 +1341,7 @@ find_suitable_key(pgp_op_t            op,
     ctx.search.type = PGP_KEY_SEARCH_GRIP;
 
     while (subkey_grip) {
-        memcpy(ctx.search.by.grip, subkey_grip, PGP_FINGERPRINT_SIZE);
+        memcpy(ctx.search.by.grip, subkey_grip, PGP_KEY_GRIP_SIZE);
         pgp_key_t *subkey = pgp_request_key(key_provider, &ctx);
         if (subkey && (subkey->key_flags & desired_usage)) {
             return subkey;

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -534,25 +534,25 @@ error:
 */
 
 const pgp_key_pkt_t *
-pgp_get_key_pkt(const pgp_key_t *key)
+pgp_key_get_pkt(const pgp_key_t *key)
 {
     return &key->pkt;
 }
 
 const pgp_key_material_t *
-pgp_get_key_material(const pgp_key_t *key)
+pgp_key_get_material(const pgp_key_t *key)
 {
     return &key->pkt.material;
 }
 
 pgp_pubkey_alg_t
-pgp_get_key_alg(const pgp_key_t *key)
+pgp_key_get_alg(const pgp_key_t *key)
 {
     return key->pkt.alg;
 }
 
 int
-pgp_get_key_type(const pgp_key_t *key)
+pgp_key_get_type(const pgp_key_t *key)
 {
     return key->pkt.tag;
 }
@@ -576,7 +576,7 @@ pgp_key_is_encrypted(const pgp_key_t *key)
         return false;
     }
 
-    const pgp_key_pkt_t *pkt = pgp_get_key_pkt(key);
+    const pgp_key_pkt_t *pkt = pgp_key_get_pkt(key);
     return !pkt->material.secret;
 }
 
@@ -694,21 +694,15 @@ pgp_decrypt_seckey(const pgp_key_t *              key,
     }
     // attempt to decrypt with the provided password
     packet = pgp_key_get_rawpacket(key, 0);
-    decrypted_seckey = decryptor(packet->raw, packet->length, pgp_get_key_pkt(key), password);
+    decrypted_seckey = decryptor(packet->raw, packet->length, pgp_key_get_pkt(key), password);
 
 done:
     pgp_forget(password, sizeof(password));
     return decrypted_seckey;
 }
 
-/**
-\ingroup Core_Keys
-\brief Get Key ID from key
-\param key Key to get Key ID from
-\return Pointer to Key ID inside key
-*/
 const uint8_t *
-pgp_get_key_id(const pgp_key_t *key)
+pgp_key_get_keyid(const pgp_key_t *key)
 {
     return key->keyid;
 }
@@ -1161,7 +1155,7 @@ pgp_key_protect(pgp_key_t *                  key,
     // write the protected key to packets[0]
     if (!write_key_to_rawpacket(decrypted_seckey,
                                 pgp_key_get_rawpacket(key, 0),
-                                (pgp_content_enum) pgp_get_key_type(key),
+                                (pgp_content_enum) pgp_key_get_type(key),
                                 format,
                                 new_password)) {
         goto done;
@@ -1208,7 +1202,7 @@ pgp_key_unprotect(pgp_key_t *key, const pgp_password_provider_t *password_provid
     seckey->sec_protection.s2k.usage = PGP_S2KU_NONE;
     if (!write_key_to_rawpacket(seckey,
                                 pgp_key_get_rawpacket(key, 0),
-                                (pgp_content_enum) pgp_get_key_type(key),
+                                (pgp_content_enum) pgp_key_get_type(key),
                                 key->format,
                                 NULL)) {
         goto done;

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -560,13 +560,13 @@ pgp_get_key_type(const pgp_key_t *key)
 bool
 pgp_is_key_public(const pgp_key_t *key)
 {
-    return pgp_is_public_key_tag((pgp_content_enum) key->pkt.tag);
+    return is_public_key_pkt(key->pkt.tag);
 }
 
 bool
 pgp_is_key_secret(const pgp_key_t *key)
 {
-    return pgp_is_secret_key_tag((pgp_content_enum) key->pkt.tag);
+    return is_secret_key_pkt(key->pkt.tag);
 }
 
 bool
@@ -599,63 +599,15 @@ pgp_key_can_encrypt(const pgp_key_t *key)
 }
 
 bool
-pgp_is_secret_key_tag(int tag)
-{
-    switch (tag) {
-    case PGP_PTAG_CT_SECRET_KEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool
-pgp_is_public_key_tag(int tag)
-{
-    switch (tag) {
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool
-pgp_is_primary_key_tag(int tag)
-{
-    switch (tag) {
-    case PGP_PTAG_CT_PUBLIC_KEY:
-    case PGP_PTAG_CT_SECRET_KEY:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool
 pgp_key_is_primary_key(const pgp_key_t *key)
 {
-    return pgp_is_primary_key_tag((pgp_content_enum) key->pkt.tag);
-}
-
-bool
-pgp_is_subkey_tag(pgp_content_enum tag)
-{
-    switch (tag) {
-    case PGP_PTAG_CT_PUBLIC_SUBKEY:
-    case PGP_PTAG_CT_SECRET_SUBKEY:
-        return true;
-    default:
-        return false;
-    }
+    return is_primary_key_pkt(key->pkt.tag);
 }
 
 bool
 pgp_key_is_subkey(const pgp_key_t *key)
 {
-    return pgp_is_subkey_tag((pgp_content_enum) key->pkt.tag);
+    return is_subkey_pkt(key->pkt.tag);
 }
 
 pgp_key_pkt_t *

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -233,8 +233,8 @@ pgp_key_free_data(pgp_key_t *key)
         return;
     }
 
-    for (n = 0; n < pgp_get_userid_count(key); ++n) {
-        free((void *) pgp_get_userid(key, n));
+    for (n = 0; n < pgp_key_get_userid_count(key); ++n) {
+        free((void *) pgp_key_get_userid(key, n));
     }
     list_destroy(&key->uids);
 
@@ -442,8 +442,8 @@ pgp_key_copy_fields(pgp_key_t *dst, const pgp_key_t *src)
     rnp_result_t tmpret;
 
     /* uids */
-    for (size_t i = 0; i < pgp_get_userid_count(src); i++) {
-        if (!pgp_add_userid(dst, (const uint8_t *) pgp_get_userid(src, i))) {
+    for (size_t i = 0; i < pgp_key_get_userid_count(src); i++) {
+        if (!pgp_key_add_userid(dst, (const uint8_t *) pgp_key_get_userid(src, i))) {
             goto error;
         }
     }
@@ -714,7 +714,7 @@ pgp_key_get_keyid(const pgp_key_t *key)
 \return Num of user ids
 */
 size_t
-pgp_get_userid_count(const pgp_key_t *key)
+pgp_key_get_userid_count(const pgp_key_t *key)
 {
     return list_length(key->uids);
 }
@@ -727,20 +727,20 @@ pgp_get_userid_count(const pgp_key_t *key)
 \return Pointer to requested user id
 */
 const char *
-pgp_get_userid(const pgp_key_t *key, size_t idx)
+pgp_key_get_userid(const pgp_key_t *key, size_t idx)
 {
     list_item *uid = list_at(key->uids, idx);
     return uid ? *((char **) uid) : NULL;
 }
 
 const char *
-pgp_get_primary_userid(const pgp_key_t *key)
+pgp_key_get_primary_userid(const pgp_key_t *key)
 {
     if (key->uid0_set) {
-        return pgp_get_userid(key, key->uid0);
+        return pgp_key_get_userid(key, key->uid0);
     }
     if (list_length(key->uids)) {
-        return pgp_get_userid(key, 0);
+        return pgp_key_get_userid(key, 0);
     }
     return NULL;
 }
@@ -791,7 +791,7 @@ copy_userid(uint8_t **dst, const uint8_t *src)
 \return Pointer to new User ID
 */
 uint8_t *
-pgp_add_userid(pgp_key_t *key, const uint8_t *userid)
+pgp_key_add_userid(pgp_key_t *key, const uint8_t *userid)
 {
     list_item *uidp = list_append(&key->uids, NULL, sizeof(userid));
     if (!(uidp)) {

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -707,6 +707,12 @@ pgp_key_get_keyid(const pgp_key_t *key)
     return key->keyid;
 }
 
+const pgp_fingerprint_t *
+pgp_key_get_fp(const pgp_key_t *key)
+{
+    return &key->fingerprint;
+}
+
 /**
 \ingroup Core_Keys
 \brief How many User IDs in this key?

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -208,7 +208,7 @@ pgp_rawpacket_free(pgp_rawpacket_t *packet)
 }
 
 bool
-pgp_key_from_keypkt(pgp_key_t *key, const pgp_key_pkt_t *pkt, const pgp_content_enum tag)
+pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt, const pgp_content_enum tag)
 {
     assert(!key->pkt.version);
     assert(is_key_pkt(tag));

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -84,12 +84,12 @@ struct pgp_key_t {
 
 struct pgp_key_t *pgp_key_new(void);
 
-/** create a key from pgp_keydata_key_t
+/** create a key from the key pkt
  *
  *  This sets up basic properties of the key like keyid/fpr/grip, type, etc.
  *  It does not set primary_grip or subkey_grips (the key store does this).
  */
-bool pgp_key_from_keypkt(pgp_key_t *key, const pgp_key_pkt_t *pkt, const pgp_content_enum tag);
+bool pgp_key_from_pkt(pgp_key_t *key, const pgp_key_pkt_t *pkt, const pgp_content_enum tag);
 
 /** free the internal data of a key *and* the key structure itself
  *

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -159,6 +159,22 @@ bool    pgp_key_can_sign(const pgp_key_t *key);
 bool    pgp_key_can_certify(const pgp_key_t *key);
 bool    pgp_key_can_encrypt(const pgp_key_t *key);
 
+/**
+ * @brief Get key's expiration time in seconds. If 0 then it doesn't expire.
+ *
+ * @param key populated key, could not be NULL
+ * @return key expiration time
+ */
+uint32_t pgp_key_get_expiration(const pgp_key_t *key);
+
+/**
+ * @brief Get key's creation time in seconds since Jan, 1 1980.
+ *
+ * @param key populated key, could not be NULL
+ * @return key creation time
+ */
+uint32_t pgp_key_get_creation(const pgp_key_t *key);
+
 bool pgp_key_is_public(const pgp_key_t *);
 bool pgp_key_is_secret(const pgp_key_t *);
 bool pgp_key_is_primary_key(const pgp_key_t *key);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -154,9 +154,10 @@ int pgp_key_get_type(const pgp_key_t *key);
 
 bool pgp_key_is_encrypted(const pgp_key_t *);
 
-bool pgp_key_can_sign(const pgp_key_t *key);
-bool pgp_key_can_certify(const pgp_key_t *key);
-bool pgp_key_can_encrypt(const pgp_key_t *key);
+uint8_t pgp_key_get_flags(const pgp_key_t *key);
+bool    pgp_key_can_sign(const pgp_key_t *key);
+bool    pgp_key_can_certify(const pgp_key_t *key);
+bool    pgp_key_can_encrypt(const pgp_key_t *key);
 
 bool pgp_key_is_public(const pgp_key_t *);
 bool pgp_key_is_secret(const pgp_key_t *);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -152,14 +152,14 @@ pgp_pubkey_alg_t pgp_get_key_alg(const pgp_key_t *key);
 
 int pgp_get_key_type(const pgp_key_t *key);
 
-bool pgp_is_key_encrypted(const pgp_key_t *);
+bool pgp_key_is_encrypted(const pgp_key_t *);
 
 bool pgp_key_can_sign(const pgp_key_t *key);
 bool pgp_key_can_certify(const pgp_key_t *key);
 bool pgp_key_can_encrypt(const pgp_key_t *key);
 
-bool pgp_is_key_public(const pgp_key_t *);
-bool pgp_is_key_secret(const pgp_key_t *);
+bool pgp_key_is_public(const pgp_key_t *);
+bool pgp_key_is_secret(const pgp_key_t *);
 bool pgp_key_is_primary_key(const pgp_key_t *key);
 bool pgp_key_is_subkey(const pgp_key_t *key);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -174,7 +174,7 @@ pgp_key_pkt_t *pgp_decrypt_seckey(const pgp_key_t *,
 
 /**
  * @brief Get key's keyid
- * 
+ *
  * @param key populated key, should not be NULL
  * @return pointer to the 8-byte buffer with keyid
  */

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -196,6 +196,32 @@ const pgp_fingerprint_t *pgp_key_get_fp(const pgp_key_t *key);
  */
 const uint8_t *pgp_key_get_grip(const pgp_key_t *key);
 
+/**
+ * @brief Get primary key's grip for the subkey, if available.
+ *
+ * @param key subkey, which primary key's grip should be returned
+ * @return pointer to the array with grip or NULL if it is not available
+ */
+const uint8_t *pgp_key_get_primary_grip(const pgp_key_t *key);
+
+/**
+ * @brief Set primary key's grip for the subkey
+ *
+ * @param key subkey
+ * @param grip buffer with grip, should not be NULL
+ * @return true on success or false otherwise (key is not subkey, or allocation failed)
+ */
+bool pgp_key_set_primary_grip(pgp_key_t *key, const uint8_t *grip);
+
+/**
+ * @brief Link key with subkey via primary_grip and subkey_grips list
+ *
+ * @param key primary key
+ * @param subkey subkey of the primary key
+ * @return true on success or false otherwise (allocation failed, wrong key types)
+ */
+bool pgp_key_link_subkey_grip(pgp_key_t *key, pgp_key_t *subkey);
+
 size_t pgp_key_get_userid_count(const pgp_key_t *);
 
 const char *pgp_key_get_userid(const pgp_key_t *, size_t);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -152,21 +152,14 @@ pgp_pubkey_alg_t pgp_get_key_alg(const pgp_key_t *key);
 
 int pgp_get_key_type(const pgp_key_t *key);
 
-bool pgp_is_key_public(const pgp_key_t *);
-
-bool pgp_is_key_secret(const pgp_key_t *);
-
 bool pgp_is_key_encrypted(const pgp_key_t *);
 
 bool pgp_key_can_sign(const pgp_key_t *key);
 bool pgp_key_can_certify(const pgp_key_t *key);
 bool pgp_key_can_encrypt(const pgp_key_t *key);
 
-bool pgp_is_primary_key_tag(int tag);
-bool pgp_is_subkey_tag(pgp_content_enum tag);
-bool pgp_is_secret_key_tag(int tag);
-bool pgp_is_public_key_tag(int tag);
-
+bool pgp_is_key_public(const pgp_key_t *);
+bool pgp_is_key_secret(const pgp_key_t *);
 bool pgp_key_is_primary_key(const pgp_key_t *key);
 bool pgp_key_is_subkey(const pgp_key_t *key);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -180,6 +180,14 @@ pgp_key_pkt_t *pgp_decrypt_seckey(const pgp_key_t *,
  */
 const uint8_t *pgp_key_get_keyid(const pgp_key_t *key);
 
+/**
+ * @brief Get key's fingerprint
+ *
+ * @param key populated key, should not be NULL
+ * @return pointer to the fingerprint structure
+ */
+const pgp_fingerprint_t *pgp_key_get_fp(const pgp_key_t *key);
+
 size_t pgp_key_get_userid_count(const pgp_key_t *);
 
 const char *pgp_key_get_userid(const pgp_key_t *, size_t);

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -144,13 +144,13 @@ bool pgp_user_prefs_set_ks_prefs(pgp_user_prefs_t *prefs, const uint8_t *vals, s
 
 bool pgp_user_prefs_add_ks_pref(pgp_user_prefs_t *prefs, pgp_key_server_prefs_t val);
 
-const pgp_key_pkt_t *pgp_get_key_pkt(const pgp_key_t *);
+const pgp_key_pkt_t *pgp_key_get_pkt(const pgp_key_t *);
 
-const pgp_key_material_t *pgp_get_key_material(const pgp_key_t *key);
+const pgp_key_material_t *pgp_key_get_material(const pgp_key_t *key);
 
-pgp_pubkey_alg_t pgp_get_key_alg(const pgp_key_t *key);
+pgp_pubkey_alg_t pgp_key_get_alg(const pgp_key_t *key);
 
-int pgp_get_key_type(const pgp_key_t *key);
+int pgp_key_get_type(const pgp_key_t *key);
 
 bool pgp_key_is_encrypted(const pgp_key_t *);
 
@@ -172,7 +172,13 @@ pgp_key_pkt_t *pgp_decrypt_seckey(const pgp_key_t *,
                                   const pgp_password_provider_t *,
                                   const pgp_password_ctx_t *);
 
-const unsigned char *pgp_get_key_id(const pgp_key_t *);
+/**
+ * @brief Get key's keyid
+ * 
+ * @param key populated key, should not be NULL
+ * @return pointer to the 8-byte buffer with keyid
+ */
+const uint8_t *pgp_key_get_keyid(const pgp_key_t *key);
 
 size_t pgp_get_userid_count(const pgp_key_t *);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -180,15 +180,15 @@ pgp_key_pkt_t *pgp_decrypt_seckey(const pgp_key_t *,
  */
 const uint8_t *pgp_key_get_keyid(const pgp_key_t *key);
 
-size_t pgp_get_userid_count(const pgp_key_t *);
+size_t pgp_key_get_userid_count(const pgp_key_t *);
 
-const char *pgp_get_userid(const pgp_key_t *, size_t);
+const char *pgp_key_get_userid(const pgp_key_t *, size_t);
 
-const char *pgp_get_primary_userid(const pgp_key_t *);
+const char *pgp_key_get_primary_userid(const pgp_key_t *);
 
 bool pgp_key_has_userid(const pgp_key_t *, const char *);
 
-unsigned char *pgp_add_userid(pgp_key_t *, const unsigned char *);
+unsigned char *pgp_key_add_userid(pgp_key_t *, const unsigned char *);
 
 pgp_revoke_t *pgp_key_add_revoke(pgp_key_t *);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -73,7 +73,7 @@ struct pgp_key_t {
     uint8_t       key_flags;    /* key flags */
     uint8_t       keyid[PGP_KEY_ID_SIZE];
     pgp_fingerprint_t  fingerprint;
-    uint8_t            grip[PGP_FINGERPRINT_SIZE];
+    uint8_t            grip[PGP_KEY_GRIP_SIZE];
     uint32_t           uid0;         /* primary uid index in uids array */
     unsigned           uid0_set : 1; /* flag for the above */
     uint8_t            revoked;      /* key has been revoked */
@@ -187,6 +187,14 @@ const uint8_t *pgp_key_get_keyid(const pgp_key_t *key);
  * @return pointer to the fingerprint structure
  */
 const pgp_fingerprint_t *pgp_key_get_fp(const pgp_key_t *key);
+
+/**
+ * @brief Get key's grip
+ *
+ * @param key populated key, should not be NULL
+ * @return pointer to buffer with the grip
+ */
+const uint8_t *pgp_key_get_grip(const pgp_key_t *key);
 
 size_t pgp_key_get_userid_count(const pgp_key_t *);
 

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -150,6 +150,8 @@ const pgp_key_material_t *pgp_key_get_material(const pgp_key_t *key);
 
 pgp_pubkey_alg_t pgp_key_get_alg(const pgp_key_t *key);
 
+pgp_version_t pgp_key_get_version(const pgp_key_t *key);
+
 int pgp_key_get_type(const pgp_key_t *key);
 
 bool pgp_key_is_encrypted(const pgp_key_t *);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -779,7 +779,7 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
         changed = pgp_key_get_rawpacket_count(exkey) > expackets;
 
         /* add secret key if there is one */
-        if (!pgp_is_key_secret(imported)) {
+        if (!pgp_key_is_secret(imported)) {
             if (changed && print) {
                 repgp_print_key(rnp->resfp, rnp->pubring, exkey, "pub", 0);
             }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -624,12 +624,8 @@ rnp_match_keys_json(rnp_t *rnp, char **json, char *name, const char *fmt, const 
                 }
             } else {
                 json_object *obj = json_object_new_object();
-                repgp_sprint_json(rnp->pubring,
-                                  key,
-                                  obj,
-                                  pgp_is_primary_key_tag(pgp_get_key_type(key)) ? "pub" :
-                                                                                  "sub",
-                                  psigs);
+                repgp_sprint_json(
+                  rnp->pubring, key, obj, pgp_key_is_primary_key(key) ? "pub" : "sub", psigs);
                 json_object_array_add(id_array, obj);
             }
         }

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -769,7 +769,7 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
             RNP_LOG("failed to create key copy");
             continue;
         }
-        exkey = rnp_key_store_get_key_by_grip(rnp->pubring, imported->grip);
+        exkey = rnp_key_store_get_key_by_grip(rnp->pubring, pgp_key_get_grip(imported));
         expackets = exkey ? pgp_key_get_rawpacket_count(exkey) : 0;
         if (!(exkey = rnp_key_store_add_key(rnp->pubring, &keycp))) {
             RNP_LOG("failed to add key to the keyring");
@@ -790,7 +790,7 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
             RNP_LOG("failed to create secret key copy");
             continue;
         }
-        exkey = rnp_key_store_get_key_by_grip(rnp->secring, imported->grip);
+        exkey = rnp_key_store_get_key_by_grip(rnp->secring, pgp_key_get_grip(imported));
         expackets = exkey ? pgp_key_get_rawpacket_count(exkey) : 0;
         if (!(exkey = rnp_key_store_add_key(rnp->secring, &keycp))) {
             RNP_LOG("failed to add key to the keyring");

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -3252,7 +3252,7 @@ get_key_require_public(rnp_key_handle_t handle)
 
         // try keyid
         request.search.type = PGP_KEY_SEARCH_KEYID;
-        memcpy(request.search.by.keyid, handle->sec->keyid, PGP_KEY_ID_SIZE);
+        memcpy(request.search.by.keyid, pgp_key_get_keyid(handle->sec), PGP_KEY_ID_SIZE);
         handle->pub = pgp_request_key(&handle->ffi->key_provider, &request);
     }
     return handle->pub;
@@ -3282,7 +3282,7 @@ get_key_require_secret(rnp_key_handle_t handle)
 
         // try keyid
         request.search.type = PGP_KEY_SEARCH_KEYID;
-        memcpy(request.search.by.keyid, handle->pub->keyid, PGP_KEY_ID_SIZE);
+        memcpy(request.search.by.keyid, pgp_key_get_keyid(handle->pub), PGP_KEY_ID_SIZE);
         handle->sec = pgp_request_key(&handle->ffi->key_provider, &request);
     }
     return handle->sec;
@@ -3442,7 +3442,8 @@ rnp_key_get_keyid(rnp_key_handle_t handle, char **keyid)
         return RNP_ERROR_OUT_OF_MEMORY;
 
     pgp_key_t *key = get_key_prefer_public(handle);
-    if (!rnp_hex_encode(key->keyid, PGP_KEY_ID_SIZE, *keyid, hex_len, RNP_HEX_UPPERCASE)) {
+    if (!rnp_hex_encode(
+          pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, *keyid, hex_len, RNP_HEX_UPPERCASE)) {
         return RNP_ERROR_GENERIC;
     }
     return RNP_SUCCESS;
@@ -4186,7 +4187,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     // keyid
     char keyid[PGP_KEY_ID_SIZE * 2 + 1];
     if (!rnp_hex_encode(
-          key->keyid, PGP_KEY_ID_SIZE, keyid, sizeof(keyid), RNP_HEX_UPPERCASE)) {
+          pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, keyid, sizeof(keyid), RNP_HEX_UPPERCASE)) {
         return RNP_ERROR_GENERIC;
     }
     if (!add_json_string_field(jso, "keyid", keyid)) {
@@ -4496,7 +4497,8 @@ key_iter_get_item(const rnp_identifier_iterator_t it, char *buf, size_t buf_len)
     const pgp_key_t *key = it->keyp;
     switch (it->type) {
     case PGP_KEY_SEARCH_KEYID:
-        if (!rnp_hex_encode(key->keyid, sizeof(key->keyid), buf, buf_len, RNP_HEX_UPPERCASE)) {
+        if (!rnp_hex_encode(
+              pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, buf, buf_len, RNP_HEX_UPPERCASE)) {
             return false;
         }
         break;

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -4237,8 +4237,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     }
     json_object_object_add(jso, "creation time", jsocreation_time);
     // expiration
-    json_object *jsoexpiration = json_object_new_int64(
-      pubkey->version >= 4 ? key->expiration : (pubkey->v3_days * 86400));
+    json_object *jsoexpiration = json_object_new_int64(pgp_key_get_expiration(key));
     if (!jsoexpiration) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -3844,7 +3844,7 @@ done:
 static rnp_result_t
 add_json_public_mpis(json_object *jso, pgp_key_t *key)
 {
-    const pgp_key_material_t *km = pgp_get_key_material(key);
+    const pgp_key_material_t *km = pgp_key_get_material(key);
     switch (km->alg) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
@@ -3870,8 +3870,8 @@ add_json_public_mpis(json_object *jso, pgp_key_t *key)
 static rnp_result_t
 add_json_secret_mpis(json_object *jso, pgp_key_t *key)
 {
-    const pgp_key_material_t *km = pgp_get_key_material(key);
-    switch (pgp_get_key_pkt(key)->alg) {
+    const pgp_key_material_t *km = pgp_key_get_material(key);
+    switch (pgp_key_get_alg(key)) {
     case PGP_PKA_RSA:
     case PGP_PKA_RSA_ENCRYPT_ONLY:
     case PGP_PKA_RSA_SIGN_ONLY:
@@ -4126,7 +4126,7 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     bool                 have_pub = handle->pub != NULL;
     pgp_key_t *          key = get_key_prefer_public(handle);
     const char *         str = NULL;
-    const pgp_key_pkt_t *pubkey = pgp_get_key_pkt(key);
+    const pgp_key_pkt_t *pubkey = pgp_key_get_pkt(key);
 
     // type
     ARRAY_LOOKUP_BY_ID(pubkey_alg_map, type, string, pubkey->alg, str);

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -4244,11 +4244,11 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     }
     json_object_object_add(jso, "expiration", jsoexpiration);
     // key flags (usage)
-    if (!add_json_key_usage(jso, key->key_flags)) {
+    if (!add_json_key_usage(jso, pgp_key_get_flags(key))) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // key flags (other)
-    if (!add_json_key_flags(jso, key->key_flags)) {
+    if (!add_json_key_flags(jso, pgp_key_get_flags(key))) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }
     // parent / subkeys

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -3244,7 +3244,7 @@ get_key_require_public(rnp_key_handle_t handle)
 
         // try fingerprint
         request.search.type = PGP_KEY_SEARCH_FINGERPRINT;
-        request.search.by.fingerprint = handle->sec->fingerprint;
+        request.search.by.fingerprint = *pgp_key_get_fp(handle->sec);
         handle->pub = pgp_request_key(&handle->ffi->key_provider, &request);
         if (handle->pub) {
             return handle->pub;
@@ -3274,7 +3274,7 @@ get_key_require_secret(rnp_key_handle_t handle)
 
         // try fingerprint
         request.search.type = PGP_KEY_SEARCH_FINGERPRINT;
-        request.search.by.fingerprint = handle->pub->fingerprint;
+        request.search.by.fingerprint = *pgp_key_get_fp(handle->pub);
         handle->sec = pgp_request_key(&handle->ffi->key_provider, &request);
         if (handle->sec) {
             return handle->sec;
@@ -3420,8 +3420,8 @@ rnp_key_get_fprint(rnp_key_handle_t handle, char **fprint)
         return RNP_ERROR_OUT_OF_MEMORY;
 
     pgp_key_t *key = get_key_prefer_public(handle);
-    if (!rnp_hex_encode(key->fingerprint.fingerprint,
-                        key->fingerprint.length,
+    if (!rnp_hex_encode(pgp_key_get_fp(key)->fingerprint,
+                        pgp_key_get_fp(key)->length,
                         *fprint,
                         hex_len,
                         RNP_HEX_UPPERCASE)) {
@@ -4195,8 +4195,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
     }
     // fingerprint
     char fpr[PGP_FINGERPRINT_SIZE * 2 + 1];
-    if (!rnp_hex_encode(key->fingerprint.fingerprint,
-                        key->fingerprint.length,
+    if (!rnp_hex_encode(pgp_key_get_fp(key)->fingerprint,
+                        pgp_key_get_fp(key)->length,
                         fpr,
                         sizeof(fpr),
                         RNP_HEX_UPPERCASE)) {
@@ -4503,8 +4503,8 @@ key_iter_get_item(const rnp_identifier_iterator_t it, char *buf, size_t buf_len)
         }
         break;
     case PGP_KEY_SEARCH_FINGERPRINT:
-        if (!rnp_hex_encode(key->fingerprint.fingerprint,
-                            key->fingerprint.length,
+        if (!rnp_hex_encode(pgp_key_get_fp(key)->fingerprint,
+                            pgp_key_get_fp(key)->length,
                             buf,
                             buf_len,
                             RNP_HEX_UPPERCASE)) {

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -866,7 +866,7 @@ do_load_keys(rnp_ffi_t ffi, rnp_input_t input, const char *format, key_type_t ke
         pgp_key_t *key = (pgp_key_t *) key_item;
         // check that the key is the correct type and has not already been loaded
         // add secret key part if it is and we need it
-        if (pgp_is_key_secret(key) &&
+        if (pgp_key_is_secret(key) &&
             ((key_type == KEY_TYPE_SECRET) || (key_type == KEY_TYPE_ANY))) {
             if (key_needs_conversion(key, ffi->secring)) {
                 FFI_LOG(ffi, "This key format conversion is not yet supported");
@@ -1396,7 +1396,7 @@ rnp_op_add_signature(rnp_ffi_t                ffi,
     }
     newsig->signer.key = find_suitable_key(
       PGP_OP_SIGN, get_key_prefer_public(key), &key->ffi->key_provider, PGP_KF_SIGN);
-    if (newsig->signer.key && !pgp_is_key_secret(newsig->signer.key)) {
+    if (newsig->signer.key && !pgp_key_is_secret(newsig->signer.key)) {
         pgp_key_request_ctx_t ctx = {.op = PGP_OP_SIGN, .secret = true};
         ctx.search.type = PGP_KEY_SEARCH_GRIP;
         memcpy(ctx.search.by.grip, newsig->signer.key->grip, PGP_FINGERPRINT_SIZE);
@@ -2488,7 +2488,7 @@ rnp_key_export(rnp_key_handle_t handle, rnp_output_t output, uint32_t flags)
         rnp_result_t res;
         if ((res = init_armored_dst(&armordst,
                                     &output->dst,
-                                    pgp_is_key_secret(key) ? PGP_ARMORED_SECRET_KEY :
+                                    pgp_key_is_secret(key) ? PGP_ARMORED_SECRET_KEY :
                                                              PGP_ARMORED_PUBLIC_KEY))) {
             return res;
         }
@@ -3583,7 +3583,7 @@ rnp_key_protect(rnp_key_handle_t handle,
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
     seckey = &key->pkt;
-    if (pgp_is_key_encrypted(key)) {
+    if (pgp_key_is_encrypted(key)) {
         pgp_password_ctx_t ctx = {.op = PGP_OP_PROTECT, .key = key};
         decrypted_seckey = pgp_decrypt_seckey(key, &handle->ffi->pass_provider, &ctx);
         if (!decrypted_seckey) {

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -3294,10 +3294,10 @@ key_get_uid_at(pgp_key_t *key, size_t idx, char **uid)
     if (!key || !uid) {
         return RNP_ERROR_NULL_POINTER;
     }
-    if (idx >= pgp_get_userid_count(key)) {
+    if (idx >= pgp_key_get_userid_count(key)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    const char *keyuid = pgp_get_userid(key, idx);
+    const char *keyuid = pgp_key_get_userid(key, idx);
     size_t      len = strlen(keyuid);
     *uid = (char *) calloc(1, len + 1);
     if (!*uid) {
@@ -3394,7 +3394,7 @@ rnp_key_get_uid_count(rnp_key_handle_t handle, size_t *count)
     }
 
     pgp_key_t *key = get_key_prefer_public(handle);
-    *count = pgp_get_userid_count(key);
+    *count = pgp_key_get_userid_count(key);
     return RNP_SUCCESS;
 }
 
@@ -4336,8 +4336,8 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
             return RNP_ERROR_OUT_OF_MEMORY;
         }
         json_object_object_add(jso, "userids", jsouids_arr);
-        for (unsigned i = 0; i < pgp_get_userid_count(key); i++) {
-            json_object *jsouid = json_object_new_string(pgp_get_userid(key, i));
+        for (unsigned i = 0; i < pgp_key_get_userid_count(key); i++) {
+            json_object *jsouid = json_object_new_string(pgp_key_get_userid(key, i));
             if (!jsouid || json_object_array_add(jsouids_arr, jsouid)) {
                 json_object_put(jsouid);
                 return RNP_ERROR_OUT_OF_MEMORY;
@@ -4433,7 +4433,7 @@ key_iter_next_item(rnp_identifier_iterator_t it)
     case PGP_KEY_SEARCH_USERID:
         it->uididx++;
         if (it->keyp) {
-            while (it->uididx >= pgp_get_userid_count(it->keyp)) {
+            while (it->uididx >= pgp_key_get_userid_count(it->keyp)) {
                 if (!key_iter_next_key(it)) {
                     return false;
                 }
@@ -4476,7 +4476,7 @@ key_iter_first_item(rnp_identifier_iterator_t it)
         if (!key_iter_first_key(it)) {
             return false;
         }
-        while (it->uididx >= pgp_get_userid_count(it->keyp)) {
+        while (it->uididx >= pgp_key_get_userid_count(it->keyp)) {
             if (!key_iter_next_key(it)) {
                 it->store = NULL;
                 return false;
@@ -4517,7 +4517,7 @@ key_iter_get_item(const rnp_identifier_iterator_t it, char *buf, size_t buf_len)
         }
         break;
     case PGP_KEY_SEARCH_USERID: {
-        const char *userid = pgp_get_userid(key, it->uididx);
+        const char *userid = pgp_key_get_userid(key, it->uididx);
         if (strlen(userid) >= buf_len) {
             return false;
         }

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -2511,7 +2511,7 @@ rnp_key_export(rnp_key_handle_t handle, rnp_output_t output, uint32_t flags)
         }
         // subkey, write the primary + this subkey only
         pgp_key_t *primary;
-        if (!(primary = rnp_key_store_get_key_by_grip(store, key->primary_grip))) {
+        if (!(primary = rnp_key_store_get_key_by_grip(store, pgp_key_get_primary_grip(key)))) {
             // shouldn't happen
             return RNP_ERROR_GENERIC;
         }
@@ -4273,8 +4273,11 @@ key_to_json(json_object *jso, rnp_key_handle_t handle, uint32_t flags)
             subgrip_item = list_next(subgrip_item);
         }
     } else {
-        if (!rnp_hex_encode(
-              key->primary_grip, PGP_KEY_GRIP_SIZE, grip, sizeof(grip), RNP_HEX_UPPERCASE)) {
+        if (!rnp_hex_encode(pgp_key_get_primary_grip(key),
+                            PGP_KEY_GRIP_SIZE,
+                            grip,
+                            sizeof(grip),
+                            RNP_HEX_UPPERCASE)) {
             return RNP_ERROR_GENERIC;
         }
         if (!add_json_string_field(jso, "primary key grip", grip)) {

--- a/src/lib/types.h
+++ b/src/lib/types.h
@@ -56,9 +56,6 @@
 #include "list.h"
 #include "crypto/common.h"
 
-#define PGP_KEY_ID_SIZE 8
-#define PGP_FINGERPRINT_HEX_SIZE (PGP_FINGERPRINT_SIZE * 3) + 1
-
 /* SHA1 Hash Size */
 #define PGP_SHA1_HASH_SIZE 20
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1143,7 +1143,7 @@ rnp_key_store_g10_from_src(rnp_key_store_t *         key_store,
         }
 
         /* public key packet has some more info then the secret part */
-        if (!copy_key_pkt(&key.pkt, pgp_get_key_pkt(pubkey), false)) {
+        if (!copy_key_pkt(&key.pkt, pgp_key_get_pkt(pubkey), false)) {
             goto done;
         }
 

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1019,11 +1019,11 @@ g10_parse_seckey(pgp_key_pkt_t *seckey,
     }
 
     if (rnp_get_debug(__FILE__)) {
-        uint8_t grip[PGP_FINGERPRINT_SIZE];
-        char    grips[PGP_FINGERPRINT_HEX_SIZE];
+        uint8_t grip[PGP_KEY_GRIP_SIZE];
+        char    grips[PGP_KEY_GRIP_SIZE * 3];
         if (rnp_key_store_get_key_grip(&seckey->material, grip)) {
             RNP_LOG("loaded G10 key with GRIP: %s\n",
-                    rnp_strhexdump_upper(grips, grip, PGP_FINGERPRINT_SIZE, ""));
+                    rnp_strhexdump_upper(grips, grip, PGP_KEY_GRIP_SIZE, ""));
         }
     }
     ret = true;

--- a/src/librekey/key_store_g10.cpp
+++ b/src/librekey/key_store_g10.cpp
@@ -1094,8 +1094,7 @@ copy_secret_fields(pgp_key_pkt_t *dst, const pgp_key_pkt_t *src)
 
     dst->material.secret = src->material.secret;
     dst->sec_protection = src->sec_protection;
-    dst->tag = pgp_is_subkey_tag((pgp_content_enum) dst->tag) ? PGP_PTAG_CT_SECRET_SUBKEY :
-                                                                PGP_PTAG_CT_SECRET_KEY;
+    dst->tag = is_subkey_pkt(dst->tag) ? PGP_PTAG_CT_SECRET_SUBKEY : PGP_PTAG_CT_SECRET_KEY;
 
     return true;
 }

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -571,13 +571,13 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
 
     // skip serial number
 
-    if (!pu16(&memdst, pgp_get_userid_count(key)) || !pu16(&memdst, 12)) {
+    if (!pu16(&memdst, pgp_key_get_userid_count(key)) || !pu16(&memdst, 12)) {
         goto finish;
     }
 
     uid_start = memdst.writeb;
 
-    for (i = 0; i < pgp_get_userid_count(key); i++) {
+    for (i = 0; i < pgp_key_get_userid_count(key); i++) {
         if (!pu32(&memdst, 0) ||
             !pu32(&memdst, 0)) { // UID offset and length, update when blob has done
             goto finish;
@@ -623,8 +623,8 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
     }
 
     // wrtite UID, we might redesign PGP write and use this information from keyblob
-    for (i = 0; i < pgp_get_userid_count(key); i++) {
-        const char *uid = (const char *) pgp_get_userid(key, i);
+    for (i = 0; i < pgp_key_get_userid_count(key); i++) {
+        const char *uid = (const char *) pgp_key_get_userid(key, i);
         p = (uint8_t *) mem_dest_get_memory(&memdst) + uid_start + (12 * i);
         /* store absolute uid offset in the output stream */
         pt = memdst.writeb + dst->writeb;

--- a/src/librekey/key_store_kbx.cpp
+++ b/src/librekey/key_store_kbx.cpp
@@ -546,7 +546,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
         goto finish;
     }
 
-    if (!pbuf(&memdst, key->fingerprint.fingerprint, PGP_FINGERPRINT_SIZE) ||
+    if (!pbuf(&memdst, pgp_key_get_fp(key)->fingerprint, PGP_FINGERPRINT_SIZE) ||
         !pu32(&memdst, memdst.writeb - 8) || // offset to keyid (part of fpr for V4)
         !pu16(&memdst, 0) ||                 // flags, not used by GnuPG
         !pu16(&memdst, 0)) {                 // RFU
@@ -557,7 +557,7 @@ rnp_key_store_kbx_write_pgp(rnp_key_store_t *key_store, pgp_key_t *key, pgp_dest
     for (list_item *sgrip = list_front(key->subkey_grips); sgrip; sgrip = list_next(sgrip)) {
         const pgp_key_t *subkey =
           rnp_key_store_get_key_by_grip(key_store, (const uint8_t *) sgrip);
-        if (!pbuf(&memdst, subkey->fingerprint.fingerprint, PGP_FINGERPRINT_SIZE) ||
+        if (!pbuf(&memdst, pgp_key_get_fp(subkey)->fingerprint, PGP_FINGERPRINT_SIZE) ||
             !pu32(&memdst, memdst.writeb - 8) || // offset to keyid (part of fpr for V4)
             !pu16(&memdst, 0) ||                 // flags, not used by GnuPG
             !pu16(&memdst, 0)) {                 // RFU

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -275,15 +275,15 @@ rnp_key_add_signatures(pgp_key_t *key, list signatures)
 }
 
 bool
-rnp_key_add_subkey_grip(pgp_key_t *key, uint8_t *grip)
+rnp_key_add_subkey_grip(pgp_key_t *key, const uint8_t *grip)
 {
     for (list_item *li = list_front(key->subkey_grips); li; li = list_next(li)) {
-        if (!memcmp(grip, (uint8_t *) li, PGP_FINGERPRINT_SIZE)) {
+        if (!memcmp(grip, (uint8_t *) li, PGP_KEY_GRIP_SIZE)) {
             return true;
         }
     }
 
-    return list_append(&key->subkey_grips, grip, PGP_FINGERPRINT_SIZE);
+    return list_append(&key->subkey_grips, grip, PGP_KEY_GRIP_SIZE);
 }
 
 bool
@@ -426,13 +426,13 @@ rnp_key_from_transferable_subkey(pgp_key_t *                subkey,
 
     /* setup key grips if primary is available */
     if (primary) {
-        subkey->primary_grip = (uint8_t *) malloc(PGP_FINGERPRINT_SIZE);
+        subkey->primary_grip = (uint8_t *) malloc(PGP_KEY_GRIP_SIZE);
         if (!subkey->primary_grip) {
             RNP_LOG("alloc failed");
             goto error;
         }
-        memcpy(subkey->primary_grip, primary->grip, PGP_FINGERPRINT_SIZE);
-        if (!rnp_key_add_subkey_grip(primary, subkey->grip)) {
+        memcpy(subkey->primary_grip, primary->grip, PGP_KEY_GRIP_SIZE);
+        if (!rnp_key_add_subkey_grip(primary, pgp_key_get_grip(subkey))) {
             RNP_LOG("failed to add subkey grip");
             goto error;
         }
@@ -537,7 +537,7 @@ do_write(rnp_key_store_t *key_store, pgp_dest_t *dst, bool secret)
         for (list_item *subkey_grip = list_front(key->subkey_grips); subkey_grip;
              subkey_grip = list_next(subkey_grip)) {
             search.type = PGP_KEY_SEARCH_GRIP;
-            memcpy(search.by.grip, (uint8_t *) subkey_grip, PGP_FINGERPRINT_SIZE);
+            memcpy(search.by.grip, (uint8_t *) subkey_grip, PGP_KEY_GRIP_SIZE);
             pgp_key_t *subkey = NULL;
             for (list_item *subkey_item = list_front(rnp_key_store_get_keys(key_store));
                  subkey_item;

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -519,7 +519,7 @@ do_write(rnp_key_store_t *key_store, pgp_dest_t *dst, bool secret)
     for (list_item *key_item = list_front(rnp_key_store_get_keys(key_store)); key_item;
          key_item = list_next(key_item)) {
         pgp_key_t *key = (pgp_key_t *) key_item;
-        if (pgp_is_key_secret(key) != secret) {
+        if (pgp_key_is_secret(key) != secret) {
             continue;
         }
         // skip subkeys, they are written below (orphans are ignored)
@@ -543,7 +543,7 @@ do_write(rnp_key_store_t *key_store, pgp_dest_t *dst, bool secret)
                  subkey_item;
                  subkey_item = list_next(subkey_item)) {
                 pgp_key_t *candidate = (pgp_key_t *) subkey_item;
-                if (pgp_is_key_secret(candidate) != secret) {
+                if (pgp_key_is_secret(candidate) != secret) {
                     continue;
                 }
                 if (rnp_key_matches_search(candidate, &search)) {
@@ -572,7 +572,7 @@ rnp_key_store_pgp_write_to_dst(rnp_key_store_t *key_store, bool armor, pgp_dest_
     if (armor) {
         pgp_armored_msg_t type = PGP_ARMORED_PUBLIC_KEY;
         if (rnp_key_store_get_key_count(key_store) &&
-            pgp_is_key_secret(rnp_key_store_get_key(key_store, 0))) {
+            pgp_key_is_secret(rnp_key_store_get_key(key_store, 0))) {
             type = PGP_ARMORED_SECRET_KEY;
         }
         if (init_armored_dst(&armordst, dst, type)) {

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -172,7 +172,7 @@ create_key_from_pkt(pgp_key_t *key, pgp_key_pkt_t *pkt)
     }
 
     key->format = GPG_KEY_STORE;
-    key->key_flags = pgp_pk_alg_capabilities(pgp_get_key_pkt(key)->alg);
+    key->key_flags = pgp_pk_alg_capabilities(pgp_key_get_alg(key));
     return true;
 }
 

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -159,7 +159,7 @@ create_key_from_pkt(pgp_key_t *key, pgp_key_pkt_t *pkt)
     }
 
     /* this call transfers ownership */
-    if (!pgp_key_from_keypkt(key, &keypkt, (pgp_content_enum) pkt->tag)) {
+    if (!pgp_key_from_pkt(key, &keypkt, (pgp_content_enum) pkt->tag)) {
         RNP_LOG("failed to setup key fields");
         free_key_pkt(&keypkt);
         return false;

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -193,7 +193,7 @@ rnp_key_add_signature(pgp_key_t *key, pgp_signature_t *sig)
         return false;
     }
 
-    subsig->uid = pgp_get_userid_count(key) - 1;
+    subsig->uid = pgp_key_get_userid_count(key) - 1;
     if (!copy_signature_packet(&subsig->sig, sig)) {
         return false;
     }
@@ -205,7 +205,7 @@ rnp_key_add_signature(pgp_key_t *key, pgp_signature_t *sig)
         signature_get_trust(&subsig->sig, &subsig->trustlevel, &subsig->trustamount);
     }
     if (signature_get_primary_uid(&subsig->sig)) {
-        key->uid0 = pgp_get_userid_count(key) - 1;
+        key->uid0 = pgp_key_get_userid_count(key) - 1;
         key->uid0_set = 1;
     }
 
@@ -241,7 +241,7 @@ rnp_key_add_signature(pgp_key_t *key, pgp_signature_t *sig)
     if (signature_has_revocation_reason(&subsig->sig)) {
         /* not sure whether this logic is correct - we should check signature type? */
         pgp_revoke_t *revocation = NULL;
-        if (!pgp_get_userid_count(key)) {
+        if (!pgp_key_get_userid_count(key)) {
             /* revoke whole key */
             key->revoked = 1;
             revocation = &key->revocation;
@@ -251,7 +251,7 @@ rnp_key_add_signature(pgp_key_t *key, pgp_signature_t *sig)
                 RNP_LOG("failed to add revoke");
                 return false;
             }
-            revocation->uid = pgp_get_userid_count(key) - 1;
+            revocation->uid = pgp_key_get_userid_count(key) - 1;
         }
         signature_get_revocation_reason(&subsig->sig, &revocation->code, &revocation->reason);
         if (!strlen(revocation->reason)) {
@@ -327,7 +327,7 @@ rnp_key_add_transferable_userid(pgp_key_t *key, pgp_transferable_userid_t *uid)
 
     memcpy(uidz, uid->uid.uid, uid->uid.uid_len);
     uidz[uid->uid.uid_len] = 0;
-    if (!pgp_add_userid(key, uidz)) {
+    if (!pgp_key_add_userid(key, uidz)) {
         RNP_LOG("failed to add user id");
         free(uidz);
         return false;

--- a/src/librekey/key_store_pgp.cpp
+++ b/src/librekey/key_store_pgp.cpp
@@ -425,17 +425,8 @@ rnp_key_from_transferable_subkey(pgp_key_t *                subkey,
     }
 
     /* setup key grips if primary is available */
-    if (primary) {
-        subkey->primary_grip = (uint8_t *) malloc(PGP_KEY_GRIP_SIZE);
-        if (!subkey->primary_grip) {
-            RNP_LOG("alloc failed");
-            goto error;
-        }
-        memcpy(subkey->primary_grip, primary->grip, PGP_KEY_GRIP_SIZE);
-        if (!rnp_key_add_subkey_grip(primary, pgp_key_get_grip(subkey))) {
-            RNP_LOG("failed to add subkey grip");
-            goto error;
-        }
+    if (primary && !pgp_key_link_subkey_grip(primary, subkey)) {
+        goto error;
     }
     return true;
 error:

--- a/src/librekey/key_store_pgp.h
+++ b/src/librekey/key_store_pgp.h
@@ -84,6 +84,6 @@ bool rnp_key_add_key_rawpacket(pgp_key_t *key, pgp_key_pkt_t *pkt);
 
 bool rnp_key_to_src(const pgp_key_t *key, pgp_source_t *src);
 
-bool rnp_key_add_subkey_grip(pgp_key_t *key, uint8_t *grip);
+bool rnp_key_add_subkey_grip(pgp_key_t *key, const uint8_t *grip);
 
 #endif /* KEY_STORE_PGP_H_ */

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -321,7 +321,7 @@ rnp_key_store_write_to_dst(rnp_key_store_t *key_store, pgp_dest_t *dst)
  */
 
 void
-rnp_key_store_format_key(char *buffer, uint8_t *keyid, int len)
+rnp_key_store_format_key(char *buffer, const uint8_t *keyid, int len)
 {
     unsigned int i;
     unsigned int n;
@@ -350,7 +350,7 @@ rnp_key_store_format_key(char *buffer, uint8_t *keyid, int len)
 bool
 rnp_key_store_get_first_ring(rnp_key_store_t *ring, char *id, size_t len, int last)
 {
-    uint8_t *src;
+    const uint8_t *src;
 
     /* The NULL test on the ring may not be necessary for non-debug
      * builds - it would be much better that a NULL ring never
@@ -372,7 +372,7 @@ rnp_key_store_get_first_ring(rnp_key_store_t *ring, char *id, size_t len, int la
 
     list_item *key_item = last ? list_back(rnp_key_store_get_keys(ring)) :
                                  list_front(rnp_key_store_get_keys(ring));
-    src = (uint8_t *) ((pgp_key_t *) key_item)->keyid;
+    src = pgp_key_get_keyid((pgp_key_t *) key_item);
     rnp_key_store_format_key(id, src, len);
 
     return true;
@@ -632,7 +632,7 @@ rnp_key_store_refresh_subkey_grips(rnp_key_store_t *keyring, pgp_key_t *key)
             }
 
             if (signature_get_keyid(&subsig->sig, keyid) &&
-                !memcmp(key->keyid, keyid, PGP_KEY_ID_SIZE)) {
+                !memcmp(pgp_key_get_keyid(key), keyid, PGP_KEY_ID_SIZE)) {
                 found = true;
                 break;
             }
@@ -786,10 +786,11 @@ rnp_key_store_get_key_by_id(const rnp_key_store_t *keyring,
          key_item;
          key_item = list_next(key_item)) {
         pgp_key_t *key = (pgp_key_t *) key_item;
-        RNP_DHEX("keyring keyid", key->keyid, PGP_KEY_ID_SIZE);
+        RNP_DHEX("keyring keyid", pgp_key_get_keyid(key), PGP_KEY_ID_SIZE);
         RNP_DHEX("keyid", keyid, PGP_KEY_ID_SIZE);
-        if (memcmp(key->keyid, keyid, PGP_KEY_ID_SIZE) == 0 ||
-            memcmp(&key->keyid[PGP_KEY_ID_SIZE / 2], keyid, PGP_KEY_ID_SIZE / 2) == 0) {
+        if (memcmp(pgp_key_get_keyid(key), keyid, PGP_KEY_ID_SIZE) == 0 ||
+            memcmp(pgp_key_get_keyid(key) + PGP_KEY_ID_SIZE / 2, keyid, PGP_KEY_ID_SIZE / 2) ==
+              0) {
             return key;
         }
     }

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -625,8 +625,7 @@ rnp_key_store_refresh_subkey_grips(rnp_key_store_t *keyring, pgp_key_t *key)
             }
 
             if (signature_get_keyfp(&subsig->sig, &keyfp) &&
-                (key->fingerprint.length == keyfp.length) &&
-                !memcmp(key->fingerprint.fingerprint, keyfp.fingerprint, keyfp.length)) {
+                fingerprint_equal(pgp_key_get_fp(key), &keyfp)) {
                 found = true;
                 break;
             }
@@ -843,12 +842,9 @@ rnp_key_store_get_key_by_grip(const rnp_key_store_t *keyring, const uint8_t *gri
 pgp_key_t *
 rnp_key_store_get_key_by_fpr(const rnp_key_store_t *keyring, const pgp_fingerprint_t *fpr)
 {
-    for (list_item *key_item = list_front(keyring->keys); key_item;
-         key_item = list_next(key_item)) {
-        pgp_key_t *key = (pgp_key_t *) key_item;
-        if (key->fingerprint.length == fpr->length &&
-            memcmp(key->fingerprint.fingerprint, fpr->fingerprint, fpr->length) == 0) {
-            return key;
+    for (list_item *key = list_front(keyring->keys); key; key = list_next(key)) {
+        if (fingerprint_equal(pgp_key_get_fp((pgp_key_t *) key), fpr)) {
+            return (pgp_key_t *) key;
         }
     }
     return NULL;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -662,7 +662,7 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
     pgp_key_t *added_key = NULL;
 
     RNP_DLOG("rnp_key_store_add_key");
-    assert(pgp_get_key_type(srckey) && pgp_get_key_pkt(srckey)->version);
+    assert(pgp_key_get_type(srckey) && pgp_key_get_pkt(srckey)->version);
     added_key = rnp_key_store_get_key_by_grip(keyring, srckey->grip);
 
     if (added_key) {

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -945,10 +945,10 @@ get_key_by_name(const rnp_key_store_t *keyring,
          key_item = list_next(key_item)) {
         keyp = (pgp_key_t *) key_item;
 
-        for (i = 0; i < pgp_get_userid_count(keyp); i++) {
-            if (regexec(&r, (char *) pgp_get_userid(keyp, i), 0, NULL, 0) == 0) {
+        for (i = 0; i < pgp_key_get_userid_count(keyp); i++) {
+            if (regexec(&r, (char *) pgp_key_get_userid(keyp, i), 0, NULL, 0) == 0) {
                 RNP_DLOG("MATCHED keyid \"%s\" len %" PRIsize "u",
-                         (char *) pgp_get_userid(keyp, i),
+                         (char *) pgp_key_get_userid(keyp, i),
                          len);
                 regfree(&r);
                 *key = keyp;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -45,6 +45,7 @@
 #include <rnp/rnp_sdk.h>
 #include <rekey/rnp_key_store.h>
 #include <librepgp/packet-print.h>
+#include <librepgp/stream-packet.h>
 
 #include "key_store_internal.h"
 #include "key_store_pgp.h"
@@ -511,8 +512,7 @@ rnp_key_store_merge_subkey(pgp_key_t *dst, const pgp_key_t *src, pgp_key_t *prim
     }
 
     /* if src is secret key then merged key will become secret as well. */
-    if (pgp_is_secret_key_tag(srckey.subkey.tag) &&
-        !pgp_is_secret_key_tag(dstkey.subkey.tag)) {
+    if (is_secret_key_pkt(srckey.subkey.tag) && !is_secret_key_pkt(dstkey.subkey.tag)) {
         pgp_key_pkt_t tmp = dstkey.subkey;
         dstkey.subkey = srckey.subkey;
         srckey.subkey = tmp;
@@ -562,7 +562,7 @@ rnp_key_store_merge_key(pgp_key_t *dst, const pgp_key_t *src)
     }
 
     /* if src is secret key then merged key will become secret as well. */
-    if (pgp_is_secret_key_tag(srckey.key.tag) && !pgp_is_secret_key_tag(dstkey.key.tag)) {
+    if (is_secret_key_pkt(srckey.key.tag) && !is_secret_key_pkt(dstkey.key.tag)) {
         pgp_key_pkt_t tmp = dstkey.key;
         dstkey.key = srckey.key;
         srckey.key = tmp;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -653,7 +653,7 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
     pgp_key_t *added_key = NULL;
 
     RNP_DLOG("rnp_key_store_add_key");
-    assert(pgp_key_get_type(srckey) && pgp_key_get_pkt(srckey)->version);
+    assert(pgp_key_get_type(srckey) && pgp_key_get_version(srckey));
     added_key = rnp_key_store_get_key_by_grip(keyring, pgp_key_get_grip(srckey));
 
     if (added_key) {

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -456,7 +456,7 @@ rnp_key_store_list(FILE *fp, const rnp_key_store_t *keyring, const int psigs)
     for (list_item *key_item = list_front(rnp_key_store_get_keys(keyring)); key_item;
          key_item = list_next(key_item)) {
         pgp_key_t *key = (pgp_key_t *) key_item;
-        if (pgp_is_key_secret(key)) {
+        if (pgp_key_is_secret(key)) {
             repgp_print_key(fp, keyring, key, "sec", 0);
         } else {
             repgp_print_key(fp, keyring, key, "pub", psigs);
@@ -474,7 +474,7 @@ rnp_key_store_json(const rnp_key_store_t *keyring, json_object *obj, const int p
         pgp_key_t *  key = (pgp_key_t *) key_item;
         json_object *jso = json_object_new_object();
         const char * header = NULL;
-        if (pgp_is_key_secret(key)) { /* secret key is always shown as "sec" */
+        if (pgp_key_is_secret(key)) { /* secret key is always shown as "sec" */
             header = "sec";
         } else if (pgp_key_is_primary_key(key)) { /* top-level public key */
             header = "pub";

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -450,7 +450,8 @@ pgp_sprint_key(const rnp_key_store_t *keyring,
 
     rnp_strhexdump(keyid, pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, "");
 
-    rnp_strhexdump(fingerprint, key->fingerprint.fingerprint, key->fingerprint.length, " ");
+    rnp_strhexdump(
+      fingerprint, pgp_key_get_fp(key)->fingerprint, pgp_key_get_fp(key)->length, " ");
 
     ptimestr(creation, sizeof(creation), (time_t) pgp_key_get_pkt(key)->creation_time);
 
@@ -516,10 +517,11 @@ repgp_sprint_json(const struct rnp_key_store_t *keyring,
                            "key id",
                            json_object_new_string(rnp_strhexdump(
                              keyid, pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, "")));
-    json_object_object_add(keyjson,
-                           "fingerprint",
-                           json_object_new_string(rnp_strhexdump(
-                             fp, key->fingerprint.fingerprint, key->fingerprint.length, "")));
+    json_object_object_add(
+      keyjson,
+      "fingerprint",
+      json_object_new_string(rnp_strhexdump(
+        fp, pgp_key_get_fp(key)->fingerprint, pgp_key_get_fp(key)->length, "")));
     json_object_object_add(
       keyjson, "creation time", json_object_new_int(pgp_key_get_pkt(key)->creation_time));
     json_object_object_add(keyjson, "expiration", json_object_new_int(key->expiration));
@@ -642,7 +644,8 @@ pgp_hkp_sprint_key(const struct rnp_key_store_t *keyring,
         }
     }
 
-    rnp_strhexdump(fingerprint, key->fingerprint.fingerprint, PGP_FINGERPRINT_SIZE, "");
+    rnp_strhexdump(
+      fingerprint, pgp_key_get_fp(key)->fingerprint, pgp_key_get_fp(key)->length, "");
 
     n = -1;
     {
@@ -689,15 +692,16 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
 
     const pgp_key_pkt_t *     pkt = pgp_key_get_pkt(key);
     const pgp_key_material_t *material = pgp_key_get_material(key);
-    cc = snprintf(out,
-                  outsize,
-                  "key=%s\nname=%s\ncreation=%lld\nexpiry=%lld\nversion=%d\nalg=%d\n",
-                  rnp_strhexdump(fp, key->fingerprint.fingerprint, PGP_FINGERPRINT_SIZE, ""),
-                  pgp_key_get_primary_userid(key),
-                  (long long) pkt->creation_time,
-                  (long long) pkt->v3_days,
-                  pkt->version,
-                  pkt->alg);
+    cc = snprintf(
+      out,
+      outsize,
+      "key=%s\nname=%s\ncreation=%lld\nexpiry=%lld\nversion=%d\nalg=%d\n",
+      rnp_strhexdump(fp, pgp_key_get_fp(key)->fingerprint, pgp_key_get_fp(key)->length, ""),
+      pgp_key_get_primary_userid(key),
+      (long long) pkt->creation_time,
+      (long long) pkt->v3_days,
+      pkt->version,
+      pkt->alg);
     switch (pkt->alg) {
     case PGP_PKA_DSA: {
         char *p = mpi2hex(&material->dsa.p);

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -687,11 +687,10 @@ repgp_print_key(FILE *                 fp,
 int
 pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
 {
-    char fp[PGP_FINGERPRINT_HEX_SIZE];
-    int  cc;
-
-    const pgp_key_pkt_t *     pkt = pgp_key_get_pkt(key);
+    char                      fp[PGP_FINGERPRINT_HEX_SIZE];
+    int                       cc;
     const pgp_key_material_t *material = pgp_key_get_material(key);
+
     cc = snprintf(
       out,
       outsize,
@@ -700,9 +699,9 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
       pgp_key_get_primary_userid(key),
       (long long) pgp_key_get_creation(key),
       (long long) pgp_key_get_expiration(key),
-      pkt->version,
+      pgp_key_get_version(key),
       pgp_key_get_alg(key));
-    switch (pkt->alg) {
+    switch (pgp_key_get_alg(key)) {
     case PGP_PKA_DSA: {
         char *p = mpi2hex(&material->dsa.p);
         char *q = mpi2hex(&material->dsa.q);
@@ -755,7 +754,7 @@ pgp_sprint_pubkey(const pgp_key_t *key, char *out, size_t outsize)
         break;
     }
     default:
-        RNP_LOG("pgp_print_pubkey: Unusual algorithm: %d", (int) pkt->alg);
+        RNP_LOG("pgp_print_pubkey: Unusual algorithm: %d", (int) pgp_key_get_alg(key));
     }
     return cc;
 }

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -152,7 +152,7 @@ psubkeybinding(char *buf, size_t size, const pgp_key_t *key, const char *expired
     char t[32];
     char key_usage[8];
 
-    format_key_usage(key_usage, sizeof(key_usage), key->key_flags);
+    format_key_usage(key_usage, sizeof(key_usage), pgp_key_get_flags(key));
     return snprintf(buf,
                     size,
                     "encryption %zu/%s %s %s [%s] %s\n",
@@ -455,7 +455,7 @@ pgp_sprint_key(const rnp_key_store_t *keyring,
 
     ptimestr(creation, sizeof(creation), (time_t) pgp_key_get_pkt(key)->creation_time);
 
-    if (!format_key_usage(key_usage, sizeof(key_usage), key->key_flags)) {
+    if (!format_key_usage(key_usage, sizeof(key_usage), pgp_key_get_flags(key))) {
         free(uid_notices);
         return -1;
     }
@@ -525,9 +525,9 @@ repgp_sprint_json(const struct rnp_key_store_t *keyring,
     json_object_object_add(
       keyjson, "creation time", json_object_new_int(pgp_key_get_pkt(key)->creation_time));
     json_object_object_add(keyjson, "expiration", json_object_new_int(key->expiration));
-    json_object_object_add(keyjson, "key flags", json_object_new_int(key->key_flags));
+    json_object_object_add(keyjson, "key flags", json_object_new_int(pgp_key_get_flags(key)));
     json_object *usage_arr = json_object_new_array();
-    format_key_usage_json(usage_arr, key->key_flags);
+    format_key_usage_json(usage_arr, pgp_key_get_flags(key));
     json_object_object_add(keyjson, "usage", usage_arr);
 
     // iterating through the uids

--- a/src/librepgp/packet-print.cpp
+++ b/src/librepgp/packet-print.cpp
@@ -158,7 +158,7 @@ psubkeybinding(char *buf, size_t size, const pgp_key_t *key, const char *expired
                     "encryption %zu/%s %s %s [%s] %s\n",
                     key_bitlength(pgp_key_get_material(key)),
                     pgp_show_pka(pgp_key_get_alg(key)),
-                    rnp_strhexdump(keyid, key->keyid, PGP_KEY_ID_SIZE, ""),
+                    rnp_strhexdump(keyid, pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, ""),
                     ptimestr(t, sizeof(t), (time_t) pgp_key_get_pkt(key)->creation_time),
                     key_usage,
                     expired);
@@ -448,7 +448,7 @@ pgp_sprint_key(const rnp_key_store_t *keyring,
     }
     uid_notices[uid_notices_offset] = '\0';
 
-    rnp_strhexdump(keyid, key->keyid, PGP_KEY_ID_SIZE, "");
+    rnp_strhexdump(keyid, pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, "");
 
     rnp_strhexdump(fingerprint, key->fingerprint.fingerprint, key->fingerprint.length, " ");
 
@@ -512,10 +512,10 @@ repgp_sprint_json(const struct rnp_key_store_t *keyring,
       keyjson, "key bits", json_object_new_int(key_bitlength(pgp_key_get_material(key))));
     json_object_object_add(
       keyjson, "pka", json_object_new_string(pgp_show_pka(pgp_key_get_alg(key))));
-    json_object_object_add(
-      keyjson,
-      "key id",
-      json_object_new_string(rnp_strhexdump(keyid, key->keyid, PGP_KEY_ID_SIZE, "")));
+    json_object_object_add(keyjson,
+                           "key id",
+                           json_object_new_string(rnp_strhexdump(
+                             keyid, pgp_key_get_keyid(key), PGP_KEY_ID_SIZE, "")));
     json_object_object_add(keyjson,
                            "fingerprint",
                            json_object_new_string(rnp_strhexdump(

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1635,7 +1635,7 @@ validate_pgp_key_signatures(pgp_signatures_info_t *result,
             res = RNP_ERROR_BAD_STATE;
             goto done;
         }
-        info.key = pgp_get_key_pkt(primary);
+        info.key = pgp_key_get_pkt(primary);
         info.uid = NULL;
         info.subkey = &tskey.subkey;
         res = validate_pgp_key_signature_list(tskey.signatures, &info);
@@ -1702,7 +1702,7 @@ validate_pgp_key(const pgp_key_t *key, const rnp_key_store_t *keyring)
     free_signatures_info(&sinfo);
     /* if signatures are ok then check key material */
     if (!res) {
-        res = validate_pgp_key_material(pgp_get_key_material(key), &rng);
+        res = validate_pgp_key_material(pgp_key_get_material(key), &rng);
     }
 
     rng_destroy(&rng);

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1630,7 +1630,8 @@ validate_pgp_key_signatures(pgp_signatures_info_t *result,
 
     /* subkey may have only binding signatures */
     if (pgp_key_is_subkey(key)) {
-        pgp_key_t *primary = rnp_key_store_get_key_by_grip(keyring, key->primary_grip);
+        pgp_key_t *primary =
+          rnp_key_store_get_key_by_grip(keyring, pgp_key_get_primary_grip(key));
         if (!primary) {
             res = RNP_ERROR_BAD_STATE;
             goto done;

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1599,7 +1599,7 @@ validate_pgp_key_signatures(pgp_signatures_info_t *result,
     rng_t                     rng = {};
 
     /* no signatures in g10 secret keys */
-    if (pgp_is_key_secret(key) && (key->format == G10_KEY_STORE)) {
+    if (pgp_key_is_secret(key) && (key->format == G10_KEY_STORE)) {
         return RNP_SUCCESS;
     }
 
@@ -1691,7 +1691,7 @@ validate_pgp_key(const pgp_key_t *key, const rnp_key_store_t *keyring)
     res = validate_pgp_key_signatures(&sinfo, key, keyring);
     if (!res) {
         bool valid = false;
-        if (pgp_is_key_secret(key)) {
+        if (pgp_key_is_secret(key)) {
             // secret key may be stored without signatures
             valid = sinfo.validc == list_length(sinfo.sigs);
         } else {

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -359,7 +359,7 @@ transferable_key_merge(pgp_transferable_key_t *dst, const pgp_transferable_key_t
             continue;
         }
         /* add subkey */
-        if (pgp_is_public_key_tag(dst->key.tag) != pgp_is_public_key_tag(lskey->subkey.tag)) {
+        if (is_public_key_pkt(dst->key.tag) != is_public_key_pkt(lskey->subkey.tag)) {
             RNP_LOG("warning: adding public/secret subkey to secret/public key");
         }
         subkey =

--- a/src/librepgp/stream-packet.cpp
+++ b/src/librepgp/stream-packet.cpp
@@ -2157,7 +2157,7 @@ key_pkt_equal(const pgp_key_pkt_t *key1, const pgp_key_pkt_t *key2, bool pubonly
         return false;
     }
 
-    /* check basic tags */
+    /* check basic fields */
     if ((key1->version != key2->version) || (key1->alg != key2->alg) ||
         (key1->creation_time != key2->creation_time)) {
         return false;

--- a/src/librepgp/stream-parse.cpp
+++ b/src/librepgp/stream-parse.cpp
@@ -1867,7 +1867,7 @@ init_encrypted_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *r
                 continue;
             }
             /* Decrypt key */
-            if (pgp_is_key_encrypted(seckey)) {
+            if (pgp_key_is_encrypted(seckey)) {
                 pgp_password_ctx_t pass_ctx{.op = PGP_OP_DECRYPT, .key = seckey};
                 decrypted_seckey =
                   pgp_decrypt_seckey(seckey, ctx->handler.password_provider, &pass_ctx);
@@ -1888,7 +1888,7 @@ init_encrypted_src(pgp_processing_ctx_t *ctx, pgp_source_t *src, pgp_source_t *r
             }
 
             /* Destroy decrypted key */
-            if (pgp_is_key_encrypted(seckey)) {
+            if (pgp_key_is_encrypted(seckey)) {
                 free_key_pkt(decrypted_seckey);
                 free(decrypted_seckey);
                 decrypted_seckey = NULL;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1122,7 +1122,8 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
     }
 
     /* check whether key was not expired when sig created */
-    if (sinfo->signer->expiration && (kcreate + sinfo->signer->expiration < create)) {
+    if (pgp_key_get_expiration(sinfo->signer) &&
+        (kcreate + pgp_key_get_expiration(sinfo->signer) < create)) {
         RNP_LOG("signature made after key expiration");
         sinfo->valid = false;
     }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1115,7 +1115,7 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
     }
 
     /* check key creation time vs signature creation */
-    kcreate = pgp_key_get_pkt(sinfo->signer)->creation_time;
+    kcreate = pgp_key_get_creation(sinfo->signer);
     if (kcreate > create) {
         RNP_LOG("key is newer than signature");
         sinfo->valid = false;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1093,7 +1093,7 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
     /* Validate signature itself */
     if (sinfo->signer->valid) {
         sinfo->valid =
-          !signature_validate(sinfo->sig, pgp_get_key_material(sinfo->signer), hash);
+          !signature_validate(sinfo->sig, pgp_key_get_material(sinfo->signer), hash);
     } else {
         sinfo->valid = false;
         RNP_LOG("invalid or untrusted key");
@@ -1115,7 +1115,7 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
     }
 
     /* check key creation time vs signature creation */
-    kcreate = pgp_get_key_pkt(sinfo->signer)->creation_time;
+    kcreate = pgp_key_get_pkt(sinfo->signer)->creation_time;
     if (kcreate > create) {
         RNP_LOG("key is newer than signature");
         sinfo->valid = false;

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -1129,7 +1129,7 @@ signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash)
 
     /* Check signer's fingerprint */
     if (signature_get_keyfp(sinfo->sig, &fp) &&
-        !fingerprint_equal(&fp, &sinfo->signer->fingerprint)) {
+        !fingerprint_equal(&fp, pgp_key_get_fp(sinfo->signer))) {
         RNP_LOG("issuer fingerprint doesn't match signer's one");
         sinfo->valid = false;
     }

--- a/src/librepgp/stream-sig.cpp
+++ b/src/librepgp/stream-sig.cpp
@@ -218,7 +218,7 @@ signature_get_keyid(const pgp_signature_t *sig, uint8_t *id)
 }
 
 bool
-signature_set_keyid(pgp_signature_t *sig, uint8_t *id)
+signature_set_keyid(pgp_signature_t *sig, const uint8_t *id)
 {
     pgp_sig_subpkt_t *subpkt;
 
@@ -1166,7 +1166,7 @@ signature_check_certification(pgp_signature_info_t *  sinfo,
     /* check key expiration time, only for self-signature. While sinfo->expired tells about
        the signature expiry, we'll use it for bkey expiration as well */
     if (signature_get_keyid(sinfo->sig, keyid) &&
-        !memcmp(keyid, sinfo->signer->keyid, PGP_KEY_ID_SIZE)) {
+        !memcmp(keyid, pgp_key_get_keyid(sinfo->signer), PGP_KEY_ID_SIZE)) {
         uint32_t expiry = signature_get_key_expiration(sinfo->sig);
         uint32_t now = time(NULL);
 

--- a/src/librepgp/stream-sig.h
+++ b/src/librepgp/stream-sig.h
@@ -135,7 +135,7 @@ bool signature_get_keyid(const pgp_signature_t *sig, uint8_t *id);
  * @param id pointer to buffer with PGP_KEY_ID_SIZE bytes of key id.
  * @return true on success or false otherwise
  */
-bool signature_set_keyid(pgp_signature_t *sig, uint8_t *id);
+bool signature_set_keyid(pgp_signature_t *sig, const uint8_t *id);
 
 /**
  * @brief Get signature's creation time
@@ -345,8 +345,7 @@ rnp_result_t signature_validate_direct(const pgp_signature_t *   sig,
  *         RNP_ERROR_SIGNATURE_EXPIRED for expired signature. Other error code means problems
  *         during the signature validation (out of memory, wrong parameters, etc).
  */
-rnp_result_t signature_check(pgp_signature_info_t *sinfo,
-                             pgp_hash_t *hash);
+rnp_result_t signature_check(pgp_signature_info_t *sinfo, pgp_hash_t *hash);
 
 rnp_result_t signature_check_certification(pgp_signature_info_t *  sinfo,
                                            const pgp_key_pkt_t *   key,
@@ -356,8 +355,7 @@ rnp_result_t signature_check_binding(pgp_signature_info_t *sinfo,
                                      const pgp_key_pkt_t * key,
                                      const pgp_key_pkt_t * subkey);
 
-rnp_result_t signature_check_direct(pgp_signature_info_t *sinfo,
-                                    const pgp_key_pkt_t * key);
+rnp_result_t signature_check_direct(pgp_signature_info_t *sinfo, const pgp_key_pkt_t *key);
 
 /**
  * @brief Check whether signatures info structure has all correct signatures.

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1094,7 +1094,7 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
     }
 
     /* decrypt the secret key if needed */
-    if (pgp_is_key_encrypted(signer->key)) {
+    if (pgp_key_is_encrypted(signer->key)) {
         deckey = pgp_decrypt_seckey(signer->key, param->password_provider, &ctx);
         if (!deckey) {
             RNP_LOG("wrong secret key password");
@@ -1109,7 +1109,7 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
     ret = signature_calculate(sig, &deckey->material, &hash, rnp_ctx_rng_handle(param->ctx));
 
     /* destroy decrypted secret key */
-    if (pgp_is_key_encrypted(signer->key)) {
+    if (pgp_key_is_encrypted(signer->key)) {
         free_key_pkt(deckey);
         free(deckey);
         deckey = NULL;
@@ -1242,7 +1242,7 @@ signed_add_signer(pgp_dest_signed_param_t *param, rnp_signer_info_t *signer, boo
 {
     pgp_dest_signer_info_t sinfo = {};
 
-    if (!pgp_is_key_secret(signer->key)) {
+    if (!pgp_key_is_secret(signer->key)) {
         RNP_LOG("secret key required for signing");
         return RNP_ERROR_BAD_PARAMETERS;
     }

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1079,7 +1079,7 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
 
     /* fill signature fields */
     res = signature_set_keyfp(sig, &signer->key->fingerprint) &&
-          signature_set_keyid(sig, signer->key->keyid) &&
+          signature_set_keyid(sig, pgp_key_get_keyid(signer->key)) &&
           signature_set_creation(sig, signer->sigcreate ? signer->sigcreate : time(NULL)) &&
           signature_set_expiration(sig, signer->sigexpire) && signature_fill_hashed_data(sig);
 
@@ -1270,7 +1270,7 @@ signed_add_signer(pgp_dest_signed_param_t *param, rnp_signer_info_t *signer, boo
     sinfo.onepass.type = PGP_SIG_BINARY;
     sinfo.onepass.halg = sinfo.halg;
     sinfo.onepass.palg = pgp_key_get_alg(sinfo.key);
-    memcpy(sinfo.onepass.keyid, sinfo.key->keyid, PGP_KEY_ID_SIZE);
+    memcpy(sinfo.onepass.keyid, pgp_key_get_keyid(sinfo.key), PGP_KEY_ID_SIZE);
     sinfo.onepass.nested = false;
     if (!list_append(&param->siginfos, &sinfo, sizeof(sinfo))) {
         return RNP_ERROR_OUT_OF_MEMORY;

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1078,7 +1078,7 @@ signed_fill_signature(pgp_dest_signed_param_t *param,
     rnp_result_t       ret = RNP_ERROR_GENERIC;
 
     /* fill signature fields */
-    res = signature_set_keyfp(sig, &signer->key->fingerprint) &&
+    res = signature_set_keyfp(sig, pgp_key_get_fp(signer->key)) &&
           signature_set_keyid(sig, pgp_key_get_keyid(signer->key)) &&
           signature_set_creation(sig, signer->sigcreate ? signer->sigcreate : time(NULL)) &&
           signature_set_expiration(sig, signer->sigexpire) && signature_fill_hashed_data(sig);

--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -510,7 +510,7 @@ encrypted_add_recipient(pgp_write_handler_t *handler,
         RNP_LOG("attempt to use invalid key as recipient");
         return RNP_ERROR_NO_SUITABLE_KEY;
     }
-    keypkt = pgp_get_key_pkt(userkey);
+    keypkt = pgp_key_get_pkt(userkey);
 
     /* Fill pkey */
     pkey.version = PGP_PKSK_V3;
@@ -1132,8 +1132,8 @@ signed_write_signature(pgp_dest_signed_param_t *param,
         sig.palg = signer->onepass.palg;
         sig.type = signer->onepass.type;
     } else {
-        sig.halg = pgp_hash_adjust_alg_to_key(signer->halg, pgp_get_key_pkt(signer->key));
-        sig.palg = pgp_get_key_alg(signer->key);
+        sig.halg = pgp_hash_adjust_alg_to_key(signer->halg, pgp_key_get_pkt(signer->key));
+        sig.palg = pgp_key_get_alg(signer->key);
         sig.type = param->ctx->detached ? PGP_SIG_BINARY : PGP_SIG_TEXT;
     }
 
@@ -1253,7 +1253,7 @@ signed_add_signer(pgp_dest_signed_param_t *param, rnp_signer_info_t *signer, boo
     sinfo.sigexpire = signer->sigexpire;
 
     /* Add hash to the list */
-    sinfo.halg = pgp_hash_adjust_alg_to_key(signer->halg, pgp_get_key_pkt(signer->key));
+    sinfo.halg = pgp_hash_adjust_alg_to_key(signer->halg, pgp_key_get_pkt(signer->key));
     if (!pgp_hash_list_add(&param->hashes, sinfo.halg)) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
@@ -1269,10 +1269,9 @@ signed_add_signer(pgp_dest_signed_param_t *param, rnp_signer_info_t *signer, boo
     sinfo.onepass.version = 3;
     sinfo.onepass.type = PGP_SIG_BINARY;
     sinfo.onepass.halg = sinfo.halg;
-    sinfo.onepass.palg = pgp_get_key_alg(sinfo.key);
+    sinfo.onepass.palg = pgp_key_get_alg(sinfo.key);
     memcpy(sinfo.onepass.keyid, sinfo.key->keyid, PGP_KEY_ID_SIZE);
     sinfo.onepass.nested = false;
-
     if (!list_append(&param->siginfos, &sinfo, sizeof(sinfo))) {
         return RNP_ERROR_OUT_OF_MEMORY;
     }

--- a/src/rnpkeys/rnpkeys.cpp
+++ b/src/rnpkeys/rnpkeys.cpp
@@ -210,9 +210,9 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         rnp_action_keygen_t *        action = &rnp->action.generate_key_ctx;
         rnp_keygen_primary_desc_t *  primary_desc = &action->primary.keygen;
         rnp_key_protection_params_t *protection = &action->primary.protection;
-        pgp_key_t *primary_key = NULL;
-        pgp_key_t *subkey = NULL;
-        char *key_info = NULL;
+        pgp_key_t *                  primary_key = NULL;
+        pgp_key_t *                  subkey = NULL;
+        char *                       key_info = NULL;
 
         memset(action, 0, sizeof(*action));
         /* setup key generation and key protection parameters */
@@ -222,8 +222,8 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         primary_desc->crypto.hash_alg = pgp_str_to_hash_alg(rnp_cfg_gethashalg(cfg));
 
         if (primary_desc->crypto.hash_alg == PGP_HASH_UNKNOWN) {
-           fprintf(stderr, "Unknown hash algorithm: %s\n", rnp_cfg_getstr(cfg, CFG_HASH));
-           return false;
+            fprintf(stderr, "Unknown hash algorithm: %s\n", rnp_cfg_getstr(cfg, CFG_HASH));
+            return false;
         }
 
         primary_desc->crypto.rng = &rnp->rng;
@@ -231,9 +231,9 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
         protection->symm_alg = pgp_str_to_cipher(rnp_cfg_getstr(cfg, CFG_CIPHER));
         protection->iterations = rnp_cfg_getint(cfg, CFG_S2K_ITER);
 
-        if(protection->iterations == 0) {
-           protection->iterations =
-              pgp_s2k_compute_iters(protection->hash_alg, rnp_cfg_getint(cfg, CFG_S2K_MSEC), 10);
+        if (protection->iterations == 0) {
+            protection->iterations = pgp_s2k_compute_iters(
+              protection->hash_alg, rnp_cfg_getint(cfg, CFG_S2K_MSEC), 10);
         }
 
         action->subkey.keygen.crypto.rng = &rnp->rng;
@@ -255,7 +255,7 @@ rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, char *f)
             return false;
         }
         /* show the primary key, use public key part */
-        primary_key = rnp_key_store_get_key_by_fpr(rnp->pubring, &primary_key->fingerprint);
+        primary_key = rnp_key_store_get_key_by_fpr(rnp->pubring, pgp_key_get_fp(primary_key));
         if (!primary_key) {
             RNP_LOG("Cannot get public key part");
             return false;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -849,7 +849,7 @@ test_generated_key_sigs(void **state)
         assert_rnp_success(signature_validate_certification(
           psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         assert_true(signature_get_keyfp(psig, &fp));
-        assert_true(fingerprint_equal(&fp, &pub.fingerprint));
+        assert_true(fingerprint_equal(&fp, pgp_key_get_fp(&pub)));
         // check subpackets and their contents
         subpkt = signature_get_subpkt(psig, PGP_SIG_SUBPKT_ISSUER_FPR);
         assert_non_null(subpkt);
@@ -869,7 +869,7 @@ test_generated_key_sigs(void **state)
         assert_rnp_success(signature_validate_certification(
           ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
         assert_true(signature_get_keyfp(ssig, &fp));
-        assert_true(fingerprint_equal(&fp, &sec.fingerprint));
+        assert_true(fingerprint_equal(&fp, pgp_key_get_fp(&sec)));
 
         // modify a hashed portion of the sig packets
         psig->hashed_data[32] ^= 0xff;
@@ -960,7 +960,7 @@ test_generated_key_sigs(void **state)
         assert_rnp_success(signature_validate_binding(
           psig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&pub)));
         assert_true(signature_get_keyfp(psig, &fp));
-        assert_true(fingerprint_equal(&fp, &primary_pub->fingerprint));
+        assert_true(fingerprint_equal(&fp, pgp_key_get_fp(primary_pub)));
         // check subpackets and their contents
         subpkt = signature_get_subpkt(psig, PGP_SIG_SUBPKT_ISSUER_FPR);
         assert_non_null(subpkt);
@@ -978,7 +978,7 @@ test_generated_key_sigs(void **state)
         assert_rnp_success(signature_validate_binding(
           ssig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&sec)));
         assert_true(signature_get_keyfp(ssig, &fp));
-        assert_true(fingerprint_equal(&fp, &primary_sec->fingerprint));
+        assert_true(fingerprint_equal(&fp, pgp_key_get_fp(primary_sec)));
 
         // modify a hashed portion of the sig packets
         psig->hashed_data[10] ^= 0xff;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -847,7 +847,7 @@ test_generated_key_sigs(void **state)
         uid.uid = (uint8_t *) pgp_get_userid(&pub, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_success(signature_validate_certification(
-          psig, pgp_get_key_pkt(&pub), &uid, pgp_get_key_material(&pub)));
+          psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         assert_true(signature_get_keyfp(psig, &fp));
         assert_true(fingerprint_equal(&fp, &pub.fingerprint));
         // check subpackets and their contents
@@ -866,7 +866,7 @@ test_generated_key_sigs(void **state)
         uid.uid = (uint8_t *) pgp_get_userid(&sec, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_success(signature_validate_certification(
-          ssig, pgp_get_key_pkt(&sec), &uid, pgp_get_key_material(&sec)));
+          ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
         assert_true(signature_get_keyfp(ssig, &fp));
         assert_true(fingerprint_equal(&fp, &sec.fingerprint));
 
@@ -877,11 +877,11 @@ test_generated_key_sigs(void **state)
         uid.uid = (uint8_t *) pgp_get_userid(&pub, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_failure(signature_validate_certification(
-          psig, pgp_get_key_pkt(&pub), &uid, pgp_get_key_material(&pub)));
+          psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         uid.uid = (uint8_t *) pgp_get_userid(&sec, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_failure(signature_validate_certification(
-          ssig, pgp_get_key_pkt(&sec), &uid, pgp_get_key_material(&sec)));
+          ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
         // restore the original data
         psig->hashed_data[32] ^= 0xff;
         ssig->hashed_data[32] ^= 0xff;
@@ -889,9 +889,9 @@ test_generated_key_sigs(void **state)
         uid.uid = (uint8_t *) "fake";
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_failure(signature_validate_certification(
-          psig, pgp_get_key_pkt(&pub), &uid, pgp_get_key_material(&pub)));
+          psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
         assert_rnp_failure(signature_validate_certification(
-          ssig, pgp_get_key_pkt(&sec), &uid, pgp_get_key_material(&sec)));
+          ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
 
         // validate via an alternative method
         pgp_signatures_info_t result = {0};
@@ -957,7 +957,7 @@ test_generated_key_sigs(void **state)
         assert_int_equal(PGP_PTAG_CT_SIGNATURE, pgp_key_get_rawpacket(&sec, 1)->tag);
         // validate the binding sig
         assert_rnp_success(signature_validate_binding(
-          psig, pgp_get_key_pkt(primary_pub), pgp_get_key_pkt(&pub)));
+          psig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&pub)));
         assert_true(signature_get_keyfp(psig, &fp));
         assert_true(fingerprint_equal(&fp, &primary_pub->fingerprint));
         // check subpackets and their contents
@@ -975,7 +975,7 @@ test_generated_key_sigs(void **state)
         assert_true(subpkt->fields.create <= time(NULL));
 
         assert_rnp_success(signature_validate_binding(
-          ssig, pgp_get_key_pkt(primary_pub), pgp_get_key_pkt(&sec)));
+          ssig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&sec)));
         assert_true(signature_get_keyfp(ssig, &fp));
         assert_true(fingerprint_equal(&fp, &primary_sec->fingerprint));
 
@@ -984,9 +984,9 @@ test_generated_key_sigs(void **state)
         ssig->hashed_data[10] ^= 0xff;
         // ensure validation fails
         assert_rnp_failure(signature_validate_binding(
-          psig, pgp_get_key_pkt(primary_pub), pgp_get_key_pkt(&pub)));
+          psig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&pub)));
         assert_rnp_failure(signature_validate_binding(
-          ssig, pgp_get_key_pkt(primary_pub), pgp_get_key_pkt(&sec)));
+          ssig, pgp_key_get_pkt(primary_pub), pgp_key_get_pkt(&sec)));
         // restore the original data
         psig->hashed_data[10] ^= 0xff;
         ssig->hashed_data[10] ^= 0xff;

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -303,11 +303,11 @@ rnpkeys_generatekey_verifySupportedHashAlg(void **state)
 
             /* Some minor checks */
             for (size_t i = 0; i < rnp_key_store_get_key_count(rnp.pubring); i++) {
-                assert_true(pgp_is_key_public(rnp_key_store_get_key(rnp.pubring, i)));
+                assert_true(pgp_key_is_public(rnp_key_store_get_key(rnp.pubring, i)));
             }
 
             for (size_t i = 0; i < rnp_key_store_get_key_count(rnp.secring); i++) {
-                assert_true(pgp_is_key_secret(rnp_key_store_get_key(rnp.secring, i)));
+                assert_true(pgp_key_is_secret(rnp_key_store_get_key(rnp.secring, i)));
             }
 
             // G10 doesn't support metadata

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -857,7 +857,8 @@ test_generated_key_sigs(void **state)
         subpkt = signature_get_subpkt(psig, PGP_SIG_SUBPKT_ISSUER_KEY_ID);
         assert_non_null(subpkt);
         assert_false(subpkt->hashed);
-        assert_int_equal(0, memcmp(subpkt->fields.issuer, pub.keyid, PGP_KEY_ID_SIZE));
+        assert_int_equal(
+          0, memcmp(subpkt->fields.issuer, pgp_key_get_keyid(&pub), PGP_KEY_ID_SIZE));
         subpkt = signature_get_subpkt(psig, PGP_SIG_SUBPKT_CREATION_TIME);
         assert_non_null(subpkt);
         assert_true(subpkt->hashed);
@@ -967,8 +968,8 @@ test_generated_key_sigs(void **state)
         subpkt = signature_get_subpkt(psig, PGP_SIG_SUBPKT_ISSUER_KEY_ID);
         assert_non_null(subpkt);
         assert_false(subpkt->hashed);
-        assert_int_equal(0,
-                         memcmp(subpkt->fields.issuer, primary_pub->keyid, PGP_KEY_ID_SIZE));
+        assert_int_equal(
+          0, memcmp(subpkt->fields.issuer, pgp_key_get_keyid(primary_pub), PGP_KEY_ID_SIZE));
         subpkt = signature_get_subpkt(psig, PGP_SIG_SUBPKT_CREATION_TIME);
         assert_non_null(subpkt);
         assert_true(subpkt->hashed);

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -824,8 +824,8 @@ test_generated_key_sigs(void **state)
         assert_true(rnp_key_store_add_key(pubring, &pub));
         assert_true(rnp_key_store_add_key(secring, &sec));
         // retrieve back from our rings (for later)
-        primary_pub = rnp_key_store_get_key_by_grip(pubring, pub.grip);
-        primary_sec = rnp_key_store_get_key_by_grip(secring, pub.grip);
+        primary_pub = rnp_key_store_get_key_by_grip(pubring, pgp_key_get_grip(&pub));
+        primary_sec = rnp_key_store_get_key_by_grip(secring, pgp_key_get_grip(&pub));
         assert_non_null(primary_pub);
         assert_non_null(primary_sec);
 
@@ -996,8 +996,8 @@ test_generated_key_sigs(void **state)
         assert_true(rnp_key_store_add_key(pubring, &pub));
         assert_true(rnp_key_store_add_key(secring, &sec));
         // retrieve back from our rings
-        sub_pub = rnp_key_store_get_key_by_grip(pubring, pub.grip);
-        sub_sec = rnp_key_store_get_key_by_grip(secring, pub.grip);
+        sub_pub = rnp_key_store_get_key_by_grip(pubring, pgp_key_get_grip(&pub));
+        sub_sec = rnp_key_store_get_key_by_grip(secring, pgp_key_get_grip(&pub));
         assert_non_null(sub_pub);
         assert_non_null(sub_sec);
 

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -844,7 +844,7 @@ test_generated_key_sigs(void **state)
         assert_int_equal(PGP_PTAG_CT_SIGNATURE, pgp_key_get_rawpacket(&sec, 2)->tag);
 
         // validate the userid self-sig
-        uid.uid = (uint8_t *) pgp_get_userid(&pub, 0);
+        uid.uid = (uint8_t *) pgp_key_get_userid(&pub, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_success(signature_validate_certification(
           psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
@@ -864,7 +864,7 @@ test_generated_key_sigs(void **state)
         assert_true(subpkt->hashed);
         assert_true(subpkt->fields.create <= time(NULL));
 
-        uid.uid = (uint8_t *) pgp_get_userid(&sec, 0);
+        uid.uid = (uint8_t *) pgp_key_get_userid(&sec, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_success(signature_validate_certification(
           ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));
@@ -875,11 +875,11 @@ test_generated_key_sigs(void **state)
         psig->hashed_data[32] ^= 0xff;
         ssig->hashed_data[32] ^= 0xff;
         // ensure validation fails
-        uid.uid = (uint8_t *) pgp_get_userid(&pub, 0);
+        uid.uid = (uint8_t *) pgp_key_get_userid(&pub, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_failure(signature_validate_certification(
           psig, pgp_key_get_pkt(&pub), &uid, pgp_key_get_material(&pub)));
-        uid.uid = (uint8_t *) pgp_get_userid(&sec, 0);
+        uid.uid = (uint8_t *) pgp_key_get_userid(&sec, 0);
         uid.uid_len = strlen((char *) uid.uid);
         assert_rnp_failure(signature_validate_certification(
           ssig, pgp_key_get_pkt(&sec), &uid, pgp_key_get_material(&sec)));

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -68,7 +68,7 @@ test_key_add_userid(void **state)
     assert_true(pgp_key_unlock(key, &pprov));
 
     // save the counts for a few items
-    unsigned uidc = pgp_get_userid_count(key);
+    unsigned uidc = pgp_key_get_userid_count(key);
     unsigned subsigc = pgp_key_get_subsig_count(key);
 
     // add a userid
@@ -82,7 +82,7 @@ test_key_add_userid(void **state)
     assert_true(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig));
 
     // make sure this userid has been marked as primary
-    assert_int_equal(pgp_get_userid_count(key) - 1, key->uid0);
+    assert_int_equal(pgp_key_get_userid_count(key) - 1, key->uid0);
 
     // try to add the same userid (should fail)
     rnp_selfsig_cert_info_t dup_selfsig;
@@ -105,17 +105,17 @@ test_key_add_userid(void **state)
     assert_true(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
 
     // confirm that the counts have increased as expected
-    assert_int_equal(pgp_get_userid_count(key), uidc + 2);
+    assert_int_equal(pgp_key_get_userid_count(key), uidc + 2);
     assert_int_equal(pgp_key_get_subsig_count(key), subsigc + 2);
 
     // check the userids array
     // added1
-    assert_int_equal(0, strcmp(pgp_get_userid(key, uidc), "added1"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc), "added1"));
     assert_int_equal(uidc, pgp_key_get_subsig(key, subsigc)->uid);
     assert_int_equal(0xAB, pgp_key_get_subsig(key, subsigc)->key_flags);
     assert_int_equal(123456789, key->expiration);
     // added2
-    assert_int_equal(0, strcmp(pgp_get_userid(key, uidc + 1), "added2"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1), "added2"));
     assert_int_equal(uidc + 1, pgp_key_get_subsig(key, subsigc + 1)->uid);
     assert_int_equal(0xCD, pgp_key_get_subsig(key, subsigc + 1)->key_flags);
 
@@ -140,17 +140,17 @@ test_key_add_userid(void **state)
     assert_non_null(key = rnp_key_store_get_key_by_name(ks, keyids[0], NULL));
 
     // confirm that the counts have increased as expected
-    assert_int_equal(pgp_get_userid_count(key), uidc + 2);
+    assert_int_equal(pgp_key_get_userid_count(key), uidc + 2);
     assert_int_equal(pgp_key_get_subsig_count(key), subsigc + 2);
 
     // check the userids array
     // added1
-    assert_int_equal(0, strcmp(pgp_get_userid(key, uidc), "added1"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc), "added1"));
     assert_int_equal(uidc, pgp_key_get_subsig(key, subsigc)->uid);
     assert_int_equal(0xAB, pgp_key_get_subsig(key, subsigc)->key_flags);
     assert_int_equal(123456789, key->expiration);
     // added2
-    assert_int_equal(0, strcmp(pgp_get_userid(key, uidc + 1), "added2"));
+    assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1), "added2"));
     assert_int_equal(uidc + 1, pgp_key_get_subsig(key, subsigc + 1)->uid);
     assert_int_equal(0xCD, pgp_key_get_subsig(key, subsigc + 1)->key_flags);
 

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -113,7 +113,7 @@ test_key_add_userid(void **state)
     assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc), "added1"));
     assert_int_equal(uidc, pgp_key_get_subsig(key, subsigc)->uid);
     assert_int_equal(0xAB, pgp_key_get_subsig(key, subsigc)->key_flags);
-    assert_int_equal(123456789, key->expiration);
+    assert_int_equal(123456789, pgp_key_get_expiration(key));
     // added2
     assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1), "added2"));
     assert_int_equal(uidc + 1, pgp_key_get_subsig(key, subsigc + 1)->uid);
@@ -148,7 +148,7 @@ test_key_add_userid(void **state)
     assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc), "added1"));
     assert_int_equal(uidc, pgp_key_get_subsig(key, subsigc)->uid);
     assert_int_equal(0xAB, pgp_key_get_subsig(key, subsigc)->key_flags);
-    assert_int_equal(123456789, key->expiration);
+    assert_int_equal(123456789, pgp_key_get_expiration(key));
     // added2
     assert_int_equal(0, strcmp(pgp_key_get_userid(key, uidc + 1), "added2"));
     assert_int_equal(uidc + 1, pgp_key_get_subsig(key, subsigc + 1)->uid);

--- a/src/tests/key-add-userid.cpp
+++ b/src/tests/key-add-userid.cpp
@@ -79,7 +79,7 @@ test_key_add_userid(void **state)
     selfsig.key_flags = 0xAB;
     selfsig.key_expiration = 123456789;
     selfsig.primary = 1;
-    assert_true(pgp_key_add_userid(key, pgp_get_key_pkt(key), PGP_HASH_SHA1, &selfsig));
+    assert_true(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig));
 
     // make sure this userid has been marked as primary
     assert_int_equal(pgp_get_userid_count(key) - 1, key->uid0);
@@ -88,21 +88,21 @@ test_key_add_userid(void **state)
     rnp_selfsig_cert_info_t dup_selfsig;
     memset(&dup_selfsig, 0, sizeof(dup_selfsig));
     strcpy((char *) dup_selfsig.userid, "added1");
-    assert_false(pgp_key_add_userid(key, pgp_get_key_pkt(key), PGP_HASH_SHA1, &dup_selfsig));
+    assert_false(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &dup_selfsig));
 
     // try to add another primary userid (should fail)
     rnp_selfsig_cert_info_t selfsig2;
     memset(&selfsig2, 0, sizeof(selfsig2));
     strcpy((char *) selfsig2.userid, "added2");
     selfsig2.primary = 1;
-    assert_false(pgp_key_add_userid(key, pgp_get_key_pkt(key), PGP_HASH_SHA1, &selfsig2));
+    assert_false(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
 
     strcpy((char *) selfsig2.userid, "added2");
     selfsig2.key_flags = 0xCD;
     selfsig2.primary = 0;
 
     // actually add another userid
-    assert_true(pgp_key_add_userid(key, pgp_get_key_pkt(key), PGP_HASH_SHA1, &selfsig2));
+    assert_true(pgp_key_add_userid(key, pgp_key_get_pkt(key), PGP_HASH_SHA1, &selfsig2));
 
     // confirm that the counts have increased as expected
     assert_int_equal(pgp_get_userid_count(key), uidc + 2);

--- a/src/tests/key-grip.cpp
+++ b/src/tests/key-grip.cpp
@@ -35,7 +35,7 @@
 void
 test_key_grip(void **state)
 {
-    uint8_t          grip[PGP_FINGERPRINT_SIZE];
+    uint8_t          grip[PGP_KEY_GRIP_SIZE];
     const pgp_key_t *key;
     rnp_key_store_t *pub_store = NULL;
     rnp_key_store_t *sec_store = NULL;

--- a/src/tests/key-protect.cpp
+++ b/src/tests/key-protect.cpp
@@ -91,13 +91,13 @@ test_key_protect_load_pgp(void **state)
     }
 
     // confirm that this key is indeed RSA
-    assert_int_equal(pgp_get_key_alg(key), PGP_PKA_RSA);
+    assert_int_equal(pgp_key_get_alg(key), PGP_PKA_RSA);
 
     // confirm key material is currently all NULL (in other words, the key is locked)
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.d));
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.p));
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.q));
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.u));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.d));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.p));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.q));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.u));
 
     // try to unprotect with a failing password provider
     pgp_password_provider_t pprov = {.callback = failing_password_callback, .userdata = NULL};
@@ -116,10 +116,10 @@ test_key_protect_load_pgp(void **state)
     assert_true(pgp_key_is_locked(key));
 
     // confirm secret key material is still NULL
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.d));
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.p));
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.q));
-    assert_true(mpi_empty(&pgp_get_key_material(key)->rsa.u));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.d));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.p));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.q));
+    assert_true(mpi_empty(&pgp_key_get_material(key)->rsa.u));
 
     // unlock (no password required since the key is not protected)
     pprov = {.callback = asserting_password_callback, .userdata = NULL};
@@ -127,16 +127,16 @@ test_key_protect_load_pgp(void **state)
     assert_false(pgp_key_is_locked(key));
 
     // secret key material should be available
-    assert_false(mpi_empty(&pgp_get_key_material(key)->rsa.d));
-    assert_false(mpi_empty(&pgp_get_key_material(key)->rsa.p));
-    assert_false(mpi_empty(&pgp_get_key_material(key)->rsa.q));
-    assert_false(mpi_empty(&pgp_get_key_material(key)->rsa.u));
+    assert_false(mpi_empty(&pgp_key_get_material(key)->rsa.d));
+    assert_false(mpi_empty(&pgp_key_get_material(key)->rsa.p));
+    assert_false(mpi_empty(&pgp_key_get_material(key)->rsa.q));
+    assert_false(mpi_empty(&pgp_key_get_material(key)->rsa.u));
 
     // save the secret MPIs for some later comparisons
-    pgp_mpi_t d = pgp_get_key_material(key)->rsa.d;
-    pgp_mpi_t p = pgp_get_key_material(key)->rsa.p;
-    pgp_mpi_t q = pgp_get_key_material(key)->rsa.q;
-    pgp_mpi_t u = pgp_get_key_material(key)->rsa.u;
+    pgp_mpi_t d = pgp_key_get_material(key)->rsa.d;
+    pgp_mpi_t p = pgp_key_get_material(key)->rsa.p;
+    pgp_mpi_t q = pgp_key_get_material(key)->rsa.q;
+    pgp_mpi_t u = pgp_key_get_material(key)->rsa.u;
 
     // confirm that packets[0] is no longer encrypted
     {
@@ -158,46 +158,46 @@ test_key_protect_load_pgp(void **state)
         assert_false(pgp_key_is_locked(reloaded_key));
         assert_false(pgp_key_is_protected(reloaded_key));
         // secret key material should not be NULL
-        assert_false(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.d));
-        assert_false(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.p));
-        assert_false(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.q));
-        assert_false(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.u));
+        assert_false(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.d));
+        assert_false(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.p));
+        assert_false(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.q));
+        assert_false(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.u));
 
         // compare MPIs of the reloaded key, with the unlocked key from earlier
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.d,
-                              &pgp_get_key_material(reloaded_key)->rsa.d));
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.p,
-                              &pgp_get_key_material(reloaded_key)->rsa.p));
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.q,
-                              &pgp_get_key_material(reloaded_key)->rsa.q));
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.u,
-                              &pgp_get_key_material(reloaded_key)->rsa.u));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.d,
+                              &pgp_key_get_material(reloaded_key)->rsa.d));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.p,
+                              &pgp_key_get_material(reloaded_key)->rsa.p));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.q,
+                              &pgp_key_get_material(reloaded_key)->rsa.q));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.u,
+                              &pgp_key_get_material(reloaded_key)->rsa.u));
         // negative test to try to ensure the above is a valid test
-        assert_false(mpi_equal(&pgp_get_key_material(key)->rsa.d,
-                               &pgp_get_key_material(reloaded_key)->rsa.p));
+        assert_false(mpi_equal(&pgp_key_get_material(key)->rsa.d,
+                               &pgp_key_get_material(reloaded_key)->rsa.p));
 
         // lock it
         assert_true(pgp_key_lock(reloaded_key));
         assert_true(pgp_key_is_locked(reloaded_key));
         // confirm that secret MPIs are NULL again
-        assert_true(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.d));
-        assert_true(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.p));
-        assert_true(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.q));
-        assert_true(mpi_empty(&pgp_get_key_material(reloaded_key)->rsa.u));
+        assert_true(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.d));
+        assert_true(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.p));
+        assert_true(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.q));
+        assert_true(mpi_empty(&pgp_key_get_material(reloaded_key)->rsa.u));
         // unlock it (no password, since it's not protected)
         pgp_password_provider_t pprov = {.callback = asserting_password_callback,
                                          .userdata = NULL};
         assert_true(pgp_key_unlock(reloaded_key, &pprov));
         assert_false(pgp_key_is_locked(reloaded_key));
         // compare MPIs of the reloaded key, with the unlocked key from earlier
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.d,
-                              &pgp_get_key_material(reloaded_key)->rsa.d));
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.p,
-                              &pgp_get_key_material(reloaded_key)->rsa.p));
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.q,
-                              &pgp_get_key_material(reloaded_key)->rsa.q));
-        assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.u,
-                              &pgp_get_key_material(reloaded_key)->rsa.u));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.d,
+                              &pgp_key_get_material(reloaded_key)->rsa.d));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.p,
+                              &pgp_key_get_material(reloaded_key)->rsa.p));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.q,
+                              &pgp_key_get_material(reloaded_key)->rsa.q));
+        assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.u,
+                              &pgp_key_get_material(reloaded_key)->rsa.u));
 
         rnp_key_store_free(ks);
     }
@@ -249,10 +249,10 @@ test_key_protect_load_pgp(void **state)
     assert_false(pgp_key_is_locked(key));
 
     // compare secret MPIs with those from earlier
-    assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.d, &d));
-    assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.p, &p));
-    assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.q, &q));
-    assert_true(mpi_equal(&pgp_get_key_material(key)->rsa.u, &u));
+    assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.d, &d));
+    assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.p, &p));
+    assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.q, &q));
+    assert_true(mpi_equal(&pgp_key_get_material(key)->rsa.u, &u));
 
     // cleanup
     pgp_key_free(key);

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -67,7 +67,7 @@ test_key_store_search(void **state)
             // set the userids
             for (size_t uidn = 0; testdata[i].userids[uidn]; uidn++) {
                 const char *userid = testdata[i].userids[uidn];
-                assert_true(pgp_add_userid(&key, (const uint8_t *) userid));
+                assert_true(pgp_key_add_userid(&key, (const uint8_t *) userid));
             }
             // add to the store
             assert_true(rnp_key_store_add_key(store, &key));
@@ -127,8 +127,8 @@ test_key_store_search(void **state)
             while (key) {
                 // check that the userid actually matches
                 bool found = false;
-                for (unsigned j = 0; j < pgp_get_userid_count(key); j++) {
-                    if (!strcmp(pgp_get_userid(key, j), userid)) {
+                for (unsigned j = 0; j < pgp_key_get_userid_count(key); j++) {
+                    if (!strcmp(pgp_key_get_userid(key, j), userid)) {
                         found = true;
                     }
                 }

--- a/src/tests/key-store-search.cpp
+++ b/src/tests/key-store-search.cpp
@@ -82,7 +82,7 @@ test_key_store_search(void **state)
         for (pgp_key_t *key = rnp_key_store_get_key_by_id(store, keyid, NULL); key;
              key = rnp_key_store_get_key_by_id(store, keyid, key)) {
             // check that the keyid actually matches
-            assert_int_equal(0, memcmp(key->keyid, keyid, PGP_KEY_ID_SIZE));
+            assert_int_equal(0, memcmp(pgp_key_get_keyid(key), keyid, PGP_KEY_ID_SIZE));
             // check that we have not already encountered this key pointer
             assert_null(list_find(seen_keys, &key, sizeof(key)));
             // keep track of what key pointers we have seen
@@ -101,7 +101,8 @@ test_key_store_search(void **state)
             uint8_t expected_keyid[PGP_KEY_ID_SIZE];
             assert_true(
               rnp_hex_decode(testdata[i].keyid, expected_keyid, sizeof(expected_keyid)));
-            assert_int_equal(0, memcmp(key->keyid, expected_keyid, PGP_KEY_ID_SIZE));
+            assert_int_equal(0,
+                             memcmp(pgp_key_get_keyid(key), expected_keyid, PGP_KEY_ID_SIZE));
             // check that we have not already encountered this key pointer
             assert_null(list_find(seen_keys, &key, sizeof(key)));
             // keep track of what key pointers we have seen

--- a/src/tests/key-unlock.cpp
+++ b/src/tests/key-unlock.cpp
@@ -91,12 +91,12 @@ test_key_unlock_pgp(void **state)
     rnp_assert_non_null(rstate, key);
 
     // confirm that this key is indeed RSA first
-    assert_int_equal(pgp_get_key_alg(key), PGP_PKA_RSA);
+    assert_int_equal(pgp_key_get_alg(key), PGP_PKA_RSA);
     // confirm the secret MPIs are NULL
-    assert_int_equal(pgp_get_key_material(key)->rsa.d.len, 0);
-    assert_int_equal(pgp_get_key_material(key)->rsa.p.len, 0);
-    assert_int_equal(pgp_get_key_material(key)->rsa.q.len, 0);
-    assert_int_equal(pgp_get_key_material(key)->rsa.u.len, 0);
+    assert_int_equal(pgp_key_get_material(key)->rsa.d.len, 0);
+    assert_int_equal(pgp_key_get_material(key)->rsa.p.len, 0);
+    assert_int_equal(pgp_key_get_material(key)->rsa.q.len, 0);
+    assert_int_equal(pgp_key_get_material(key)->rsa.u.len, 0);
 
     // try to unlock with a failing password provider
     provider =
@@ -117,10 +117,10 @@ test_key_unlock_pgp(void **state)
     rnp_assert_false(rstate, pgp_key_is_locked(key));
 
     // confirm the secret MPIs are now filled in
-    assert_int_not_equal(pgp_get_key_material(key)->rsa.d.len, 0);
-    assert_int_not_equal(pgp_get_key_material(key)->rsa.p.len, 0);
-    assert_int_not_equal(pgp_get_key_material(key)->rsa.q.len, 0);
-    assert_int_not_equal(pgp_get_key_material(key)->rsa.u.len, 0);
+    assert_int_not_equal(pgp_key_get_material(key)->rsa.d.len, 0);
+    assert_int_not_equal(pgp_key_get_material(key)->rsa.p.len, 0);
+    assert_int_not_equal(pgp_key_get_material(key)->rsa.q.len, 0);
+    assert_int_not_equal(pgp_key_get_material(key)->rsa.u.len, 0);
 
     // now the signing key is unlocked, confirm that no password is required for signing
     rnp.password_provider =

--- a/src/tests/key-validate.cpp
+++ b/src/tests/key-validate.cpp
@@ -40,8 +40,11 @@ all_keys_valid(const rnp_key_store_t *keyring)
     for (size_t i = 0; i < rnp_key_store_get_key_count(keyring); i++) {
         pgp_key_t *key = rnp_key_store_get_key(keyring, i);
         if (!key->valid) {
-            assert_true(rnp_hex_encode(
-              key->keyid, PGP_KEY_ID_SIZE, keyid, sizeof(keyid), RNP_HEX_LOWERCASE));
+            assert_true(rnp_hex_encode(pgp_key_get_keyid(key),
+                                       PGP_KEY_ID_SIZE,
+                                       keyid,
+                                       sizeof(keyid),
+                                       RNP_HEX_LOWERCASE));
             RNP_LOG("key %s is not valid", keyid);
             return false;
         }

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -388,7 +388,7 @@ test_load_check_bitfields_and_times_v3(void **state)
     key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check key version
-    assert_int_equal(pgp_key_get_pkt(key)->version, PGP_V3);
+    assert_int_equal(pgp_key_get_version(key), PGP_V3);
     // check subsig count
     assert_int_equal(pgp_key_get_subsig_count(key), 1);
     sig = &pgp_key_get_subsig(key, 0)->sig;

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -237,7 +237,7 @@ test_load_check_bitfields_and_times(void **state)
         assert_int_equal(signature_get_expiration(sig), 0);
     }
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 0);
+    assert_int_equal(pgp_key_get_expiration(key), 0);
 
     // find
     key = NULL;
@@ -253,11 +253,11 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569820);
-    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_creation(key));
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 0);
+    assert_int_equal(pgp_key_get_expiration(key), 0);
 
     // find
     key = NULL;
@@ -273,11 +273,11 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569851);
-    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_creation(key));
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 123 * 24 * 60 * 60 /* 123 days */);
+    assert_int_equal(pgp_key_get_expiration(key), 123 * 24 * 60 * 60 /* 123 days */);
 
     // find
     key = NULL;
@@ -293,11 +293,11 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569896);
-    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_creation(key));
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 0);
+    assert_int_equal(pgp_key_get_expiration(key), 0);
 
     // find
     key = NULL;
@@ -320,7 +320,7 @@ test_load_check_bitfields_and_times(void **state)
         assert_int_equal(signature_get_expiration(sig), 0);
     }
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 2076663808);
+    assert_int_equal(pgp_key_get_expiration(key), 2076663808);
 
     // find
     key = NULL;
@@ -336,11 +336,11 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569946);
-    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_creation(key));
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 2076663808);
+    assert_int_equal(pgp_key_get_expiration(key), 2076663808);
 
     // find
     key = NULL;
@@ -356,11 +356,11 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500570165);
-    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_creation(key));
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
-    assert_int_equal(key->expiration, 0);
+    assert_int_equal(pgp_key_get_expiration(key), 0);
 
     // cleanup
     rnp_key_store_free(key_store);
@@ -400,11 +400,11 @@ test_load_check_bitfields_and_times_v3(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check creation time
     assert_int_equal(signature_get_creation(sig), 1005209227);
-    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_creation(key));
     // check signature expiration time (V3 sigs have none)
     assert_int_equal(signature_get_expiration(sig), 0);
     // check key expiration
-    assert_int_equal(key->expiration, 0); // only for V4 keys
+    assert_int_equal(pgp_key_get_expiration(key), 0); // only for V4 keys
     assert_int_equal(pgp_key_get_pkt(key)->v3_days, 0);
 
     // cleanup

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -527,7 +527,7 @@ test_load_merge(void **state)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 1);
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_false(key->valid);
-    assert_int_equal(pgp_get_userid_count(key), 1);
+    assert_int_equal(pgp_key_get_userid_count(key), 1);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -540,7 +540,7 @@ test_load_merge(void **state)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 1);
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
-    assert_int_equal(pgp_get_userid_count(key), 1);
+    assert_int_equal(pgp_key_get_userid_count(key), 1);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 3);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -556,7 +556,7 @@ test_load_merge(void **state)
     assert_int_equal(rnp_key_store_get_key_count(key_store), 1);
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
-    assert_int_equal(pgp_get_userid_count(key), 2);
+    assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -575,7 +575,7 @@ test_load_merge(void **state)
     assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(key->valid);
     assert_false(skey1->valid);
-    assert_int_equal(pgp_get_userid_count(key), 2);
+    assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
@@ -584,7 +584,7 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey1), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 1);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -600,7 +600,7 @@ test_load_merge(void **state)
     assert_non_null(skey1 = rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(key->valid);
     assert_true(skey1->valid);
-    assert_int_equal(pgp_get_userid_count(key), 2);
+    assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
@@ -609,7 +609,7 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey1), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -628,7 +628,7 @@ test_load_merge(void **state)
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_true(skey2->valid);
-    assert_int_equal(pgp_get_userid_count(key), 2);
+    assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
@@ -638,12 +638,12 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey1), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey2), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey2), 0);
     assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -662,7 +662,7 @@ test_load_merge(void **state)
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_true(skey2->valid);
-    assert_int_equal(pgp_get_userid_count(key), 2);
+    assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
@@ -672,12 +672,12 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey1), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey2), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey2), 0);
     assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
@@ -701,7 +701,7 @@ test_load_merge(void **state)
     assert_true(key->valid);
     assert_true(skey1->valid);
     assert_true(skey2->valid);
-    assert_int_equal(pgp_get_userid_count(key), 2);
+    assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
@@ -711,12 +711,12 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey1), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey1), 0);
     assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_int_equal(pgp_get_userid_count(skey2), 0);
+    assert_int_equal(pgp_key_get_userid_count(skey2), 0);
     assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -85,7 +85,7 @@ test_load_v3_keyring_pgp(void **state)
                      PGP_KF_ENCRYPT | PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH);
 
     // check if the key is secret and is locked
-    assert_true(pgp_is_key_secret(key));
+    assert_true(pgp_key_is_secret(key));
     assert_true(pgp_key_is_locked(key));
 
     // decrypt the key
@@ -431,7 +431,7 @@ test_load_armored_pub_sec(void **state)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_true(pgp_key_is_primary_key(key));
-    assert_true(pgp_is_key_secret(key));
+    assert_true(pgp_key_is_secret(key));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -443,7 +443,7 @@ test_load_armored_pub_sec(void **state)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_true(pgp_key_is_subkey(key));
-    assert_true(pgp_is_key_secret(key));
+    assert_true(pgp_key_is_secret(key));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -452,7 +452,7 @@ test_load_armored_pub_sec(void **state)
     assert_non_null(key = rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(key->valid);
     assert_true(pgp_key_is_subkey(key));
-    assert_true(pgp_is_key_secret(key));
+    assert_true(pgp_key_is_secret(key));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 2);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -750,7 +750,7 @@ test_load_public_from_secret(void **state)
 
     /* copy the secret key */
     assert_rnp_success(pgp_key_copy(&keycp, key, false));
-    assert_true(pgp_is_key_secret(&keycp));
+    assert_true(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_false(
       memcmp(pgp_key_get_subkey_grip(&keycp, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
@@ -762,7 +762,7 @@ test_load_public_from_secret(void **state)
 
     /* copy the public part */
     assert_rnp_success(pgp_key_copy(&keycp, key, true));
-    assert_false(pgp_is_key_secret(&keycp));
+    assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_false(
       memcmp(pgp_key_get_subkey_grip(&keycp, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
@@ -776,7 +776,7 @@ test_load_public_from_secret(void **state)
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
-    assert_false(pgp_is_key_secret(&keycp));
+    assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_false(memcmp(keycp.primary_grip, key->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.grip, skey1->grip, PGP_FINGERPRINT_SIZE));
@@ -788,7 +788,7 @@ test_load_public_from_secret(void **state)
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
-    assert_false(pgp_is_key_secret(&keycp));
+    assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_false(memcmp(keycp.primary_grip, key->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.grip, skey2->grip, PGP_FINGERPRINT_SIZE));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -59,7 +59,7 @@ test_load_v3_keyring_pgp(void **state)
     assert_non_null(key);
 
     // confirm the key flags are correct
-    assert_int_equal(key->key_flags,
+    assert_int_equal(pgp_key_get_flags(key),
                      PGP_KF_ENCRYPT | PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH);
 
     // cleanup
@@ -81,7 +81,7 @@ test_load_v3_keyring_pgp(void **state)
     assert_non_null(key);
 
     // confirm the key flags are correct
-    assert_int_equal(key->key_flags,
+    assert_int_equal(pgp_key_get_flags(key),
                      PGP_KF_ENCRYPT | PGP_KF_SIGN | PGP_KF_CERTIFY | PGP_KF_AUTH);
 
     // check if the key is secret and is locked
@@ -128,7 +128,7 @@ test_load_v4_keyring_pgp(void **state)
     assert_non_null(key);
 
     // confirm the key flags are correct
-    assert_int_equal(key->key_flags, PGP_KF_ENCRYPT);
+    assert_int_equal(pgp_key_get_flags(key), PGP_KF_ENCRYPT);
 
     // cleanup
     rnp_key_store_free(key_store);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -91,7 +91,7 @@ test_load_v3_keyring_pgp(void **state)
     // decrypt the key
     pgp_rawpacket_t *pkt = pgp_key_get_rawpacket(key, 0);
     pgp_key_pkt_t *  seckey =
-      pgp_decrypt_seckey_pgp(pkt->raw, pkt->length, pgp_get_key_pkt(key), "password");
+      pgp_decrypt_seckey_pgp(pkt->raw, pkt->length, pgp_key_get_pkt(key), "password");
     assert_non_null(seckey);
 
     // cleanup
@@ -253,7 +253,7 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569820);
-    assert_int_equal(signature_get_creation(sig), pgp_get_key_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
@@ -273,7 +273,7 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569851);
-    assert_int_equal(signature_get_creation(sig), pgp_get_key_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
@@ -293,7 +293,7 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569896);
-    assert_int_equal(signature_get_creation(sig), pgp_get_key_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
@@ -336,7 +336,7 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500569946);
-    assert_int_equal(signature_get_creation(sig), pgp_get_key_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
@@ -356,7 +356,7 @@ test_load_check_bitfields_and_times(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check SS_CREATION_TIME [0]
     assert_int_equal(signature_get_creation(sig), 1500570165);
-    assert_int_equal(signature_get_creation(sig), pgp_get_key_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
     // check SS_EXPIRATION_TIME [0]
     assert_int_equal(signature_get_expiration(sig), 0);
     // check SS_KEY_EXPIRY
@@ -388,7 +388,7 @@ test_load_check_bitfields_and_times_v3(void **state)
     key = rnp_key_store_get_key_by_id(key_store, keyid, NULL);
     assert_non_null(key);
     // check key version
-    assert_int_equal(pgp_get_key_pkt(key)->version, PGP_V3);
+    assert_int_equal(pgp_key_get_pkt(key)->version, PGP_V3);
     // check subsig count
     assert_int_equal(pgp_key_get_subsig_count(key), 1);
     sig = &pgp_key_get_subsig(key, 0)->sig;
@@ -400,12 +400,12 @@ test_load_check_bitfields_and_times_v3(void **state)
     assert_int_equal(memcmp(keyid, signer_id, PGP_KEY_ID_SIZE), 0);
     // check creation time
     assert_int_equal(signature_get_creation(sig), 1005209227);
-    assert_int_equal(signature_get_creation(sig), pgp_get_key_pkt(key)->creation_time);
+    assert_int_equal(signature_get_creation(sig), pgp_key_get_pkt(key)->creation_time);
     // check signature expiration time (V3 sigs have none)
     assert_int_equal(signature_get_expiration(sig), 0);
     // check key expiration
     assert_int_equal(key->expiration, 0); // only for V4 keys
-    assert_int_equal(pgp_get_key_pkt(key)->v3_days, 0);
+    assert_int_equal(pgp_key_get_pkt(key)->v3_days, 0);
 
     // cleanup
     rnp_key_store_free(key_store);
@@ -770,9 +770,9 @@ test_load_public_from_secret(void **state)
       memcmp(pgp_key_get_subkey_grip(&keycp, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.grip, key->grip, PGP_FINGERPRINT_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
-    assert_null(pgp_get_key_pkt(&keycp)->sec_data);
-    assert_int_equal(pgp_get_key_pkt(&keycp)->sec_len, 0);
-    assert_false(pgp_get_key_pkt(&keycp)->material.secret);
+    assert_null(pgp_key_get_pkt(&keycp)->sec_data);
+    assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
+    assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 1 */
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
@@ -782,9 +782,9 @@ test_load_public_from_secret(void **state)
     assert_false(memcmp(keycp.grip, skey1->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.keyid, sub1id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_null(pgp_get_key_pkt(&keycp)->sec_data);
-    assert_int_equal(pgp_get_key_pkt(&keycp)->sec_len, 0);
-    assert_false(pgp_get_key_pkt(&keycp)->material.secret);
+    assert_null(pgp_key_get_pkt(&keycp)->sec_data);
+    assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
+    assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* subkey 2 */
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
@@ -794,9 +794,9 @@ test_load_public_from_secret(void **state)
     assert_false(memcmp(keycp.grip, skey2->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.keyid, sub2id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_null(pgp_get_key_pkt(&keycp)->sec_data);
-    assert_int_equal(pgp_get_key_pkt(&keycp)->sec_len, 0);
-    assert_false(pgp_get_key_pkt(&keycp)->material.secret);
+    assert_null(pgp_key_get_pkt(&keycp)->sec_data);
+    assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
+    assert_false(pgp_key_get_pkt(&keycp)->material.secret);
     rnp_key_store_add_key(pubstore, &keycp);
     /* save pubring */
     assert_true(rnp_key_store_write_to_path(pubstore));

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -780,7 +780,7 @@ test_load_public_from_secret(void **state)
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_false(memcmp(keycp.primary_grip, key->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.grip, skey1->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(keycp.keyid, sub1id, PGP_KEY_ID_SIZE));
+    assert_false(memcmp(pgp_key_get_keyid(&keycp), sub1id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
@@ -792,7 +792,7 @@ test_load_public_from_secret(void **state)
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
     assert_false(memcmp(keycp.primary_grip, key->grip, PGP_FINGERPRINT_SIZE));
     assert_false(memcmp(keycp.grip, skey2->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(keycp.keyid, sub2id, PGP_KEY_ID_SIZE));
+    assert_false(memcmp(pgp_key_get_keyid(&keycp), sub2id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -491,6 +491,16 @@ load_keystore(rnp_key_store_t *keystore, const char *fname)
     return res;
 }
 
+static bool
+check_subkey_grip(pgp_key_t *key, pgp_key_t *subkey, size_t index)
+{
+    if (memcmp(
+          pgp_key_get_subkey_grip(key, index), pgp_key_get_grip(subkey), PGP_KEY_GRIP_SIZE)) {
+        return false;
+    }
+    return !memcmp(pgp_key_get_grip(key), pgp_key_get_primary_grip(subkey), PGP_KEY_GRIP_SIZE);
+}
+
 void
 test_load_merge(void **state)
 {
@@ -577,8 +587,7 @@ test_load_merge(void **state)
     assert_false(skey1->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, skey1, 0));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -586,7 +595,6 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 1);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
 
@@ -603,8 +611,7 @@ test_load_merge(void **state)
     assert_true(skey1->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, skey1, 0));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -612,7 +619,6 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -632,10 +638,8 @@ test_load_merge(void **state)
     assert_true(skey2->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, skey1, 0));
+    assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -643,12 +647,10 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -668,10 +670,8 @@ test_load_merge(void **state)
     assert_true(skey2->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, skey1, 0));
+    assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -679,12 +679,10 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -709,10 +707,8 @@ test_load_merge(void **state)
     assert_true(skey2->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, skey1, 0));
+    assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -720,12 +716,10 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -772,10 +766,8 @@ test_load_public_from_secret(void **state)
     assert_rnp_success(pgp_key_copy(&keycp, key, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(&keycp, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(&keycp, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(&keycp, skey1, 0));
+    assert_true(check_subkey_grip(&keycp, skey2, 1));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
@@ -786,7 +778,7 @@ test_load_public_from_secret(void **state)
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
-    assert_false(memcmp(keycp.primary_grip, pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, &keycp, 0));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_keyid(&keycp), sub1id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -798,7 +790,7 @@ test_load_public_from_secret(void **state)
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
-    assert_false(memcmp(keycp.primary_grip, pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
+    assert_true(check_subkey_grip(key, &keycp, 1));
     assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_keyid(&keycp), sub2id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
@@ -1006,7 +998,7 @@ test_load_subkey(void **state)
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
-    assert_null(skey1->primary_grip);
+    assert_null(pgp_key_get_primary_grip(skey1));
 
     /* load second subkey, without signature */
     assert_true(load_keystore(key_store, MERGE_PATH "key-pub-just-subkey-2-no-sigs.pgp"));
@@ -1015,7 +1007,7 @@ test_load_subkey(void **state)
     assert_false(skey2->valid);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 1);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
-    assert_null(skey2->primary_grip);
+    assert_null(pgp_key_get_primary_grip(skey2));
     assert_false(skey1 == skey2);
 
     /* load primary key without subkey signatures */
@@ -1029,11 +1021,9 @@ test_load_subkey(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 2)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
-    assert_non_null(skey1->primary_grip);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
+    assert_non_null(pgp_key_get_primary_grip(skey1));
+    assert_true(check_subkey_grip(key, skey1, 0));
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_true(skey1->valid);
     assert_false(skey2->valid);
 
@@ -1043,11 +1033,9 @@ test_load_subkey(void **state)
     assert_true(key == rnp_key_store_get_key_by_id(key_store, keyid, NULL));
     assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
-    assert_non_null(skey2->primary_grip);
-    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
+    assert_non_null(pgp_key_get_primary_grip(skey2));
+    assert_true(check_subkey_grip(key, skey2, 1));
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(
-      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_true(skey2->valid);
 
     rnp_key_store_free(key_store);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -577,7 +577,8 @@ test_load_merge(void **state)
     assert_false(skey1->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -585,7 +586,7 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 1);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
 
@@ -602,7 +603,8 @@ test_load_merge(void **state)
     assert_true(skey1->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -610,7 +612,7 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -630,8 +632,10 @@ test_load_merge(void **state)
     assert_true(skey2->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -639,12 +643,12 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
-    assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -664,8 +668,10 @@ test_load_merge(void **state)
     assert_true(skey2->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -673,12 +679,12 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
-    assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -703,8 +709,10 @@ test_load_merge(void **state)
     assert_true(skey2->valid);
     assert_int_equal(pgp_key_get_userid_count(key), 2);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket_count(key), 5);
     assert_int_equal(pgp_key_get_rawpacket(key, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
     assert_int_equal(pgp_key_get_rawpacket(key, 1)->tag, PGP_PTAG_CT_USER_ID);
@@ -712,12 +720,12 @@ test_load_merge(void **state)
     assert_int_equal(pgp_key_get_rawpacket(key, 3)->tag, PGP_PTAG_CT_USER_ID);
     assert_int_equal(pgp_key_get_rawpacket(key, 4)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey1), 0);
-    assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey1), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey1, 1)->tag, PGP_PTAG_CT_SIGNATURE);
     assert_int_equal(pgp_key_get_userid_count(skey2), 0);
-    assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_rawpacket_count(skey2), 2);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 0)->tag, PGP_PTAG_CT_SECRET_SUBKEY);
     assert_int_equal(pgp_key_get_rawpacket(skey2, 1)->tag, PGP_PTAG_CT_SIGNATURE);
@@ -753,10 +761,10 @@ test_load_public_from_secret(void **state)
     assert_true(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_false(
-      memcmp(pgp_key_get_subkey_grip(&keycp, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
+      memcmp(pgp_key_get_subkey_grip(&keycp, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_false(
-      memcmp(pgp_key_get_subkey_grip(&keycp, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(keycp.grip, key->grip, PGP_FINGERPRINT_SIZE));
+      memcmp(pgp_key_get_subkey_grip(&keycp, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
+    assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_SECRET_KEY);
     pgp_key_free_data(&keycp);
 
@@ -765,10 +773,10 @@ test_load_public_from_secret(void **state)
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 2);
     assert_false(
-      memcmp(pgp_key_get_subkey_grip(&keycp, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
+      memcmp(pgp_key_get_subkey_grip(&keycp, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_false(
-      memcmp(pgp_key_get_subkey_grip(&keycp, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(keycp.grip, key->grip, PGP_FINGERPRINT_SIZE));
+      memcmp(pgp_key_get_subkey_grip(&keycp, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
+    assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_KEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
     assert_int_equal(pgp_key_get_pkt(&keycp)->sec_len, 0);
@@ -778,8 +786,8 @@ test_load_public_from_secret(void **state)
     assert_rnp_success(pgp_key_copy(&keycp, skey1, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
-    assert_false(memcmp(keycp.primary_grip, key->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(keycp.grip, skey1->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(memcmp(keycp.primary_grip, pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
+    assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_keyid(&keycp), sub1id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
@@ -790,8 +798,8 @@ test_load_public_from_secret(void **state)
     assert_rnp_success(pgp_key_copy(&keycp, skey2, true));
     assert_false(pgp_key_is_secret(&keycp));
     assert_int_equal(pgp_key_get_subkey_count(&keycp), 0);
-    assert_false(memcmp(keycp.primary_grip, key->grip, PGP_FINGERPRINT_SIZE));
-    assert_false(memcmp(keycp.grip, skey2->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(memcmp(keycp.primary_grip, pgp_key_get_grip(key), PGP_KEY_GRIP_SIZE));
+    assert_false(memcmp(pgp_key_get_grip(&keycp), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_false(memcmp(pgp_key_get_keyid(&keycp), sub2id, PGP_KEY_ID_SIZE));
     assert_int_equal(pgp_key_get_rawpacket(&keycp, 0)->tag, PGP_PTAG_CT_PUBLIC_SUBKEY);
     assert_null(pgp_key_get_pkt(&keycp)->sec_data);
@@ -1022,9 +1030,10 @@ test_load_subkey(void **state)
     assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_non_null(skey1->primary_grip);
-    assert_int_equal(memcmp(key->grip, skey1->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey1->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_subkey_count(key), 1);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 0), skey1->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 0), pgp_key_get_grip(skey1), PGP_KEY_GRIP_SIZE));
     assert_true(skey1->valid);
     assert_false(skey2->valid);
 
@@ -1035,9 +1044,10 @@ test_load_subkey(void **state)
     assert_true(skey1 == rnp_key_store_get_key_by_id(key_store, sub1id, NULL));
     assert_true(skey2 == rnp_key_store_get_key_by_id(key_store, sub2id, NULL));
     assert_non_null(skey2->primary_grip);
-    assert_int_equal(memcmp(key->grip, skey2->primary_grip, PGP_FINGERPRINT_SIZE), 0);
+    assert_int_equal(memcmp(pgp_key_get_grip(key), skey2->primary_grip, PGP_KEY_GRIP_SIZE), 0);
     assert_int_equal(pgp_key_get_subkey_count(key), 2);
-    assert_false(memcmp(pgp_key_get_subkey_grip(key, 1), skey2->grip, PGP_FINGERPRINT_SIZE));
+    assert_false(
+      memcmp(pgp_key_get_subkey_grip(key, 1), pgp_key_get_grip(skey2), PGP_KEY_GRIP_SIZE));
     assert_true(skey2->valid);
 
     rnp_key_store_free(key_store);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -342,7 +342,7 @@ test_stream_signatures(void **state)
     sig.palg = pgp_key_get_alg(key);
     sig.type = PGP_SIG_BINARY;
     assert_true(signature_set_keyfp(&sig, &key->fingerprint));
-    assert_true(signature_set_keyid(&sig, key->keyid));
+    assert_true(signature_set_keyid(&sig, pgp_key_get_keyid(key)));
     assert_true(signature_set_creation(&sig, create));
     assert_true(signature_set_expiration(&sig, expire));
     assert_true(signature_fill_hashed_data(&sig));

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1132,7 +1132,7 @@ test_stream_key_signature_validate(void **state)
     assert_true(rnp_key_store_get_key_count(pubring) > 0);
     for (size_t i = 0; i < rnp_key_store_get_key_count(pubring); i++) {
         pkey = rnp_key_store_get_key(pubring, i);
-        if (!pgp_is_primary_key_tag(pgp_get_key_pkt(pkey)->tag)) {
+        if (!pgp_key_is_primary_key(pkey)) {
             continue;
         }
 

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -332,7 +332,7 @@ test_stream_signatures(void **state)
     assert_non_null(secring);
     assert_true(rnp_key_store_load_from_path(secring, NULL));
     assert_non_null(key = rnp_key_store_get_key_by_id(secring, keyid, NULL));
-    assert_true(pgp_is_key_secret(key));
+    assert_true(pgp_key_is_secret(key));
     /* fill signature */
     uint32_t create = time(NULL);
     uint32_t expire = 123456;

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -341,7 +341,7 @@ test_stream_signatures(void **state)
     sig.halg = halg;
     sig.palg = pgp_key_get_alg(key);
     sig.type = PGP_SIG_BINARY;
-    assert_true(signature_set_keyfp(&sig, &key->fingerprint));
+    assert_true(signature_set_keyfp(&sig, pgp_key_get_fp(key)));
     assert_true(signature_set_keyid(&sig, pgp_key_get_keyid(key)));
     assert_true(signature_set_creation(&sig, create));
     assert_true(signature_set_expiration(&sig, expire));
@@ -362,8 +362,7 @@ test_stream_signatures(void **state)
     assert_int_equal(signature_get_expiration(&sig), expire);
     assert_true(signature_has_keyfp(&sig));
     assert_true(signature_get_keyfp(&sig, &fp));
-    assert_int_equal(fp.length, key->fingerprint.length);
-    assert_int_equal(0, memcmp(fp.fingerprint, key->fingerprint.fingerprint, fp.length));
+    assert_true(fingerprint_equal(&fp, pgp_key_get_fp(key)));
     assert_rnp_success(signature_validate(&sig, pgp_key_get_material(key), &hash));
     free_signature(&sig);
     /* cleanup */

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -36,8 +36,8 @@ find_subsig(const pgp_key_t *key, const char *userid)
 {
     // find the userid index
     int uididx = -1;
-    for (unsigned i = 0; i < pgp_get_userid_count(key); i++) {
-        if (memcmp(pgp_get_userid(key, i), userid, strlen(userid)) == 0) {
+    for (unsigned i = 0; i < pgp_key_get_userid_count(key); i++) {
+        if (memcmp(pgp_key_get_userid(key, i), userid, strlen(userid)) == 0) {
             uididx = i;
             break;
         }


### PR DESCRIPTION
This PR further improves usage of pgp_key_t in code.
This would allow easier C++ migration later and better layers separation.
Changes:
- removed redundant key tag check functions
- some function renames to start with `pgp_key_`
- field accessors instead of direct field access
