### PR TITLE
Fix broken versioning when added as a git submodule.

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -76,7 +76,7 @@ function(extract_version_info version var_prefix)
 endfunction()
 
 function(determine_version source_dir var_prefix)
-  if (IS_DIRECTORY "${source_dir}/.git/")
+  if (EXISTS "${source_dir}/.git")
     # for GIT_EXECUTABLE
     find_package(Git REQUIRED)
     # get a description of the version, something like:


### PR DESCRIPTION
Our version determining code will currently error out if rnp is used as a submodule because it checks for a directory named `.git`, which is in fact a file when used as a submodule.