### PR TITLE
Fix primary key protection in rnp_generate_key_ex.

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3393,11 +3393,11 @@ rnp_generate_key_ex(rnp_ffi_t         ffi,
     if ((ret = rnp_op_generate_get_key(subop, &subkey))) {
         goto done;
     }
-    /* only now will protect the primary key - to not spend time on unlocking to sign subkey */
-    if (password && (ret = rnp_key_protect(primary, password, NULL, NULL, NULL, 0))) {
-        goto done;
-    }
 done:
+    /* only now will protect the primary key - to not spend time on unlocking to sign subkey */
+    if (!ret && password) {
+        ret = rnp_key_protect(primary, password, NULL, NULL, NULL, 0);
+    }
     if (ret && primary) {
         rnp_key_remove(primary, RNP_KEY_REMOVE_PUBLIC | RNP_KEY_REMOVE_SECRET);
     }

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -1209,6 +1209,19 @@ test_ffi_key_generate_misc(void **state)
     /* cleanup */
     assert_rnp_success(rnp_key_handle_destroy(key));
     assert_rnp_success(rnp_key_handle_destroy(subkey));
+    /* generate encrypted RSA key (primary only) */
+    key = NULL;
+    assert_rnp_success(rnp_generate_key_ex(ffi, "RSA", NULL, 1024, 0, NULL, NULL, "rsa_1024", "123", &key));
+    assert_non_null(key);
+    assert_rnp_success(rnp_key_is_locked(key, &locked));
+    assert_true(locked);
+    bool prot = false;
+    assert_rnp_success(rnp_key_is_protected(key, &prot));
+    assert_true(prot);
+    /* cleanup */
+    rnp_key_handle_destroy(key);
+
+    /* cleanup */
     assert_rnp_success(rnp_ffi_destroy(ffi));
 }
 


### PR DESCRIPTION
I've been doing some work on ruby-rnp and noticed that the password parameter here ends up being ignored when generating a primary key only. This API didn't make it into a release yet, so not a huge deal.