### PR TITLE
JSON output for packet dumper and FFI packet dump

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -59,6 +59,13 @@ typedef uint32_t rnp_result_t;
 #define RNP_JSON_SIGNATURE_MPIS (1U << 3)
 
 /**
+ * Flags to include additional data in packet dumping
+ */
+#define RNP_JSON_DUMP_MPI (1U << 0)
+#define RNP_JSON_DUMP_RAW (1U << 1)
+#define RNP_JSON_DUMP_GRIP (1U << 2)
+
+/**
  * Flags for the key loading/saving functions.
  */
 #define RNP_LOAD_SAVE_PUBLIC_KEYS (1U << 0)
@@ -935,6 +942,32 @@ rnp_result_t rnp_key_have_secret(rnp_key_handle_t key, bool *result);
 rnp_result_t rnp_key_have_public(rnp_key_handle_t key, bool *result);
 
 /* TODO: function to add a userid to a key */
+
+/** Get the information about key packets in JSON string.
+ *  Note: this will not work for G10 keys.
+ *
+ * @param key key's handle, cannot be NULL
+ * @param secret dump secret key instead of public
+ * @param flags include additional fields in JSON (see RNP_JSON_DUMP_MPI and other
+ *              RNP_JSON_DUMP_* flags)
+ * @param result resulting JSON string will be stored here. You must free it using the
+ *               rnp_buffer_destroy() function.
+ * @return 0 on success, or any other value on error
+ */
+rnp_result_t rnp_key_packets_to_json(rnp_key_handle_t key,
+                                     bool             secret,
+                                     uint32_t         flags,
+                                     char **          result);
+
+/** Dump OpenPGP packets stream information to the JSON string.
+ * @param input source with OpenPGP data
+ * @param flags include additional fields in JSON (see RNP_JSON_DUMP_MPI and other
+ *              RNP_JSON_DUMP_* flags)
+ * @result resulting JSON string will be stored here. You must free it using the
+ *         rnp_buffer_destroy() function.
+ * @return 0 on success, or any other value on error
+ */
+rnp_result_t rnp_dump_packets_to_json(rnp_input_t input, uint32_t flags, char **result);
 
 /* Signing operations */
 

--- a/src/apps/packet-dumper/CMakeLists.txt
+++ b/src/apps/packet-dumper/CMakeLists.txt
@@ -22,10 +22,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+find_package(JSON-C 0.11 REQUIRED)
+
 add_executable(redumper redumper.cpp)
 target_include_directories(redumper PRIVATE
   "${PROJECT_SOURCE_DIR}/src"
   "${PROJECT_SOURCE_DIR}/src/lib"
 )
-target_link_libraries(redumper PRIVATE librnp)
-
+target_link_libraries(redumper
+  PRIVATE
+    librnp
+    JSON-C::JSON-C
+)

--- a/src/apps/packet-dumper/redumper.cpp
+++ b/src/apps/packet-dumper/redumper.cpp
@@ -89,7 +89,8 @@ main(int argc, char *const argv[])
         json_object *dump = NULL;
         res = stream_dump_packets_json(&ctx, &src, &dump);
         if (res == RNP_SUCCESS) {
-            json_object_to_fd(STDOUT_FILENO, dump, JSON_C_TO_STRING_PRETTY);
+            const char *json = json_object_to_json_string_ext(dump, JSON_C_TO_STRING_PRETTY);
+            fprintf(stdout, "%s\n", json);
             json_object_put(dump);
         }
     }

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1573,10 +1573,8 @@ signature_dump_subpacket_json(rnp_dump_ctx_t *ctx, pgp_sig_subpkt_t *subpkt, jso
         return !stream_dump_signature_pkt_json(ctx, &subpkt->fields.sig, sig);
     }
     case PGP_SIG_SUBPKT_ISSUER_FPR:
-        return obj_add_hex_json(obj,
-                                "issuer fingerprint",
-                                subpkt->fields.issuer_fp.fp,
-                                subpkt->fields.issuer_fp.len);
+        return obj_add_hex_json(
+          obj, "fingerprint", subpkt->fields.issuer_fp.fp, subpkt->fields.issuer_fp.len);
     case PGP_SIG_SUBPKT_NOTATION_DATA:
     default:
         if (!ctx->dump_packets) {
@@ -1621,7 +1619,7 @@ signature_dump_subpackets_json(rnp_dump_ctx_t *ctx, const pgp_signature_t *sig)
             goto error;
         }
 
-        if (signature_dump_subpacket_json(ctx, subpkt, jso_subpkt)) {
+        if (!signature_dump_subpacket_json(ctx, subpkt, jso_subpkt)) {
             goto error;
         }
     }
@@ -2114,7 +2112,8 @@ stream_dump_hdr_json(pgp_source_t *src, pgp_packet_hdr_t *hdr, json_object *pkt)
     if (!obj_add_hex_json(jso_hdr, "hdr", hdr->hdr, hdr->hdr_len)) {
         goto error;
     }
-    if (!obj_add_field_json(jso_hdr, "offset", json_object_new_int64(hdr->pkt_len))) {
+    if (!hdr->partial && !hdr->indeterminate &&
+        !obj_add_field_json(jso_hdr, "length", json_object_new_int64(hdr->pkt_len))) {
         goto error;
     }
     if (!obj_add_field_json(jso_hdr, "partial", json_object_new_boolean(hdr->partial))) {

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1286,10 +1286,13 @@ obj_add_field_json(json_object *obj, const char *name, json_object *val)
     if (!val) {
         return false;
     }
-    if (json_object_object_add(obj, name, val)) {
+    // TODO: in JSON-C 0.13 json_object_object_add returns bool instead of void
+    json_object_object_add(obj, name, val);
+    if (!json_object_object_get_ex(obj, name, NULL)) {
         json_object_put(val);
         return false;
     }
+
     return true;
 }
 

--- a/src/librepgp/stream-dump.cpp
+++ b/src/librepgp/stream-dump.cpp
@@ -1990,7 +1990,32 @@ stream_dump_encrypted_json(pgp_source_t *src, json_object *pkt, pgp_content_enum
 static rnp_result_t
 stream_dump_one_pass_json(pgp_source_t *src, json_object *pkt)
 {
-    return RNP_ERROR_NOT_IMPLEMENTED;
+    pgp_one_pass_sig_t onepass;
+    rnp_result_t       ret;
+
+    if ((ret = stream_parse_one_pass(src, &onepass))) {
+        return ret;
+    }
+
+    if (!obj_add_field_json(pkt, "version", json_object_new_int(onepass.version))) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (!obj_add_intstr_json(pkt, "type", onepass.type, sig_type_map)) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (!obj_add_intstr_json(pkt, "hash algorithm", onepass.halg, hash_alg_map)) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (!obj_add_intstr_json(pkt, "public key algorithm", onepass.palg, pubkey_alg_map)) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (!obj_add_hex_json(pkt, "signer", onepass.keyid, PGP_KEY_ID_SIZE)) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (!obj_add_field_json(pkt, "nested", json_object_new_boolean(onepass.nested))) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    return RNP_SUCCESS;
 }
 
 static rnp_result_t

--- a/src/librepgp/stream-dump.h
+++ b/src/librepgp/stream-dump.h
@@ -30,6 +30,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <sys/types.h>
+#include "json_object.h"
+#include "json.h"
 #include "rnp.h"
 #include "stream-common.h"
 
@@ -40,5 +42,9 @@ typedef struct rnp_dump_ctx_t {
 } rnp_dump_ctx_t;
 
 rnp_result_t stream_dump_packets(rnp_dump_ctx_t *ctx, pgp_source_t *src, pgp_dest_t *dst);
+
+rnp_result_t stream_dump_packets_json(rnp_dump_ctx_t *ctx,
+                                      pgp_source_t *  src,
+                                      json_object **  jso);
 
 #endif

--- a/src/librepgp/stream-packet.h
+++ b/src/librepgp/stream-packet.h
@@ -36,6 +36,15 @@
 /* maximum size of the 'small' packet */
 #define PGP_MAX_PKT_SIZE 0x100000
 
+typedef struct pgp_packet_hdr_t {
+    pgp_content_enum tag;
+    uint8_t          hdr[PGP_MAX_HEADER_SIZE];
+    size_t           hdr_len;
+    size_t           pkt_len;
+    bool             partial;
+    bool             indeterminate;
+} pgp_packet_hdr_t;
+
 /* structure for convenient writing or parsing of non-stream packets */
 typedef struct pgp_packet_body_t {
     int      tag;       /* packet tag */
@@ -210,6 +219,15 @@ void free_packet_body(pgp_packet_body_t *body);
  *  @return void
  **/
 void stream_flush_packet_body(pgp_packet_body_t *body, pgp_dest_t *dst);
+
+/** @brief get and parse OpenPGP packet header to the structure.
+ *         Note: this will not read but just peek required bytes.
+ *
+ *  @param src source to read from
+ *  @param hdr header structure
+ *  @return RNP_SUCCESS or error code if operation failed
+ **/
+rnp_result_t stream_peek_packet_hdr(pgp_source_t *src, pgp_packet_hdr_t *hdr);
 
 /** @brief read 'short-length' packet body (including tag and length bytes) from the source
  *  @param src source to read from

--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -494,5 +494,11 @@ test_cli_redumper(void **state)
     status = system(cmd);
     assert_true(WIFEXITED(status));
     assert_int_equal(WEXITSTATUS(status), 0);
+    /* run redumper on some data with json output */
+    chnum = snprintf(cmd, sizeof(cmd), "%s -j \"%s\"", redumper_path, KEYS "/1/pubring.gpg");
+    assert_true(chnum < (int) sizeof(cmd));
+    status = system(cmd);
+    assert_true(WIFEXITED(status));
+    assert_int_equal(WEXITSTATUS(status), 0);
     free(redumper_path);
 }

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -232,6 +232,8 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_enarmor_dearmor),
       cmocka_unit_test(test_ffi_version),
       cmocka_unit_test(test_ffi_key_export),
+      cmocka_unit_test(test_ffi_key_dump),
+      cmocka_unit_test(test_ffi_pkt_dump),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -200,6 +200,10 @@ void test_ffi_version(void **state);
 
 void test_ffi_key_export(void **state);
 
+void test_ffi_key_dump(void **state);
+
+void test_ffi_pkt_dump(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -1233,7 +1233,7 @@ test_stream_verify_no_key(void **state)
 }
 
 static bool
-check_dump_file(const char *file, bool mpi, bool grip)
+check_dump_file_dst(const char *file, bool mpi, bool grip)
 {
     pgp_source_t   src;
     pgp_dest_t     dst;
@@ -1254,6 +1254,36 @@ check_dump_file(const char *file, bool mpi, bool grip)
     src_close(&src);
     dst_close(&dst, false);
     return true;
+}
+
+static bool
+check_dump_file_json(const char *file, bool mpi, bool grip)
+{
+    pgp_source_t   src;
+    rnp_dump_ctx_t ctx = {0};
+    json_object *  jso = NULL;
+
+    ctx.dump_mpi = mpi;
+    ctx.dump_grips = grip;
+
+    if (init_file_src(&src, file)) {
+        return false;
+    }
+    if (stream_dump_packets_json(&ctx, &src, &jso)) {
+        return false;
+    }
+    if (!json_object_is_type(jso, json_type_array)) {
+        return false;
+    }
+    src_close(&src);
+    json_object_put(jso);
+    return true;
+}
+
+static bool
+check_dump_file(const char *file, bool mpi, bool grip)
+{
+    return check_dump_file_dst(file, mpi, grip) && check_dump_file_json(file, mpi, grip);
 }
 
 void


### PR DESCRIPTION
This PR adds option to output JSON while dumping packets.
Also it adds functions `rnp_key_packets_to_json` and `rnp_dump_packets_to_json` to the FFI.
First one was needed for CLI, second one will be handy as well in some cases (like tests).

Tests are basic for now since most likely there would be suggestions on JSON structure.
Here are output examples:

<details><summary>Key</summary>

```json
[
  {
    "header":{
      "offset":0,
      "tag":6,
      "tag.str":"Public Key",
      "hdr":"99032e",
      "length":814,
      "partial":false,
      "indeterminate":false
    },
    "version":4,
    "creation time":1522761670,
    "algorithm":17,
    "algorithm.str":"DSA",
    "material":{
      "p.bits":2048,
      "q.bits":256,
      "g.bits":2047,
      "y.bits":2044
    },
    "keyid":"c8a10a7d78273e10"
  },
  {
    "header":{
      "offset":817,
      "tag":13,
      "tag.str":"User ID",
      "hdr":"b406",
      "length":6,
      "partial":false,
      "indeterminate":false
    },
    "userid":"dsa-eg"
  },
  {
    "header":{
      "offset":825,
      "tag":2,
      "tag.str":"Signature",
      "hdr":"8894",
      "length":148,
      "partial":false,
      "indeterminate":false
    },
    "version":4,
    "type":19,
    "type.str":"Positive User ID certification",
    "algorithm":17,
    "algorithm.str":"DSA",
    "hash algorithm":8,
    "hash algorithm.str":"SHA256",
    "subpackets":[
      {
        "type":27,
        "type.str":"key flags",
        "length":1,
        "hashed":true,
        "critical":false,
        "flags":3,
        "flags.str":[
          "certify",
          "sign"
        ]
      },
      {
        "type":11,
        "type.str":"preferred symmetric algorithms",
        "length":4,
        "hashed":true,
        "critical":false,
        "algorithms":[
          9,
          8,
          7,
          2
        ],
        "algorithms.str":[
          "AES-256",
          "AES-192",
          "AES-128",
          "TripleDES"
        ]
      },
      {
        "type":34,
        "type.str":"preferred AEAD algorithms",
        "length":2,
        "hashed":true,
        "critical":false,
        "algorithms":[
          2,
          1
        ],
        "algorithms.str":[
          "OCB",
          "EAX"
        ]
      },
      {
        "type":21,
        "type.str":"preferred hash algorithms",
        "length":5,
        "hashed":true,
        "critical":false,
        "algorithms":[
          10,
          9,
          8,
          11,
          2
        ],
        "algorithms.str":[
          "SHA512",
          "SHA384",
          "SHA256",
          "SHA224",
          "SHA1"
        ]
      },
      {
        "type":22,
        "type.str":"preferred compression algorithms",
        "length":3,
        "hashed":true,
        "critical":false,
        "algorithms":[
          2,
          3,
          1
        ],
        "algorithms.str":[
          "ZLib",
          "BZip2",
          "ZIP"
        ]
      },
      {
        "type":30,
        "type.str":"features",
        "length":1,
        "hashed":true,
        "critical":false,
        "mdc":true,
        "aead":true,
        "v5 keys":false
      },
      {
        "type":23,
        "type.str":"key server preferences",
        "length":1,
        "hashed":true,
        "critical":false,
        "no-modify":true
      },
      {
        "type":33,
        "type.str":"issuer fingerprint",
        "length":21,
        "hashed":true,
        "critical":false,
        "fingerprint":"091c44ce9cfbc3ff7ec7a64dc8a10a7d78273e10"
      },
      {
        "type":2,
        "type.str":"signature creation time",
        "length":4,
        "hashed":true,
        "critical":false,
        "creation time":1549119339
      },
      {
        "type":16,
        "type.str":"issuer key ID",
        "length":8,
        "hashed":false,
        "critical":false,
        "issuer keyid":"c8a10a7d78273e10"
      }
    ],
    "lbits":"0192",
    "material":{
      "r.bits":251,
      "s.bits":256
    }
  },
  {
    "header":{
      "offset":975,
      "tag":14,
      "tag.str":"Public Subkey",
      "hdr":"b9030d",
      "length":781,
      "partial":false,
      "indeterminate":false
    },
    "version":4,
    "creation time":1522761670,
    "algorithm":16,
    "algorithm.str":"Elgamal (Encrypt-Only)",
    "material":{
      "p.bits":3072,
      "g.bits":3,
      "y.bits":3070
    },
    "keyid":"02a5715c3537717e"
  },
  {
    "header":{
      "offset":1759,
      "tag":2,
      "tag.str":"Signature",
      "hdr":"8878",
      "length":120,
      "partial":false,
      "indeterminate":false
    },
    "version":4,
    "type":24,
    "type.str":"Subkey Binding Signature",
    "algorithm":17,
    "algorithm.str":"DSA",
    "hash algorithm":8,
    "hash algorithm.str":"SHA256",
    "subpackets":[
      {
        "type":27,
        "type.str":"key flags",
        "length":1,
        "hashed":true,
        "critical":false,
        "flags":12,
        "flags.str":[
          "encrypt_comm",
          "encrypt_storage"
        ]
      },
      {
        "type":33,
        "type.str":"issuer fingerprint",
        "length":21,
        "hashed":true,
        "critical":false,
        "fingerprint":"091c44ce9cfbc3ff7ec7a64dc8a10a7d78273e10"
      },
      {
        "type":2,
        "type.str":"signature creation time",
        "length":4,
        "hashed":true,
        "critical":false,
        "creation time":1549119406
      },
      {
        "type":16,
        "type.str":"issuer key ID",
        "length":8,
        "hashed":false,
        "critical":false,
        "issuer keyid":"c8a10a7d78273e10"
      }
    ],
    "lbits":"844d",
    "material":{
      "r.bits":256,
      "s.bits":253
    }
  }
]
```
</details>

<details><summary>Signed data</summary>

```json
[
  {
    "header":{
      "offset":0,
      "tag":8,
      "tag.str":"Compressed Data",
      "hdr":"c8ed",
      "partial":true,
      "indeterminate":false
    },
    "algorithm":1,
    "algorithm.str":"ZIP",
    "contents":[
      {
        "header":{
          "offset":0,
          "tag":4,
          "tag.str":"One-Pass Signature",
          "hdr":"c40d",
          "length":13,
          "partial":false,
          "indeterminate":false
        },
        "version":3,
        "type":0,
        "type.str":"Signature of a binary document",
        "hash algorithm":8,
        "hash algorithm.str":"SHA256",
        "public key algorithm":17,
        "public key algorithm.str":"DSA",
        "signer":"2fcadf05ffa501bb",
        "nested":true
      },
      {
        "header":{
          "offset":15,
          "tag":11,
          "tag.str":"Literal Data",
          "hdr":"cbed",
          "partial":true,
          "indeterminate":false
        },
        "format":"b",
        "filename":"128mb.dat",
        "timestamp":1524934672,
        "datalen":134217728
      },
      {
        "header":{
          "offset":134234144,
          "tag":2,
          "tag.str":"Signature",
          "hdr":"c263",
          "length":99,
          "partial":false,
          "indeterminate":false
        },
        "version":4,
        "type":0,
        "type.str":"Signature of a binary document",
        "algorithm":17,
        "algorithm.str":"DSA",
        "hash algorithm":8,
        "hash algorithm.str":"SHA256",
        "subpackets":[
          {
            "type":33,
            "type.str":"issuer fingerprint",
            "length":21,
            "hashed":true,
            "critical":false,
            "fingerprint":"be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb"
          },
          {
            "type":2,
            "type.str":"signature creation time",
            "length":4,
            "hashed":true,
            "critical":false,
            "creation time":1524934948
          },
          {
            "type":3,
            "type.str":"signature expiration time",
            "length":4,
            "hashed":true,
            "critical":false,
            "expiration time":0
          },
          {
            "type":16,
            "type.str":"issuer key ID",
            "length":8,
            "hashed":false,
            "critical":false,
            "issuer keyid":"2fcadf05ffa501bb"
          }
        ],
        "lbits":"b9a8",
        "material":{
          "r.bits":159,
          "s.bits":157
        }
      }
    ]
  }
]
```
</summary>