### PR TITLE
ffi: Expand JSON key generation bit length support.

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -2771,12 +2771,20 @@ parse_keygen_crypto(json_object *jso, rnp_keygen_crypto_params_t *crypto)
                 return false;
             }
         } else if (!rnp_strcasecmp(key, "length")) {
-            // if the key alg is set and isn't RSA, this wouldn't be used
-            // (RSA is default, so we have to see if it is set)
-            if (crypto->key_alg && crypto->key_alg != PGP_PKA_RSA) {
-                return false;
+            int length = json_object_get_int(value);
+            switch (crypto->key_alg) {
+                case PGP_PKA_RSA:
+                    crypto->rsa.modulus_bit_len = length;
+                    break;
+                case PGP_PKA_DSA:
+                    crypto->dsa.p_bitlen = length;
+                    break;
+                case PGP_PKA_ELGAMAL:
+                    crypto->elgamal.key_bitlen = length;
+                    break;
+                default:
+                    return false;
             }
-            crypto->rsa.modulus_bit_len = json_object_get_int(value);
         } else if (!rnp_strcasecmp(key, "curve")) {
             if (!pk_alg_allows_custom_curve(crypto->key_alg)) {
                 return false;

--- a/src/tests/data/test_ffi_json/generate-pair-dsa-elg.json
+++ b/src/tests/data/test_ffi_json/generate-pair-dsa-elg.json
@@ -1,0 +1,11 @@
+{
+  "primary": {
+      "type": "DSA",
+      "length": 1024,
+      "userid": "test0"
+   },
+   "sub": {
+      "type": "Elgamal",
+      "length": 1536
+   }
+}

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -203,6 +203,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_homedir),
       cmocka_unit_test(test_ffi_keygen_json_pair),
       cmocka_unit_test(test_ffi_keygen_json_primary),
+      cmocka_unit_test(test_ffi_keygen_json_pair_dsa_elg),
       cmocka_unit_test(test_ffi_keygen_json_sub),
       cmocka_unit_test(test_ffi_keygen_json_sub_pass_required),
       cmocka_unit_test(test_ffi_key_generate_misc),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -138,6 +138,8 @@ void test_ffi_homedir(void **state);
 
 void test_ffi_keygen_json_pair(void **state);
 
+void test_ffi_keygen_json_pair_dsa_elg(void **state);
+
 void test_ffi_keygen_json_primary(void **state);
 
 void test_ffi_keygen_json_sub(void **state);


### PR DESCRIPTION
I realize the JSON key generation code is due for a rewrite (using the non-JSON keygen code) but I still think it may be worth merging.

There is currently a slight backwards-incompatible change here, so that should probably be discussed. Previously, you could pass something like:
```json
{
  "primary": {
    "length": 1024
  }
}
```
And it would default to RSA. With this change, you must specify the type:
```json
{
  "primary": {
    "type": "RSA",
    "length": 1024
  }
}
```

I don't think this was documented anywhere.