### PR TITLE
FFI: add rnp_output_to_armor()

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -1600,6 +1600,18 @@ rnp_result_t rnp_output_to_file(rnp_output_t *output, const char *path, uint32_t
 rnp_result_t rnp_output_to_memory(rnp_output_t *output, size_t max_alloc);
 
 /**
+ * @brief Output data to armored stream (and then output to other destination), allowing
+ *        streamed output.
+ *
+ * @param base initialized output structure, where armored data will be written to.
+ * @param output pointer to the opaque output structure. You must free it later using the
+ *               rnp_output_destroy() function.
+ * @param type type of the armored stream. See rnp_enarmor() for possible values.
+ * @return RNP_SUCCESS if operation succeeded or error code otherwise.
+ */
+rnp_result_t rnp_output_to_armor(rnp_output_t base, rnp_output_t *output, const char *type);
+
+/**
  * @brief Get the pointer to the buffer of output, initialized by rnp_output_to_memory
  *
  * @param output output structure, initialized by rnp_output_to_memory and populated with data

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -244,6 +244,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_supported_features),
       cmocka_unit_test(test_ffi_enable_debug),
       cmocka_unit_test(test_ffi_rnp_key_get_primary_grip),
+      cmocka_unit_test(test_ffi_output_to_armor),
       cmocka_unit_test(test_cli_rnp),
       cmocka_unit_test(test_cli_rnp_keyfile),
       cmocka_unit_test(test_cli_g10_operations),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -222,6 +222,8 @@ void test_ffi_enable_debug(void **state);
 
 void test_ffi_rnp_key_get_primary_grip(void **state);
 
+void test_ffi_output_to_armor(void **state);
+
 void test_dsa_roundtrip(void **state);
 
 void test_dsa_verify_negative(void **state);


### PR DESCRIPTION
This function is needed in CLI to export multiple keys into the single armored stream. Also may be useful in other places.

This PR should be merged once problems of #865 are resolved.