### PR TITLE
Add check for __cplusplus for closing brace.

### DIFF
--- a/include/rnp/rnp_sdk.h
+++ b/include/rnp/rnp_sdk.h
@@ -108,6 +108,9 @@ bool ishex(const char *hexid, size_t hexlen);
 bool hex2bin(const char *hex, size_t hexlen, uint8_t *bin, size_t len, size_t *out);
 
 void pgp_forget(void *, size_t);
+
+#if defined(__cplusplus)
 }
+#endif
 
 #endif


### PR DESCRIPTION
Add missing ifdef for `__cplusplus` in `rnp_sdk.h`.