### PR TITLE
ci: Only run Cirrus CI for certain branches and PRs.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,7 @@ freebsd_instance:
 
 task:
   name: build
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'release/.*' || $CIRRUS_PR != ''
   # increase timeout since we use a single task for building cache and testing
   timeout_in: 90m
   env:


### PR DESCRIPTION
I forgot to limit this to important branches as we do for Travis CI.

Note: Cirrus CI is a little weird because it will still show a build entry that failed with `INVALID_ARGUMENT: No tasks found to start!`.