### PR TITLE
FFI: add rnp_enable_debug() function.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -135,6 +135,14 @@ uint32_t rnp_version_patch(uint32_t version);
  **/
 uint64_t rnp_version_commit_timestamp();
 
+/** Enable debugging for the specified source file. Use 'all' or NULL as parameter to
+ *  enable debug for all sources.
+ *  Note: this must be only used during development since may print out confidential data.
+ *
+ * @param file name of the sourcer file. Use 'all' to enable debug for all code.
+ */
+rnp_result_t rnp_enable_debug(const char *file);
+
 /*
  * Opaque structures
  */
@@ -284,7 +292,7 @@ rnp_result_t rnp_detect_key_format(const uint8_t buf[], size_t buf_len, char **f
 
 /** Get the number of s2k hash iterations, based on calculation time requested.
  *  Number of iterations is used to derive encryption key from password.
- * 
+ *
  * @param hash hash algorithm to try
  * @param msec number of milliseconds which will be needed to derive key from the password.
  *             Since it depends on CPU speed the calculated value will make sense only for the

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -757,6 +757,12 @@ rnp_version_commit_timestamp()
 }
 
 rnp_result_t
+rnp_enable_debug(const char *file)
+{
+    return rnp_set_debug(file) ? RNP_SUCCESS : RNP_ERROR_GENERIC;
+}
+
+rnp_result_t
 rnp_get_default_homedir(char **homedir)
 {
     // checks

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5062,3 +5062,17 @@ test_ffi_supported_features(void **state)
     assert_rnp_success(rnp_supports_feature("elliptic curve", "wrong", &supported));
     assert_false(supported);
 }
+
+void
+test_ffi_enable_debug(void **state)
+{
+    assert_rnp_success(rnp_enable_debug("dummy.c"));
+    assert_rnp_success(rnp_enable_debug("1.c"));
+    assert_true(rnp_get_debug("dummy.c"));
+    assert_true(rnp_get_debug("1.c"));
+    assert_false(rnp_get_debug("dummy"));
+    /* NULL enables debug for all sources */
+    assert_rnp_success(rnp_enable_debug(NULL));
+    assert_true(rnp_get_debug("anything"));
+    assert_rnp_success(rnp_enable_debug("all"));
+}

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -242,6 +242,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_keys_import),
       cmocka_unit_test(test_ffi_calculate_iterations),
       cmocka_unit_test(test_ffi_supported_features),
+      cmocka_unit_test(test_ffi_enable_debug),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -218,6 +218,8 @@ void test_ffi_calculate_iterations(void **state);
 
 void test_ffi_supported_features(void **state);
 
+void test_ffi_enable_debug(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
Need it for the CLI since we have corresponding command-line parameters.