### PR TITLE
Check for premature armored stream end

### DIFF
--- a/src/librepgp/stream-armor.cpp
+++ b/src/librepgp/stream-armor.cpp
@@ -221,6 +221,10 @@ armored_src_read(pgp_source_t *src, void *buf, size_t len)
         if (read < 0) {
             return read;
         }
+        if (read == 0) {
+            RNP_LOG("premature end of armored input");
+            return -1;
+        }
 
         dptr = dend;
         bptr = b64buf;

--- a/src/librepgp/stream-common.cpp
+++ b/src/librepgp/stream-common.cpp
@@ -90,6 +90,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
                 len = len - left;
                 goto finish;
             } else {
+                src->error = 1;
                 return -1;
             }
         } else {
@@ -100,6 +101,7 @@ src_read(pgp_source_t *src, void *buf, size_t len)
                 len = len - left;
                 goto finish;
             } else if (read < 0) {
+                src->error = 1;
                 return -1;
             } else if ((size_t) read < left) {
                 memcpy(buf, &cache->buf[0], read);
@@ -177,6 +179,7 @@ src_peek(pgp_source_t *src, void *buf, size_t len)
             }
             return cache->len;
         } else if (read < 0) {
+            src->error = 1;
             return -1;
         } else {
             cache->len += read;
@@ -232,6 +235,12 @@ src_finish(pgp_source_t *src)
 }
 
 bool
+src_error(const pgp_source_t *src)
+{
+    return src->error;
+}
+
+bool
 src_eof(pgp_source_t *src)
 {
     uint8_t check;
@@ -240,6 +249,7 @@ src_eof(pgp_source_t *src)
         return true;
     }
 
+    /* Error on stream read is NOT considered as eof. See src_error(). */
     return src_peek(src, &check, 1) == 0;
 }
 

--- a/src/librepgp/stream-common.h
+++ b/src/librepgp/stream-common.h
@@ -83,6 +83,7 @@ typedef struct pgp_source_t {
 
     unsigned eof : 1;       /* end of data as reported by read and empty cache */
     unsigned knownsize : 1; /* whether size of the data is known */
+    unsigned error : 1;     /* there were reading error */
 } pgp_source_t;
 
 /** @brief helper function to allocate memory for source's cache and param
@@ -134,9 +135,16 @@ ssize_t src_skip(pgp_source_t *src, size_t len);
  */
 rnp_result_t src_finish(pgp_source_t *src);
 
+/** @brief check whether there were reading error on source
+ *  @param allocated and initialized source structure
+ *  @return true if there were reading error or false otherwise
+ */
+bool src_error(const pgp_source_t *src);
+
 /** @brief check whether there is no more input on source
  *  @param src allocated and initialized source structure
- *  @return true if there is no more input or false otherwise
+ *  @return true if there is no more input or false otherwise.
+ *          On read error false will be returned.
  */
 bool src_eof(pgp_source_t *src);
 

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -811,7 +811,7 @@ armoredpass:
     }
 
     /* read sequence of transferable OpenPGP keys as described in RFC 4880, 11.1 - 11.2 */
-    while (!src_eof(src)) {
+    while (!src_eof(src) && !src_error(src)) {
         ptag = stream_pkt_type(src);
 
         if ((ptag < 0) || !is_primary_key_pkt(ptag)) {

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -3812,6 +3812,27 @@ test_ffi_enarmor_dearmor(void **state)
         rnp_input_destroy(input);
         rnp_output_destroy(output);
     }
+    // test truncated armored data
+    {
+        std::ifstream keyf("data/test_stream_key_load/rsa-rsa-pub.asc",
+                           std::ios::binary | std::ios::ate);
+        std::string   keystr(keyf.tellg(), ' ');
+        keyf.seekg(0);
+        keyf.read(&keystr[0], keystr.size());
+        keyf.close();
+        for (size_t sz = keystr.size() - 2; sz > 0; sz--) {
+            rnp_input_t  input = NULL;
+            rnp_output_t output = NULL;
+
+            assert_rnp_success(
+              rnp_input_from_memory(&input, (const uint8_t *) keystr.data(), sz, true));
+            assert_rnp_success(rnp_output_to_memory(&output, 0));
+            assert_rnp_failure(rnp_dearmor(input, output));
+
+            rnp_input_destroy(input);
+            rnp_output_destroy(output);
+        }
+    }
 }
 
 void


### PR DESCRIPTION
This PR fixes #824 :

- it adds check for premature armored stream end;
- also adds check for underlying armored stream error while processing armored key(s).
- updates test to make sure there are no memory leaks/other problems while processing cut out armored input
- raises issue #826 