### PR TITLE
FFI: add rnp_calculate_iterations() function.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -282,6 +282,18 @@ rnp_result_t rnp_detect_homedir_info(
  */
 rnp_result_t rnp_detect_key_format(const uint8_t buf[], size_t buf_len, char **format);
 
+/** Get the number of s2k hash iterations, based on calculation time requested.
+ *  Number of iterations is used to derive encryption key from password.
+ * 
+ * @param hash hash algorithm to try
+ * @param msec number of milliseconds which will be needed to derive key from the password.
+ *             Since it depends on CPU speed the calculated value will make sense only for the
+ *             system it was calculated for.
+ * @param iterations approximate number of iterations to satisfy time complexity.
+ * @return RNP_SUCCESS or error code if failed.
+ */
+rnp_result_t rnp_calculate_iterations(const char *hash, size_t msec, size_t *iterations);
+
 /** load keys
  *
  * Note that for G10, the input must be a directory (which must already exist).

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -914,6 +914,21 @@ done:
     return ret;
 }
 
+rnp_result_t
+rnp_calculate_iterations(const char *hash, size_t msec, size_t *iterations)
+{
+    if (!hash || !iterations) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    pgp_hash_alg_t halg = PGP_HASH_UNKNOWN;
+    if (!str_to_hash_alg(hash, &halg)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+
+    *iterations = pgp_s2k_compute_iters(halg, msec, 0);
+    return RNP_SUCCESS;
+}
+
 static rnp_result_t
 load_keys_from_input(rnp_ffi_t ffi, rnp_input_t input, rnp_key_store_t *store)
 {

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -4868,3 +4868,11 @@ test_ffi_keys_import(void **state)
     // cleanup
     rnp_ffi_destroy(ffi);
 }
+
+void
+test_ffi_calculate_iterations(void **state)
+{
+    size_t iterations = 0;
+    assert_rnp_success(rnp_calculate_iterations("sha256", 500, &iterations));
+    assert_true(iterations > 65536);
+}

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -240,6 +240,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_file_output),
       cmocka_unit_test(test_ffi_key_signatures),
       cmocka_unit_test(test_ffi_keys_import),
+      cmocka_unit_test(test_ffi_calculate_iterations),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -214,6 +214,8 @@ void test_ffi_key_signatures(void **state);
 
 void test_ffi_keys_import(void **state);
 
+void test_ffi_calculate_iterations(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
Needed it in CLI, so here it comes.
Any comments whether we could need second parameter (sample time) or can always use the default one?