### PR TITLE
ffi: Fix to allow a NULL key server pref in key generation operation.

### DIFF
--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -3857,15 +3857,18 @@ rnp_op_generate_add_pref_cipher(rnp_op_generate_t op, const char *cipher)
 rnp_result_t
 rnp_op_generate_set_pref_keyserver(rnp_op_generate_t op, const char *keyserver)
 {
-    if (!op || !keyserver) {
+    uint8_t *_keyserver = NULL;
+    if (!op) {
         return RNP_ERROR_NULL_POINTER;
     }
     if (!op->primary) {
         return RNP_ERROR_BAD_PARAMETERS;
     }
-    uint8_t *_keyserver = (uint8_t *) strdup(keyserver);
-    if (!_keyserver) {
-        return RNP_ERROR_OUT_OF_MEMORY;
+    if (keyserver) {
+        _keyserver = (uint8_t *) strdup(keyserver);
+        if (!_keyserver) {
+            return RNP_ERROR_OUT_OF_MEMORY;
+        }
     }
     free(op->cert.prefs.key_server);
     op->cert.prefs.key_server = _keyserver;

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -1688,7 +1688,7 @@ test_ffi_key_generate_ex(void **state)
     assert_rnp_success(rnp_op_generate_set_expiration(keygen, 60 * 60 * 24 * 100));
     assert_rnp_success(rnp_op_generate_set_expiration(keygen, 60 * 60 * 24 * 300));
     /* preferred key server */
-    assert_rnp_failure(rnp_op_generate_set_pref_keyserver(keygen, NULL));
+    assert_rnp_success(rnp_op_generate_set_pref_keyserver(keygen, NULL));
     assert_rnp_success(rnp_op_generate_set_pref_keyserver(keygen, "hkp://first.server/"));
     assert_rnp_success(rnp_op_generate_set_pref_keyserver(keygen, "hkp://second.server/"));
     /* user id */


### PR DESCRIPTION
This is a minor fix to match up with the docs in the header.
```cpp
* @param keyserver NULL-terminated string with key server's URL, or NULL to delete it from
*                  user preferences.
```