### PR TITLE
FFI: add rnp_key_get_primary_grip() function.

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1027,6 +1027,17 @@ rnp_result_t rnp_key_get_keyid(rnp_key_handle_t key, char **keyid);
 rnp_result_t rnp_key_get_grip(rnp_key_handle_t key, char **grip);
 
 /**
+ * @brief Get primary's key grip for the subkey, if available.
+ *
+ * @param key key handle, should not be NULL
+ * @param grip pointer to the NULL-terminated string with hex-encoded key grip or NULL will be
+ *        stored here, depending whether primary key is available or not.
+ *        You must free it later using rnp_buffer_destroy function.
+ * @return RNP_SUCCESS or error code on failure.
+ */
+rnp_result_t rnp_key_get_primary_grip(rnp_key_handle_t key, char **grip);
+
+/**
  * @brief Check whether certain usage type is allowed for the key.
  *
  * @param key key handle, should not be NULL

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -4965,6 +4965,37 @@ rnp_key_get_grip(rnp_key_handle_t handle, char **grip)
 }
 
 rnp_result_t
+rnp_key_get_primary_grip(rnp_key_handle_t handle, char **grip)
+{
+    if (handle == NULL || grip == NULL) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+
+    pgp_key_t *key = get_key_prefer_public(handle);
+    if (!pgp_key_is_subkey(key)) {
+        return RNP_ERROR_BAD_PARAMETERS;
+    }
+    if (!pgp_key_get_primary_grip(key)) {
+        *grip = NULL;
+        return RNP_SUCCESS;
+    }
+    size_t hex_len = PGP_KEY_GRIP_SIZE * 2 + 1;
+    *grip = (char *) malloc(hex_len);
+    if (*grip == NULL) {
+        return RNP_ERROR_OUT_OF_MEMORY;
+    }
+    if (!rnp_hex_encode(pgp_key_get_primary_grip(key),
+                        PGP_KEY_GRIP_SIZE,
+                        *grip,
+                        hex_len,
+                        RNP_HEX_UPPERCASE)) {
+        free(*grip);
+        return RNP_ERROR_GENERIC;
+    }
+    return RNP_SUCCESS;
+}
+
+rnp_result_t
 rnp_key_allows_usage(rnp_key_handle_t handle, const char *usage, bool *result)
 {
     if (!handle || !usage || !result) {

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5076,3 +5076,69 @@ test_ffi_enable_debug(void **state)
     assert_true(rnp_get_debug("anything"));
     assert_rnp_success(rnp_enable_debug("all"));
 }
+
+void
+test_ffi_rnp_key_get_primary_grip(void **state)
+{
+    rnp_ffi_t        ffi = NULL;
+    rnp_input_t      input = NULL;
+    rnp_key_handle_t key = NULL;
+    char *           grip = NULL;
+
+    // setup FFI
+    assert_int_equal(RNP_SUCCESS, rnp_ffi_create(&ffi, "GPG", "GPG"));
+
+    // load our keyrings
+    assert_int_equal(RNP_SUCCESS, rnp_input_from_path(&input, "data/keyrings/1/pubring.gpg"));
+    assert_int_equal(RNP_SUCCESS, rnp_load_keys(ffi, "GPG", input, RNP_LOAD_SAVE_PUBLIC_KEYS));
+    rnp_input_destroy(input);
+
+    // locate primary key
+    key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "7BC6709B15C23A4A", &key));
+    assert_non_null(key);
+
+    // some edge cases
+    assert_rnp_failure(rnp_key_get_primary_grip(NULL, NULL));
+    assert_rnp_failure(rnp_key_get_primary_grip(NULL, &grip));
+    assert_rnp_failure(rnp_key_get_primary_grip(key, NULL));
+    assert_rnp_failure(rnp_key_get_primary_grip(key, &grip));
+    assert_null(grip);
+    rnp_key_handle_destroy(key);
+
+    // locate subkey 1
+    key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "1ED63EE56FADC34D", &key));
+    assert_non_null(key);
+    assert_rnp_success(rnp_key_get_primary_grip(key, &grip));
+    assert_non_null(grip);
+    assert_int_equal(strcmp(grip, "66D6A0800A3FACDE0C0EB60B16B3669ED380FDFA"), 0);
+    rnp_buffer_destroy(grip);
+    grip = NULL;
+    rnp_key_handle_destroy(key);
+
+    // locate subkey 2
+    key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "1D7E8A5393C997A8", &key));
+    assert_non_null(key);
+    assert_rnp_success(rnp_key_get_primary_grip(key, &grip));
+    assert_non_null(grip);
+    assert_int_equal(strcmp(grip, "66D6A0800A3FACDE0C0EB60B16B3669ED380FDFA"), 0);
+    rnp_buffer_destroy(grip);
+    grip = NULL;
+    rnp_key_handle_destroy(key);
+
+    // locate subkey 3
+    key = NULL;
+    assert_rnp_success(rnp_locate_key(ffi, "keyid", "8A05B89FAD5ADED1", &key));
+    assert_non_null(key);
+    assert_rnp_success(rnp_key_get_primary_grip(key, &grip));
+    assert_non_null(grip);
+    assert_int_equal(strcmp(grip, "66D6A0800A3FACDE0C0EB60B16B3669ED380FDFA"), 0);
+    rnp_buffer_destroy(grip);
+    grip = NULL;
+    rnp_key_handle_destroy(key);
+
+    // cleanup
+    rnp_ffi_destroy(ffi);
+}

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -243,6 +243,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_calculate_iterations),
       cmocka_unit_test(test_ffi_supported_features),
       cmocka_unit_test(test_ffi_enable_debug),
+      cmocka_unit_test(test_ffi_rnp_key_get_primary_grip),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -220,6 +220,8 @@ void test_ffi_supported_features(void **state);
 
 void test_ffi_enable_debug(void **state);
 
+void test_ffi_rnp_key_get_primary_grip(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
We didn't have a way to find primary key from subkey, so here it is.