### PR TITLE
docs: Convert README to AsciiDoc, add navigation

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -1,4 +1,6 @@
-# Introduction
+= RNP
+
+== Introduction
 
 "rnp" is a set of OpenPGP (RFC4880) tools that works on Linux, \*BSD and
 macOS as a replacement of GnuPG. It is maintained by Ribose after being
@@ -11,13 +13,13 @@ library, not a wrapper like GPGME of GnuPG.
 NetPGP was originally written (and still maintained) by Alistair Crooks
 of NetBSD.
 
-# Status
+== Status
 
-[![Travis CI Build Status](https://travis-ci.org/riboseinc/rnp.svg?branch=master)](https://travis-ci.org/riboseinc/rnp)
-[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/12616.svg)](https://scan.coverity.com/projects/riboseinc-rnp)
-[![Code coverage](https://codecov.io/gh/riboseinc/rnp/branch/master/graph/badge.svg)](https://codecov.io/gh/riboseinc/rnp)
+image:https://travis-ci.org/riboseinc/rnp.svg?branch=master["Travis CI Build Status", link="https://travis-ci.org/riboseinc/rnp"]
+image:https://img.shields.io/coverity/scan/12616.svg["Coverity Scan Build Status", link="https://scan.coverity.com/projects/riboseinc-rnp"]
+image:https://codecov.io/gh/riboseinc/rnp/branch/master/graph/badge.svg["Code coverage", link="https://codecov.io/gh/riboseinc/rnp"]
 
-# Supported Platforms
+== Supported Platforms
 
 Currently supported platforms:
 
@@ -32,22 +34,24 @@ Upcoming supported platforms:
 * SLES 12
 
 
-# Usage
+== Usage
 
-## Generating an RSA Private Key
+=== Generating an RSA Private Key
 
-By default ``rnpkeys  --generate-key`` will generate 2048-bit RSA key.
+By default `rnpkeys  --generate-key` will generate 2048-bit RSA key.
 
-``` sh
+[source,console]
+----
 export keydir=/tmp
 rnpkeys --generate-key --homedir=${keydir}
-```
+----
 
 =>
 
-``` sh
+[source,console]
+----
 rnpkeys: generated keys in directory ${keydir}/6ed2d908150b82e7
-```
+----
 
 In case you're curious, `6ed2d...` is the key fingerprint.
 
@@ -55,7 +59,8 @@ In order to use fully featured key pair generation ``--expert`` flag should be u
 
 Example:
 
-``` sh
+[source,console]
+----
 > export keydir=/tmp
 > rnpkeys --generate-key --expert --homedir=${keydir}
 
@@ -79,37 +84,40 @@ rnp: generated keys in directory /tmp/.rnp
 Enter password for d45592277b75ada1:
 Repeat password for d45592277b75ada1:
 >
-```
+----
 
 
-## Listing Keys
+=== Listing Keys
 
-``` sh
+[source,console]
+----
 export keyringdir=${keydir}/MYFINGERPRINT
 rnpkeys --list-keys --homedir=${keyringdir}
 
-```
+----
 
 =>
 
-```
+[source,console]
+----
 1 key found
 ...
-```
+----
 
 
-## Signing a File
+=== Signing a File
 
 
-### Signing in binary format
+==== Signing in binary format
 
-``` sh
+[source,console]
+----
 rnp --sign --homedir=${keyringdir} ${filename}
-```
+----
 
 =>
 
-Created `${filename}.gpg` which is an OpenPGP message that includes the
+Creates `${filename}.gpg` which is an OpenPGP message that includes the
 message together with the signature as a 'signed message'.
 
 This type of file can be verified by:
@@ -117,15 +125,16 @@ This type of file can be verified by:
 * `rnp --verify --homedir=${keyringdir} ${filename}.gpg`
 
 
-### Signing in binary detatched format
+==== Signing in binary detatched format
 
-``` sh
+[source,console]
+----
 rnp --sign --detach --homedir=${keyringdir} ${filename}
-```
+----
 
 =>
 
-Created `${filename}.sig` which is an OpenPGP message in binary
+Creates `${filename}.sig` which is an OpenPGP message in binary
 format, that only contains the signature.
 
 This type of file can be verified by:
@@ -133,15 +142,16 @@ This type of file can be verified by:
 * `rnp --verify --homedir=${keyringdir} ${filename}.sig`
 
 
-### Signing in Armored (ASCII-Armored) format
+==== Signing in Armored (ASCII-Armored) format
 
-``` sh
+[source,console]
+----
 rnp --sign --armor --homedir=${keyringdir} ${filename}
-```
+----
 
 =>
 
-Created `${filename}.asc` which is an OpenPGP message in ASCII-armored
+Creates `${filename}.asc` which is an OpenPGP message in ASCII-armored
 format, including the message together with the signature as a 'signed
 message'.
 
@@ -150,7 +160,7 @@ This type of file can be verified by:
 * `rnp --verify --homedir=${keyringdir} ${filename}.asc`
 
 
-### Other options
+==== Other options
 
 * `--clearsign` option will append a separate PGP Signaure to the end of
   the message (the new output)
@@ -159,97 +169,106 @@ This type of file can be verified by:
   the message (the new output)
 
 
-## Encrypt
+=== Encrypt
 
 
-``` sh
+[source,console]
+----
 rnp --encrypt --homedir=${keyringdir} ${filename}
-```
+----
 
 =>
 
-Creates: `${filename}.gpg`
+Creates `${filename}.gpg`.
 
 
-## Decrypt
+=== Decrypt
 
-``` sh
+[source,console]
+----
 rnp --decrypt --homedir=${keyringdir} ${filename}.gpg
-```
+----
 
 =>
 
-Creates: `${filename}`
+Creates `${filename}`.
 
 
-# For developers
+== For developers
 
 You may wish to use librnp library in your projects as well.
-See the [`src/examples/README.md`](./src/examples/README.md) for the usage details and sample code.
+See the https://github.com/riboseinc/rnp/blob/master/src/examples/README.md[`src/examples/README.md`]
+for usage details and sample code.
 
 
-# Install
+== Install
 
-## Binaries installed
+=== Binaries installed
 
 * `rnp`
 * `rnpkeys`
 
-## On macOS using Homebrew
+=== On macOS using Homebrew
 
-``` sh
+[source,console]
+----
 brew tap riboseinc/rnp
 brew install rnp
-```
+----
 
-## On RHEL and CentOS via YUM
+=== On RHEL and CentOS via YUM
 
-``` sh
+[source,console]
+----
 rpm --import https://github.com/riboseinc/yum/raw/master/ribose-packages.pub
 curl -L https://github.com/riboseinc/yum/raw/master/ribose.repo > /etc/yum.repos.d/ribose.repo
 yum install -y rnp
-```
+----
 
 ## On Debian
 
-``` sh
+[source,console]
+----
 # Clone the repository by version tag (or omit it to get the latest sources)
 sudo apt install git
 git clone https://github.com/riboseinc/rnp.git -b v0.11.0
+
 # Enable access to `testing` packages by editing /etc/apt/sources.list
 # deb http://deb.debian.org/debian testing main
 # Install required packages
 sudo apt install g++-8 cmake libbz2-dev zlib1g-dev libjson-c-dev libbotan-2-dev build-essential
+
 # Cmake recommend out-of-source builds
 mkdir rnp-build
 cd rnp-build
+
 # Cmake it
 cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off ../rnp/
 make install
-```
+----
 
-## Compiling from source
+=== Compiling from source
 
-Clone this repo or download a release and expand it.
+Clone this repo, or download a release and expand it. Then:
 
-``` bash
+[source,console]
+----
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off .
 make install
-```
+----
 
-# Versioning
+== Versioning
 
-rnp follows the [semantic versioning](http://semver.org/) syntax.
+RNP follows the http://semver.org/[semantic versioning] syntax.
 
-## Checking versions
+=== Checking versions
 
-The '--version' output of the `rnp` commands contains the `git` hash of
+The output of `rnp --version` contains the `git` hash of
 the version the binary was built from, which value is generated when
-`cmake` ran, consequently a release tarball generated with `make
+`cmake` runs. Consequently, a release tarball generated with `make
 dist` will contain this hash version.
 
-## Historic
+=== Historic
 
 The first version of rnp started at `0.8.0` to indicate its development
 completeness (or lack thereof).
-

--- a/docs/navigation.adoc
+++ b/docs/navigation.adoc
@@ -1,0 +1,8 @@
+---
+items:
+- title: Introduction
+  items:
+    - { title: README, path: README/ }
+---
+
+= Navigation


### PR DESCRIPTION
This moves the README under docs/ (where it will still be recognized by GitHub), and converts markup from Markdown to AsciiDoc. This way it’ll integrate well with rnpgp.com (and the latest version of Open Project theme also adds in-page ToC navigation for AsciiDoc-rendered documentation files).