### PR TITLE
Correctly set armor header for detached signatures.

### DIFF
--- a/src/librepgp/stream-write.cpp
+++ b/src/librepgp/stream-write.cpp
@@ -1811,7 +1811,9 @@ rnp_sign_src(pgp_write_handler_t *handler, pgp_source_t *src, pgp_dest_t *dst)
 
     /* pushing armoring stream, which will write to the output */
     if (handler->ctx->armor && !handler->ctx->clearsign) {
-        ret = init_armored_dst(&dests[destc], dst, PGP_ARMORED_MESSAGE);
+        pgp_armored_msg_t msgt =
+          handler->ctx->detached ? PGP_ARMORED_SIGNATURE : PGP_ARMORED_MESSAGE;
+        ret = init_armored_dst(&dests[destc], dst, msgt);
         if (ret != RNP_SUCCESS) {
             goto finish;
         }

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -2869,7 +2869,8 @@ test_ffi_signatures_memory(void **state)
     op = NULL;
 
     /* now verify */
-
+    // make sure it is correctly armored
+    assert_int_equal(memcmp(signed_buf, "-----BEGIN PGP MESSAGE-----", 27), 0);
     // create input and output
     test_ffi_init_verify_memory_input(state, &input, &output, signed_buf, signed_len);
     // call verify
@@ -2977,7 +2978,8 @@ test_ffi_signatures_detached_memory(void **state)
     op = NULL;
 
     /* now verify */
-
+    // make sure it is correctly armored
+    assert_int_equal(memcmp(signed_buf, "-----BEGIN PGP SIGNATURE-----", 29), 0);
     // create input and output
     test_ffi_init_sign_memory_input(state, &input, NULL);
     assert_rnp_success(rnp_input_from_memory(&signature, signed_buf, signed_len, true));


### PR DESCRIPTION
This fixes #811 and update tests to not let this happen in the future.