### PR TITLE
FFI: add rnp_import_keys() function.

### DIFF
--- a/include/rekey/rnp_key_store.h
+++ b/include/rekey/rnp_key_store.h
@@ -114,6 +114,14 @@ typedef enum key_store_format_t {
     G10_KEY_STORE,
 } key_store_format_t;
 
+/* Key import status. Order of elements is important. */
+typedef enum pgp_key_import_status_t {
+    PGP_KEY_IMPORT_STATUS_UNKNOWN = 0,
+    PGP_KEY_IMPORT_STATUS_UNCHANGED,
+    PGP_KEY_IMPORT_STATUS_UPDATED,
+    PGP_KEY_IMPORT_STATUS_NEW,
+} pgp_key_import_status_t;
+
 #define RNP_KEYSTORE_GPG "GPG" /* GPG keystore format */
 #define RNP_KEYSTORE_KBX "KBX" /* KBX keystore format */
 #define RNP_KEYSTORE_G10 "G10" /* G10 keystore format */
@@ -149,6 +157,11 @@ pgp_key_t *rnp_key_store_get_key(const rnp_key_store_t *, size_t);
 list       rnp_key_store_get_keys(const rnp_key_store_t *);
 
 pgp_key_t *rnp_key_store_add_key(rnp_key_store_t *, pgp_key_t *);
+
+pgp_key_t *rnp_key_store_import_key(rnp_key_store_t *,
+                                    pgp_key_t *,
+                                    bool,
+                                    pgp_key_import_status_t *);
 
 bool rnp_key_store_remove_key(rnp_key_store_t *, const pgp_key_t *);
 bool rnp_key_store_remove_key_by_id(rnp_key_store_t *, const uint8_t *);

--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -302,9 +302,21 @@ rnp_result_t rnp_load_keys(rnp_ffi_t   ffi,
  * @param ffi
  * @param flags choose which keys should be unloaded (pubic, secret or both).
  *              See RNP_UNLOAD_PUBLIC_KEYS/RNP_UNLOAD_SECRET_KEYS.
- * @return rnp_result_t 0 on success, or any other value on error.
+ * @return 0 on success, or any other value on error.
  */
 rnp_result_t rnp_unload_keys(rnp_ffi_t ffi, uint32_t flags);
+
+/** import keys to the keyring and receive JSON list of the new/updated keys.
+ *  Note: this will work only with keys in OpenPGP format, use rnp_load_keys for other formats.
+ * @param ffi
+ * @param input source to read from. Cannot be NULL.
+ * @param flags see RNP_LOAD_SAVE_* constants.
+ * @param results if not NULL then after the successfull execution will contain JSON with
+ *                information about new and updated keys. You must free it using the
+ *                rnp_buffer_destroy() function.
+ * @return 0 on success, or any other value on error.
+ */
+rnp_result_t rnp_import_keys(rnp_ffi_t ffi, rnp_input_t input, uint32_t flags, char **results);
 
 /** save keys
  *

--- a/src/lib/json_utils.h
+++ b/src/lib/json_utils.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef RNP_JSON_UTILS_H_
+#define RNP_JSON_UTILS_H_
+
+#include <stdio.h>
+#include "types.h"
+#include <limits.h>
+#include "json_object.h"
+#include "json.h"
+
+/**
+ * @brief Add field to the json object.
+ *        Note: this function is for convenience, it will check val for NULL and destroy val
+ *        on failure.
+ * @param obj allocated json_object of object type.
+ * @param name name of the field
+ * @param val json object of any type. Will be checked for NULL.
+ * @return true if val is not NULL and field was added successfully, false otherwise.
+ */
+bool obj_add_field_json(json_object *obj, const char *name, json_object *val);
+
+/**
+ * @brief Add hex representation of binary data as string field to JSON object.
+ *        Note: this function follows conventions of obj_add_field_json().
+ */
+bool obj_add_hex_json(json_object *obj, const char *name, const uint8_t *val, size_t val_len);
+
+/**
+ * @brief Add element to JSON array.
+ *        Note: this function follows convention of the obj_add_field_json.
+ */
+bool array_add_element_json(json_object *obj, json_object *val);
+
+#endif

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -239,6 +239,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_revocations),
       cmocka_unit_test(test_ffi_file_output),
       cmocka_unit_test(test_ffi_key_signatures),
+      cmocka_unit_test(test_ffi_keys_import),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -212,6 +212,8 @@ void test_ffi_file_output(void **state);
 
 void test_ffi_key_signatures(void **state);
 
+void test_ffi_keys_import(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
While we have `rnp_load_keys()` this one is different since it works only with OpenPGP transferable keys, and lets caller to know the results of the import (which keys were imported/updated).
Need the last part to use in CLI.