### PR TITLE
FFI: add function rnp_output_to_file()

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1387,7 +1387,7 @@ rnp_result_t rnp_input_destroy(rnp_input_t input);
 
 /**
  * @brief Initialize output structure to write to a path. If path is a file
- * that already exists then operation will fail.
+ * that already exists then it will be overwritten.
  *
  * @param output pointer to the opaque output structure.
  * @param path path to the file.

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -735,17 +735,19 @@ rnp_result_t rnp_key_get_uid_at(rnp_key_handle_t key, size_t idx, char **uid);
 
 /** Get key's user id handle by it's index.
  *  Note: user id handle may become invalid once corresponding user id or key is removed.
- * 
+ *
  * @param key key handle
  * @param idx zero-based index of the userid.
  * @param uid user id handle will be stored here on success. You must destroy it
  *            using the rnp_uid_handle_destroy().
  * @return RNP_SUCCESS or error code if failed.
  */
-rnp_result_t rnp_key_get_uid_handle_at(rnp_key_handle_t key, size_t idx, rnp_uid_handle_t *uid);
+rnp_result_t rnp_key_get_uid_handle_at(rnp_key_handle_t  key,
+                                       size_t            idx,
+                                       rnp_uid_handle_t *uid);
 
 /** Check whether user id is revoked.
- * 
+ *
  * @param uid user id handle, should not be NULL.
  * @param result boolean result will be stored here on success. Cannot be NULL.
  * @return RNP_SUCCESS or error code if failed.
@@ -753,8 +755,8 @@ rnp_result_t rnp_key_get_uid_handle_at(rnp_key_handle_t key, size_t idx, rnp_uid
 rnp_result_t rnp_uid_is_revoked(rnp_uid_handle_t uid, bool *result);
 
 /** Destroy previously allocated user id handle.
- * 
- * @param uid user id handle. 
+ *
+ * @param uid user id handle.
  * @return RNP_SUCCESS or error code
  */
 rnp_result_t rnp_uid_handle_destroy(rnp_uid_handle_t uid);
@@ -875,7 +877,7 @@ rnp_result_t rnp_key_allows_usage(rnp_key_handle_t key, const char *usage, bool 
 
 /**
  * @brief Get the key's creation time.
- * 
+ *
  * @param key key handle, should not be NULL.
  * @param result creation time will be stored here. Cannot be NULL.
  * @return RNP_SUCCESS or error code on failure.
@@ -885,7 +887,7 @@ rnp_result_t rnp_key_get_creation(rnp_key_handle_t key, uint32_t *result);
 /**
  * @brief Get the key's expiration time in seconds.
  *        Note: 0 means that the key doesn't expire.
- * 
+ *
  * @param key key handle, should not be NULL
  * @param result expiration time will be stored here. Could not be NULL.
  * @return RNP_SUCCESS or error code on failure.
@@ -894,7 +896,7 @@ rnp_result_t rnp_key_get_expiration(rnp_key_handle_t key, uint32_t *result);
 
 /**
  * @brief Check whether key is revoked.
- * 
+ *
  * @param key key handle, should not be NULL
  * @param result on success result will be stored here. Could not be NULL.
  * @return RNP_SUCCESS or error code on failure.
@@ -903,7 +905,7 @@ rnp_result_t rnp_key_is_revoked(rnp_key_handle_t key, bool *result);
 
 /**
  * @brief Get textual description of the key's revocation reason (if any)
- * 
+ *
  * @param key key handle, should not be NULL
  * @param result on success pointer to the NULL-terminated string will be stored here.
  *               You must free it later using rnp_buffer_destroy() function.
@@ -913,7 +915,7 @@ rnp_result_t rnp_key_get_revocation_reason(rnp_key_handle_t key, char **result);
 
 /**
  * @brief Check whether revoked key was superseded by other key.
- * 
+ *
  * @param key key handle, should not be NULL
  * @param result on success result will be stored here. Could not be NULL.
  * @return RNP_SUCCESS or error code on failure.
@@ -922,7 +924,7 @@ rnp_result_t rnp_key_is_superseded(rnp_key_handle_t key, bool *result);
 
 /**
  * @brief Check whether revoked key's material was compromised.
- * 
+ *
  * @param key key handle, should not be NULL
  * @param result on success result will be stored here. Could not be NULL.
  * @return RNP_SUCCESS or error code on failure.
@@ -931,7 +933,7 @@ rnp_result_t rnp_key_is_compromised(rnp_key_handle_t key, bool *result);
 
 /**
  * @brief Check whether revoked key was retired.
- * 
+ *
  * @param key key handle, should not be NULL
  * @param result on success result will be stored here. Could not be NULL.
  * @return RNP_SUCCESS or error code on failure.

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -72,6 +72,12 @@ typedef uint32_t rnp_result_t;
 #define RNP_LOAD_SAVE_SECRET_KEYS (1U << 1)
 
 /**
+ * Flags for output structure creation.
+ */
+#define RNP_OUTPUT_FILE_OVERWRITE (1U << 0)
+#define RNP_OUTPUT_FILE_RANDOM (1U << 1)
+
+/**
  * Return a constant string describing the result code
  */
 const char *rnp_result_to_string(rnp_result_t result);
@@ -1397,6 +1403,21 @@ rnp_result_t rnp_input_destroy(rnp_input_t input);
 rnp_result_t rnp_output_to_path(rnp_output_t *output, const char *path);
 
 /**
+ * @brief Initialize structure to write to a file.
+ *        Note: it doesn't allow output to directory like rnp_output_to_path does, but
+ *        allows additional options to be specified.
+ *        When RNP_OUTPUT_FILE_RANDOM flag is included then you may want to call
+ *        rnp_output_finish() to make sure that final rename succeeded.
+ * @param output pointer to the opaque output structure. After use you must free it using the
+ *               rnp_output_destroy() function.
+ * @param path path to the file.
+ * @param flags additional flags, see RNP_OUTPUT_* flags.
+ * @return RNP_SUCCESS if file was opened successfully and ready for writing or error code
+ *         otherwise.
+ */
+rnp_result_t rnp_output_to_file(rnp_output_t *output, const char *path, uint32_t flags);
+
+/**
  * @brief Initialize output structure to write to the memory.
  *
  * @param output pointer to the opaque output structure.
@@ -1443,6 +1464,17 @@ rnp_result_t rnp_output_to_callback(rnp_output_t *       output,
  * @return RNP_SUCCESS if operation succeeded or error code otherwise.
  */
 rnp_result_t rnp_output_to_null(rnp_output_t *output);
+
+/**
+ * @brief Finish writing to the output.
+ *        Note: on most output types you'll need just to call rnp_output_destroy().
+ *        However, for file output with RNP_OUTPUT_FILE_RANDOM flag, you need to call this
+ *        to make sure that rename from random to required name succeeded.
+ *
+ * @param output pointer to the opaque output structure.
+ * @return RNP_SUCCESS if operation succeeded or error code otherwise.
+ */
+rnp_result_t rnp_output_finish(rnp_output_t output);
 
 /**
  * @brief Close previously opened output and free all associated data.

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -237,6 +237,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_pkt_dump),
       cmocka_unit_test(test_ffi_load_userattr),
       cmocka_unit_test(test_ffi_revocations),
+      cmocka_unit_test(test_ffi_file_output),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -208,6 +208,8 @@ void test_ffi_load_userattr(void **state);
 
 void test_ffi_revocations(void **state);
 
+void test_ffi_file_output(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -377,16 +377,17 @@ test_stream_signatures(void **state)
 void
 test_stream_signatures_revoked_key(void **state)
 {
-    pgp_signature_t   sig = {(pgp_version_t)0};
-    pgp_source_t      sigsrc = {0};
+    pgp_signature_t sig = {(pgp_version_t) 0};
+    pgp_source_t    sigsrc = {0};
 
     /* load signature */
-    assert_rnp_success(init_file_src(&sigsrc, "data/test_stream_signatures/revoked-key-sig.gpg"));
+    assert_rnp_success(
+      init_file_src(&sigsrc, "data/test_stream_signatures/revoked-key-sig.gpg"));
     assert_rnp_success(stream_parse_signature(&sigsrc, &sig));
     src_close(&sigsrc);
     /* get revocation */
     uint8_t code = 0;
-    char *reason = NULL;
+    char *  reason = NULL;
     assert_true(signature_get_revocation_reason(&sig, &code, &reason));
     assert_non_null(reason);
     /* check revocation */

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -99,19 +99,6 @@ test_stream_memory(void **state)
     free(mown);
 }
 
-static int
-file_size(const char *path)
-{
-    struct stat path_stat;
-    if (stat(path, &path_stat) != -1) {
-        if (S_ISDIR(path_stat.st_mode)) {
-            return -1;
-        }
-        return (int) path_stat.st_size;
-    }
-    return -1;
-}
-
 static void
 copy_tmp_path(char *buf, size_t buflen, pgp_dest_t *dst)
 {

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -103,6 +103,19 @@ file_contents(const char *path, ssize_t *size)
     return mem;
 }
 
+off_t
+file_size(const char *path)
+{
+    struct stat path_stat;
+    if (stat(path, &path_stat) != -1) {
+        if (S_ISDIR(path_stat.st_mode)) {
+            return -1;
+        }
+        return path_stat.st_size;
+    }
+    return -1;
+}
+
 /* Concatenate multiple strings into a full path.
  * A directory separator is added between components.
  * Must be called in between va_start and va_end.

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -54,6 +54,8 @@ bool file_exists(const char *path);
  */
 bool file_empty(const char *path);
 
+off_t file_size(const char *path);
+
 /* Check if a directory exists */
 bool dir_exists(const char *path);
 


### PR DESCRIPTION
Main goal of this PR was to add rnp_output_t creation functions which would allow to control file overwrite/random temporary file creation. 
Probably it should have another name, like rnp_output_to_path_ex() or so on.
However then we'll probably need to control temporary dir creation as well.