### PR TITLE
FFI: add rnp_disable_debug() and allocation check to rnp_set_debug().

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -143,6 +143,12 @@ uint64_t rnp_version_commit_timestamp();
  */
 rnp_result_t rnp_enable_debug(const char *file);
 
+/**
+ * @brief Disable previously enabled debug for all files.
+ *
+ */
+rnp_result_t rnp_disable_debug();
+
 /*
  * Opaque structures
  */

--- a/src/lib/misc.cpp
+++ b/src/lib/misc.cpp
@@ -199,7 +199,7 @@ rnp_set_debug(const char *f)
         return false;
     }
     debugv[debugc++] = strdup(name);
-    return true;
+    return debugv[debugc - 1] != NULL;
 }
 
 /* get the debugging level per filename */
@@ -224,6 +224,16 @@ rnp_get_debug(const char *f)
         }
     }
     return false;
+}
+
+void
+rnp_clear_debug()
+{
+    for (int i = 0; i < debugc; i++) {
+        free(debugv[i]);
+        debugv[i] = NULL;
+    }
+    debugc = 0;
 }
 
 /* return the version for the library */

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -763,6 +763,13 @@ rnp_enable_debug(const char *file)
 }
 
 rnp_result_t
+rnp_disable_debug()
+{
+    rnp_clear_debug();
+    return RNP_SUCCESS;
+}
+
+rnp_result_t
 rnp_get_default_homedir(char **homedir)
 {
     // checks

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -125,6 +125,7 @@ const char *pgp_str_from_map(int, pgp_map_t *);
 /* debugging, reflection and information */
 bool        rnp_set_debug(const char *);
 bool        rnp_get_debug(const char *);
+void        rnp_clear_debug();
 const char *rnp_get_info(const char *);
 
 /* Portable way to convert bits to bytes */

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -5074,5 +5074,12 @@ test_ffi_enable_debug(void **state)
     /* NULL enables debug for all sources */
     assert_rnp_success(rnp_enable_debug(NULL));
     assert_true(rnp_get_debug("anything"));
+    assert_rnp_success(rnp_disable_debug());
+    assert_false(rnp_get_debug("anything"));
+    assert_false(rnp_get_debug("dummy.c"));
+    assert_false(rnp_get_debug("1.c"));
     assert_rnp_success(rnp_enable_debug("all"));
+    assert_true(rnp_get_debug("anything other"));
+    /* need to clean it up afterwards - otherwise tests will go crazy */
+    assert_rnp_success(rnp_disable_debug());
 }


### PR DESCRIPTION
We need this function to not make Travis sad because of too long logs.
Also it may be found useful in other cases.