### PR TITLE
Add rnp_unload_keys function to the FFI.

### DIFF
--- a/include/rnp/rnp2.h
+++ b/include/rnp/rnp2.h
@@ -47,6 +47,9 @@ typedef uint32_t rnp_result_t;
 #define RNP_KEY_REMOVE_PUBLIC (1U << 0)
 #define RNP_KEY_REMOVE_SECRET (1U << 1)
 
+#define RNP_KEY_UNLOAD_PUBLIC (1U << 0)
+#define RNP_KEY_UNLOAD_SECRET (1U << 1)
+
 /**
  * Flags for optional details to include in JSON.
  */
@@ -278,6 +281,15 @@ rnp_result_t rnp_load_keys(rnp_ffi_t   ffi,
                            const char *format,
                            rnp_input_t input,
                            uint32_t    flags);
+
+/** unload public and/or secret keys
+ *  Note: After unloading all key handles will become invalid and must be destroyed.
+ * @param ffi
+ * @param flags choose which keys should be unloaded (pubic, secret or both).
+ *              See RNP_UNLOAD_PUBLIC_KEYS/RNP_UNLOAD_SECRET_KEYS.
+ * @return rnp_result_t 0 on success, or any other value on error.
+ */
+rnp_result_t rnp_unload_keys(rnp_ffi_t ffi, uint32_t flags);
 
 /** save keys
  *

--- a/src/lib/rnp2.cpp
+++ b/src/lib/rnp2.cpp
@@ -1056,6 +1056,27 @@ rnp_load_keys(rnp_ffi_t ffi, const char *format, rnp_input_t input, uint32_t fla
     return do_load_keys(ffi, input, format, type);
 }
 
+rnp_result_t
+rnp_unload_keys(rnp_ffi_t ffi, uint32_t flags)
+{
+    if (!ffi) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+
+    if (flags & ~(RNP_KEY_UNLOAD_PUBLIC | RNP_KEY_UNLOAD_SECRET)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    if (flags & RNP_KEY_UNLOAD_PUBLIC) {
+        rnp_key_store_clear(ffi->pubring);
+    }
+    if (flags & RNP_KEY_UNLOAD_SECRET) {
+        rnp_key_store_clear(ffi->secring);
+    }
+
+    return RNP_SUCCESS;
+}
+
 static bool
 copy_store_keys(rnp_ffi_t ffi, rnp_key_store_t *dest, rnp_key_store_t *src)
 {

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -220,6 +220,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_signatures_detached),
       cmocka_unit_test(test_ffi_signatures),
       cmocka_unit_test(test_ffi_load_keys),
+      cmocka_unit_test(test_ffi_clear_keys),
       cmocka_unit_test(test_ffi_save_keys),
       cmocka_unit_test(test_ffi_key_to_json),
       cmocka_unit_test(test_ffi_key_iter),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -164,6 +164,8 @@ void test_ffi_detect_key_format(void **state);
 
 void test_ffi_load_keys(void **state);
 
+void test_ffi_clear_keys(void **state);
+
 void test_ffi_save_keys(void **state);
 
 void test_ffi_encrypt_pass(void **state);


### PR DESCRIPTION
We didn't have such function before, and it is useful sometimes (at least need this for CLI to FFI transition).