### PR TITLE
Remove the use of deprecated Botan functions.

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(ZLIB REQUIRED)
 
 # required packages
 find_package(JSON-C 0.11 REQUIRED)
-find_package(Botan2 2.5.0 REQUIRED)
+find_package(Botan2 2.8.0 REQUIRED)
 
 # generate a config.h
 include(CheckIncludeFileCXX)

--- a/src/lib/crypto/ecdh.cpp
+++ b/src/lib/crypto/ecdh.cpp
@@ -249,8 +249,15 @@ ecdh_encrypt_pkcs5(rng_t *                  rng,
         return RNP_ERROR_GENERIC;
     }
 
-    if (botan_privkey_create_ecdh(&eph_prv_key, rng_handle(rng), curve_desc->botan_name)) {
-        goto end;
+    if (!strcmp(curve_desc->botan_name, "curve25519")) {
+        if (botan_privkey_create(&eph_prv_key, "Curve25519", "", rng_handle(rng))) {
+            goto end;
+        }
+    } else {
+        if (botan_privkey_create(
+              &eph_prv_key, "ECDH", curve_desc->botan_name, rng_handle(rng))) {
+            goto end;
+        }
     }
 
     if (!compute_kek(kek,


### PR DESCRIPTION
There's a handful of functions that were recently deprecated in Botan, which we currently use in rnp.
Some links for more info:
* https://github.com/randombit/botan/commit/d17dbed547765739e1885bde33b0165795bcbd72
* https://github.com/randombit/botan/blob/a82d746a51c786049e855098934349a7821e1a7e/src/lib/ffi/ffi.h#L1112
* https://github.com/randombit/botan/blob/a82d746a51c786049e855098934349a7821e1a7e/src/lib/ffi/ffi.h#L942


Note that I opened https://github.com/riboseinc/rnp/issues/839 since I know this introduces something that can throw (`std::to_string`). `std::to_chars` would be better but it's c++17.