### PR TITLE
Fix double-free with invalid armored headers.

### DIFF
--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -374,7 +374,7 @@ armored_src_close(pgp_source_t *src)
         free(param->hash);
         free(param->charset);
         free(param);
-        param = NULL;
+        src->param = NULL;
     }
 }
 

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -197,6 +197,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_stream_verify_no_key),
       cmocka_unit_test(test_stream_key_signature_validate),
       cmocka_unit_test(test_stream_key_load_errors),
+      cmocka_unit_test(test_stream_814_dearmor_double_free),
       cmocka_unit_test(test_ffi_homedir),
       cmocka_unit_test(test_ffi_keygen_json_pair),
       cmocka_unit_test(test_ffi_keygen_json_primary),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -224,6 +224,8 @@ void test_stream_verify_no_key(void **state);
 
 void test_stream_key_signature_validate(void **state);
 
+void test_stream_814_dearmor_double_free(void **state);
+
 void test_cli_rnpkeys(void **state);
 
 void test_cli_rnp(void **state);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1350,3 +1350,20 @@ test_stream_z(void **state)
     src_close(&src);
     dst_close(&dst, true);
 }
+
+/* This test checks for GitHub issue #814.
+ */
+void
+test_stream_814_dearmor_double_free(void **state)
+{
+    pgp_source_t src;
+    pgp_dest_t   dst;
+    const char * buf = "-----BEGIN PGP BAD HEADER-----";
+
+    assert_rnp_success(init_mem_src(&src, buf, strlen(buf), false));
+    assert_rnp_success(init_null_dest(&dst));
+    assert_rnp_failure(rnp_dearmor_source(&src, &dst));
+    src_close(&src);
+    dst_close(&dst, true);
+}
+


### PR DESCRIPTION
Current master will crash on this test, so this fixes that.