### PR TITLE
Use FFI in rnpkeys

### DIFF
--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -93,10 +93,6 @@ The following functions are used for key management:
 .Fo rnp_match_list_keys
 .Fa "rnp_t *rnp" "char *pattern"
 .Fc
-.Ft int
-.Fo rnp_find_key
-.Fa "rnp_t *rnp" "char *userid"
-.Fc
 .Ft char *
 .Fo rnp_get_key
 .Fa "rnp_t *rnp" "const char *id"

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -105,10 +105,6 @@ The following functions are used for key management:
 .Fo rnp_export_key
 .Fa "rnp_t *rnp" "char *userid"
 .Fc
-.Ft int
-.Fo rnp_generate_key
-.Fa "rnp_t *rnp" "char *userid" "int numbits"
-.Fc
 .Pp
 The following functions are used for file management:
 .Ft rnp_result_t

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -97,10 +97,6 @@ The following functions are used for key management:
 .Fo rnp_get_key
 .Fa "rnp_t *rnp" "const char *id"
 .Fc
-.Ft int
-.Fo rnp_export_key
-.Fa "rnp_t *rnp" "char *userid"
-.Fc
 .Pp
 The following functions are used for file management:
 .Ft rnp_result_t
@@ -182,7 +178,7 @@ is appended to the home directory in order to search for
 the keyrings.
 .Pp
 To export a key, the
-.Fn rnp_export_key
+.Fn rnp_key_export
 function is used.
 Output is sent to the standard output.
 .Pp

--- a/src/lib/librnp.3
+++ b/src/lib/librnp.3
@@ -106,10 +106,6 @@ The following functions are used for key management:
 .Fa "rnp_t *rnp" "char *userid"
 .Fc
 .Ft int
-.Fo rnp_import_key
-.Fa "rnp_t *rnp" "char *file"
-.Fc
-.Ft int
 .Fo rnp_generate_key
 .Fa "rnp_t *rnp" "char *userid" "int numbits"
 .Fc
@@ -199,7 +195,7 @@ function is used.
 Output is sent to the standard output.
 .Pp
 To import a key onto the public keyring, the
-.Fn rnp_import_key
+.Fn rnp_add_key
 is used.
 The name of the file containing the key to be imported is provided
 as the filename argument.

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -1008,38 +1008,6 @@ pgp_key_get_subkey(const pgp_key_t *key, const rnp_key_store_t *store, size_t id
     return rnp_key_store_get_key_by_grip(store, grip);
 }
 
-char *
-pgp_export_key(const rnp_key_store_t *keyring, const pgp_key_t *key)
-{
-    pgp_dest_t memdst = {};
-    pgp_dest_t armordst = {};
-    char *     cp = NULL;
-    bool       res = false;
-
-    if (!keyring || !key) {
-        return NULL;
-    }
-
-    if (init_mem_dest(&memdst, NULL, 0)) {
-        return NULL;
-    }
-    bool is_public = pgp_key_is_public(key);
-    if (init_armored_dst(
-          &armordst, &memdst, is_public ? PGP_ARMORED_PUBLIC_KEY : PGP_ARMORED_SECRET_KEY)) {
-        dst_close(&memdst, true);
-        return NULL;
-    }
-    res = pgp_write_xfer_key(&armordst, key, keyring);
-    if (res && !dst_finish(&armordst)) {
-        dst_write(&memdst, "\0", 1);
-        dst_finish(&memdst);
-        cp = (char *) mem_dest_own_memory(&memdst);
-    }
-    dst_close(&armordst, true);
-    dst_close(&memdst, true);
-    return cp;
-}
-
 pgp_key_flags_t
 pgp_pk_alg_capabilities(pgp_pubkey_alg_t alg)
 {

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -306,16 +306,6 @@ pgp_key_t *pgp_key_get_subkey(const pgp_key_t *key, const rnp_key_store_t *store
 
 pgp_key_flags_t pgp_pk_alg_capabilities(pgp_pubkey_alg_t alg);
 
-/**
- * @brief Export and armor OpenPGP key, writing it to the NULL-terminated string.
- *
- * @param keyring where key belongs to. Needed to fetch all subkeys as well, not NULL.
- * @param key pointer to the key, cannot be NULL.
- * @return allocated string with armored key, or NULL on failure. Resulting string must be
- *         released by caller.
- */
-char *pgp_export_key(const rnp_key_store_t *keyring, const pgp_key_t *key);
-
 /** check if a key is currently locked
  *
  *  Note: Key locking does not apply to unprotected keys.

--- a/src/rnp/fficli.cpp
+++ b/src/rnp/fficli.cpp
@@ -1,0 +1,1013 @@
+/*
+ * Copyright (c) 2019, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/param.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <termios.h>
+#include <time.h>
+#include <regex.h>
+#include "config.h"
+#include "fficli.h"
+
+static bool
+stdin_getpass(const char *prompt, char *buffer, size_t size)
+{
+    struct termios saved_flags, noecho_flags;
+    bool           restore_ttyflags = false;
+    bool           ok = false;
+    FILE *         in = NULL;
+    FILE *         out = NULL;
+
+    // validate args
+    if (!buffer) {
+        goto end;
+    }
+    // doesn't hurt
+    *buffer = '\0';
+
+    in = fopen("/dev/tty", "w+ce");
+    if (!in) {
+        in = stdin;
+        out = stderr;
+    } else {
+        out = in;
+    }
+
+    // save the original termios
+    if (tcgetattr(fileno(in), &saved_flags) == 0) {
+        noecho_flags = saved_flags;
+        // disable echo in the local modes
+        noecho_flags.c_lflag = (noecho_flags.c_lflag & ~ECHO) | ECHONL | ISIG;
+        restore_ttyflags = (tcsetattr(fileno(in), TCSANOW, &noecho_flags) == 0);
+    }
+    if (prompt) {
+        fputs(prompt, out);
+    }
+    if (fgets(buffer, size, in) == NULL) {
+        goto end;
+    }
+
+    rnp_strip_eol(buffer);
+    ok = true;
+end:
+    if (restore_ttyflags) {
+        tcsetattr(fileno(in), TCSAFLUSH, &saved_flags);
+    }
+    if (in != stdin) {
+        fclose(in);
+    }
+    return ok;
+}
+
+static bool
+ffi_pass_callback_stdin(rnp_ffi_t        ffi,
+                        void *           app_ctx,
+                        rnp_key_handle_t key,
+                        const char *     pgp_context,
+                        char             buf[],
+                        size_t           buf_len)
+{
+    char *keyid = NULL;
+    char  target[64] = {0};
+    char  prompt[128] = {0};
+    char  buffer[MAX_PASSWORD_LENGTH];
+    bool  ok = false;
+
+    if (!ffi || !pgp_context) {
+        goto done;
+    }
+
+    if (strcmp(pgp_context, "decrypt (symmetric)") &&
+        strcmp(pgp_context, "encrypt (symmetric)")) {
+        rnp_key_get_keyid(key, &keyid);
+        snprintf(target, sizeof(target), "key 0x%s", keyid);
+        rnp_buffer_destroy(keyid);
+    }
+start:
+    if (!strcmp(pgp_context, "decrypt (symmetric)")) {
+        snprintf(prompt, sizeof(prompt), "Enter password to decrypt data: ");
+    } else if (!strcmp(pgp_context, "encrypt (symmetric)")) {
+        snprintf(prompt, sizeof(prompt), "Enter password to encrypt data: ");
+    } else {
+        snprintf(prompt, sizeof(prompt), "Enter password for %s: ", target);
+    }
+
+    if (!stdin_getpass(prompt, buf, buf_len)) {
+        goto done;
+    }
+    if (!strcmp(pgp_context, "protect") || !strcmp(pgp_context, "encrypt (symmetric)")) {
+        if (!strcmp(pgp_context, "protect")) {
+            snprintf(prompt, sizeof(prompt), "Repeat password for %s: ", target);
+        } else {
+            snprintf(prompt, sizeof(prompt), "Repeat password: ");
+        }
+
+        if (!stdin_getpass(prompt, buffer, sizeof(buffer))) {
+            goto done;
+        }
+        if (strcmp(buf, buffer) != 0) {
+            puts("\nPasswords do not match!");
+            // currently will loop forever
+            goto start;
+        }
+    }
+    ok = true;
+done:
+    puts("");
+    pgp_forget(buffer, sizeof(buffer));
+    return ok;
+}
+
+static bool
+ffi_pass_callback_file(rnp_ffi_t        ffi,
+                       void *           app_ctx,
+                       rnp_key_handle_t key,
+                       const char *     pgp_context,
+                       char             buf[],
+                       size_t           buf_len)
+{
+    if (!app_ctx || !buf || !buf_len) {
+        return false;
+    }
+
+    FILE *fp = (FILE *) app_ctx;
+    if (!fgets(buf, buf_len, fp)) {
+        return false;
+    }
+    rnp_strip_eol(buf);
+    return true;
+}
+
+bool
+cli_rnp_init(cli_rnp_t *rnp, rnp_cfg_t *cfg)
+{
+    bool coredumps = true;
+
+    /* If system resource constraints are in effect then attempt to
+     * disable core dumps.
+     */
+    if (!rnp_cfg_getbool(cfg, CFG_COREDUMPS)) {
+#ifdef HAVE_SYS_RESOURCE_H
+        coredumps = disable_core_dumps() != RNP_SUCCESS;
+#endif
+    }
+
+    if (coredumps) {
+        ERR_MSG(
+          "rnp: warning: core dumps may be enabled, sensitive data may be leaked to disk");
+    }
+
+    /* Configure the results stream. */
+    const char *ress = rnp_cfg_getstr(cfg, CFG_IO_RESS);
+    if (!ress || !strcmp(ress, "<stderr>")) {
+        rnp->resfp = stderr;
+    } else if (strcmp(ress, "<stdout>") == 0) {
+        rnp->resfp = stdout;
+    } else if (!(rnp->resfp = fopen(ress, "w"))) {
+        ERR_MSG("cannot open results %s for writing", ress);
+        return false;
+    }
+
+    bool        res = false;
+    const char *format = rnp_cfg_getstr(cfg, CFG_KR_PUB_FORMAT);
+    if (!format || !(rnp->pubformat = strdup(format))) {
+        return false;
+    }
+    format = rnp_cfg_getstr(cfg, CFG_KR_SEC_FORMAT);
+    if (!format || !(rnp->secformat = strdup(format))) {
+        return false;
+    }
+    if (rnp_ffi_create(&rnp->ffi, rnp->pubformat, rnp->secformat)) {
+        ERR_MSG("failed to initialize FFI");
+        return false;
+    }
+
+    // by default use stdin password provider
+    if (rnp_ffi_set_pass_provider(rnp->ffi, ffi_pass_callback_stdin, NULL)) {
+        goto done;
+    }
+
+    // setup file/pipe password input if requested
+    if (rnp_cfg_getint_default(cfg, CFG_PASSFD, -1) >= 0) {
+        if (!set_pass_fd(&rnp->passfp, rnp_cfg_getint(cfg, CFG_PASSFD))) {
+            goto done;
+        }
+        if (rnp_ffi_set_pass_provider(rnp->ffi, ffi_pass_callback_file, rnp->passfp)) {
+            goto done;
+        }
+    }
+
+    rnp->pswdtries = MAX_PASSWORD_ATTEMPTS;
+
+    if (rnp_cfg_getstr(cfg, CFG_KR_PUB_PATH)) {
+        rnp->pubpath = strdup(rnp_cfg_getstr(cfg, CFG_KR_PUB_PATH));
+        if (!rnp->pubpath) {
+            ERR_MSG("allocation failed");
+            goto done;
+        }
+    }
+    if (rnp_cfg_getstr(cfg, CFG_KR_SEC_PATH)) {
+        rnp->secpath = strdup(rnp_cfg_getstr(cfg, CFG_KR_SEC_PATH));
+        if (!rnp->secpath) {
+            ERR_MSG("allocation failed");
+            goto done;
+        }
+    }
+    res = true;
+done:
+    if (!res) {
+        rnp_ffi_destroy(rnp->ffi);
+        rnp->ffi = NULL;
+    }
+    return res;
+}
+
+void
+cli_rnp_end(cli_rnp_t *rnp)
+{
+    free(rnp->pubpath);
+    free(rnp->pubformat);
+    free(rnp->secpath);
+    free(rnp->secformat);
+
+    if (rnp->defkey) {
+        free(rnp->defkey);
+        rnp->defkey = NULL;
+    }
+    if (rnp->passfp) {
+        fclose(rnp->passfp);
+        rnp->passfp = NULL;
+    }
+    if (rnp->resfp && (rnp->resfp != stderr) && (rnp->resfp != stdout)) {
+        fclose(rnp->resfp);
+        rnp->resfp = NULL;
+    }
+    rnp_ffi_destroy(rnp->ffi);
+    memset(rnp, 0, sizeof(*rnp));
+}
+
+bool
+cli_rnp_load_keyrings(cli_rnp_t *rnp, bool loadsecret)
+{
+    rnp_input_t keyin = NULL;
+    size_t      keycount = 0;
+    bool        res = false;
+
+    if (rnp_unload_keys(rnp->ffi, RNP_KEY_UNLOAD_PUBLIC)) {
+        ERR_MSG("failed to clear public keyring");
+        goto done;
+    }
+
+    if (rnp_input_from_path(&keyin, rnp->pubpath)) {
+        ERR_MSG("wrong pubring path");
+        goto done;
+    }
+
+    if (rnp_load_keys(rnp->ffi, rnp->pubformat, keyin, RNP_LOAD_SAVE_PUBLIC_KEYS)) {
+        ERR_MSG("cannot read pub keyring");
+        goto done;
+    }
+
+    rnp_input_destroy(keyin);
+    keyin = NULL;
+
+    if (rnp_get_public_key_count(rnp->ffi, &keycount)) {
+        goto done;
+    }
+
+    if (keycount < 1) {
+        ERR_MSG("pub keyring '%s' is empty", rnp->pubpath);
+        goto done;
+    }
+
+    /* Only read secret keys if we need to */
+    if (loadsecret) {
+        if (rnp_unload_keys(rnp->ffi, RNP_KEY_UNLOAD_SECRET)) {
+            ERR_MSG("failed to clear secret keyring");
+            goto done;
+        }
+
+        if (rnp_input_from_path(&keyin, rnp->secpath)) {
+            ERR_MSG("wrong secring path");
+            goto done;
+        }
+
+        if (rnp_load_keys(rnp->ffi, rnp->secformat, keyin, RNP_LOAD_SAVE_SECRET_KEYS)) {
+            ERR_MSG("cannot read sec keyring");
+            goto done;
+        }
+
+        rnp_input_destroy(keyin);
+        keyin = NULL;
+
+        if (rnp_get_secret_key_count(rnp->ffi, &keycount)) {
+            goto done;
+        }
+
+        if (keycount < 1) {
+            ERR_MSG("sec keyring '%s' is empty", rnp->secpath);
+            goto done;
+        }
+    }
+    if (!rnp->defkey) {
+        cli_rnp_set_default_key(rnp);
+    }
+    res = true;
+done:
+    rnp_input_destroy(keyin);
+    return res;
+}
+
+void
+cli_rnp_set_default_key(cli_rnp_t *rnp)
+{
+    rnp_identifier_iterator_t it = NULL;
+    const char *              defkey = NULL;
+
+    if (rnp_identifier_iterator_create(rnp->ffi, &it, "grip")) {
+        return;
+    }
+    if (rnp_identifier_iterator_next(it, &defkey) == RNP_SUCCESS) {
+        rnp->defkey = strdup(defkey);
+    }
+    rnp_identifier_iterator_destroy(it);
+}
+
+const char *
+json_obj_get_str(json_object *obj, const char *key)
+{
+    json_object *fld = NULL;
+    if (!json_object_object_get_ex(obj, key, &fld)) {
+        return NULL;
+    }
+    return json_object_get_string(fld);
+}
+
+int64_t
+json_obj_get_int64(json_object *obj, const char *key)
+{
+    json_object *fld = NULL;
+    if (!json_object_object_get_ex(obj, key, &fld)) {
+        return 0;
+    }
+    return json_object_get_int64(fld);
+}
+
+static char *
+cli_key_usage_str(rnp_key_handle_t key, char *buf)
+{
+    char *orig = buf;
+    bool  allow = false;
+
+    if (!rnp_key_allows_usage(key, "encrypt", &allow) && allow) {
+        *buf++ = 'E';
+    }
+    allow = false;
+    if (!rnp_key_allows_usage(key, "sign", &allow) && allow) {
+        *buf++ = 'S';
+    }
+    allow = false;
+    if (!rnp_key_allows_usage(key, "certify", &allow) && allow) {
+        *buf++ = 'C';
+    }
+    allow = false;
+    if (!rnp_key_allows_usage(key, "authenticate", &allow) && allow) {
+        *buf++ = 'A';
+    }
+    *buf = '\0';
+    return orig;
+}
+
+void
+cli_rnp_print_key_info(FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs)
+{
+    char         buf[64] = {0};
+    const char * header = NULL;
+    bool         secret = false;
+    bool         primary = false;
+    uint32_t     bits = 0;
+    int64_t      create = 0;
+    uint32_t     expiry = 0;
+    size_t       uids = 0;
+    char *       json = NULL;
+    json_object *pkts = NULL;
+    json_object *keypkt = NULL;
+
+    /* header */
+    if (rnp_key_have_secret(key, &secret) || rnp_key_is_primary(key, &primary) ||
+        rnp_key_packets_to_json(key, false, RNP_JSON_DUMP_GRIP, &json)) {
+        fprintf(fp, "Key error.\n");
+        return;
+    }
+    if (!(pkts = json_tokener_parse(json))) {
+        fprintf(fp, "Key JSON error");
+        goto done;
+    }
+    if (!(keypkt = json_object_array_get_idx(pkts, 0))) {
+        fprintf(fp, "Key JSON error");
+        goto done;
+    }
+
+    if (psecret && secret) {
+        header = primary ? "sec" : "ssb";
+    } else {
+        header = primary ? "pub" : "sub";
+    }
+    if (primary) {
+        fprintf(fp, "\n");
+    }
+    fprintf(fp, "%s   ", header);
+
+    /* key bits */
+    rnp_key_get_bits(key, &bits);
+    fprintf(fp, "%d/", (int) bits);
+    /* key algorithm */
+    fprintf(fp, "%s ", json_obj_get_str(keypkt, "algorithm.str"));
+    /* key id */
+    fprintf(fp, "%s", json_obj_get_str(keypkt, "keyid"));
+    /* key creation time */
+    create = json_obj_get_int64(keypkt, "creation time");
+    fprintf(fp, " %s", ptimestr(buf, sizeof(buf), create));
+    /* key usage */
+    fprintf(fp, " [%s]", cli_key_usage_str(key, buf));
+    /* key expiration */
+    (void) rnp_key_get_expiration(key, &expiry);
+    if (expiry > 0) {
+        time_t now = time(NULL);
+        time_t expire_time = create + expiry;
+        ptimestr(buf, sizeof(buf), expire_time);
+        fprintf(fp, " [%s %s]", expire_time <= now ? "EXPIRED" : "EXPIRES", buf);
+    }
+    /* fingerprint */
+    fprintf(fp, "\n      %s\n", json_obj_get_str(keypkt, "fingerprint"));
+    /* user ids */
+    (void) rnp_key_get_uid_count(key, &uids);
+    for (size_t i = 0; i < uids; i++) {
+        rnp_uid_handle_t uid = NULL;
+        bool             revoked = false;
+        char *           uid_str = NULL;
+        size_t           sigs = 0;
+
+        if (rnp_key_get_uid_handle_at(key, i, &uid)) {
+            continue;
+        }
+        (void) rnp_uid_is_revoked(uid, &revoked);
+        (void) rnp_key_get_uid_at(key, i, &uid_str);
+
+        /* userid itself with revocation status */
+        fprintf(fp, "uid           %s", uid_str);
+        fprintf(fp, "%s\n", revoked ? "[REVOKED]" : "");
+
+        /* print signatures only if requested */
+        if (!psigs) {
+            (void) rnp_uid_handle_destroy(uid);
+            continue;
+        }
+
+        (void) rnp_uid_get_signature_count(uid, &sigs);
+        for (size_t j = 0; j < sigs; j++) {
+            rnp_signature_handle_t sig = NULL;
+            rnp_key_handle_t       signer = NULL;
+            char *                 keyid = NULL;
+            uint32_t               creation = 0;
+            char *                 signer_uid = NULL;
+
+            if (rnp_uid_get_signature_at(uid, j, &sig)) {
+                continue;
+            }
+            if (rnp_signature_get_creation(sig, &creation)) {
+                goto next;
+            }
+            if (rnp_signature_get_keyid(sig, &keyid)) {
+                goto next;
+            }
+            /* lowercase key id */
+            for (char *idptr = keyid; *idptr; ++idptr) {
+                *idptr = tolower(*idptr);
+            }
+            /* signer primary uid */
+            if (rnp_locate_key(ffi, "keyid", keyid, &signer)) {
+                goto next;
+            }
+            if (signer) {
+                (void) rnp_key_get_primary_uid(signer, &signer_uid);
+            }
+
+            /* signer key id */
+            fprintf(fp, "sig           %s ", keyid ? keyid : "[no key id]");
+            /* signature creation time */
+            fprintf(fp, "%s", ptimestr(buf, sizeof(buf), creation));
+            /* signer's userid */
+            fprintf(fp, " %s\n", signer_uid ? signer_uid : "[unknown]");
+        next:
+            (void) rnp_signature_handle_destroy(sig);
+            (void) rnp_key_handle_destroy(signer);
+            rnp_buffer_destroy(keyid);
+            rnp_buffer_destroy(signer_uid);
+        }
+        (void) rnp_uid_handle_destroy(uid);
+    }
+
+done:
+    rnp_buffer_destroy(json);
+    json_object_put(pkts);
+}
+
+bool
+cli_rnp_save_keyrings(cli_rnp_t *rnp)
+{
+    rnp_output_t output = NULL;
+    rnp_result_t pub_ret = 0;
+    rnp_result_t sec_ret = 0;
+
+    // check whether we have G10 secret keyring - then need to create directory
+    if (!strcmp(rnp->secformat, "G10")) {
+        struct stat path_stat;
+        if (stat(rnp->secpath, &path_stat) != -1) {
+            if (!S_ISDIR(path_stat.st_mode)) {
+                ERR_MSG("G10 keystore should be a directory: %s", rnp->secpath);
+                return false;
+            }
+        } else {
+            if (errno != ENOENT) {
+                ERR_MSG("stat(%s): %s", rnp->secpath, strerror(errno));
+                return false;
+            }
+            if (mkdir(rnp->secpath, S_IRWXU) != 0) {
+                ERR_MSG("mkdir(%s, S_IRWXU): %s", rnp->secpath, strerror(errno));
+                return false;
+            }
+        }
+    }
+
+    // public keyring
+    if (!(pub_ret = rnp_output_to_path(&output, rnp->pubpath))) {
+        pub_ret = rnp_save_keys(rnp->ffi, rnp->pubformat, output, RNP_LOAD_SAVE_PUBLIC_KEYS);
+        rnp_output_destroy(output);
+    }
+    if (pub_ret) {
+        ERR_MSG("failed to write pubring to path '%s'", rnp->pubpath);
+    }
+
+    // secret keyring
+    if (!(sec_ret = rnp_output_to_path(&output, rnp->secpath))) {
+        sec_ret = rnp_save_keys(rnp->ffi, rnp->secformat, output, RNP_LOAD_SAVE_SECRET_KEYS);
+        rnp_output_destroy(output);
+    }
+    if (sec_ret) {
+        ERR_MSG("failed to write secring to path '%s'\n", rnp->secpath);
+    }
+
+    return !pub_ret && !sec_ret;
+}
+
+bool
+cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username)
+{
+    /* set key generation parameters to rnp_cfg_t */
+    if (!cli_rnp_set_generate_params(cfg)) {
+        (void) fprintf(stderr, "Key generation setup failed.\n");
+        return false;
+    }
+    /* generate the primary key */
+    rnp_op_generate_t genkey = NULL;
+    rnp_key_handle_t  primary = NULL;
+    rnp_key_handle_t  subkey = NULL;
+    bool              res = false;
+
+    if (rnp_op_generate_create(&genkey, rnp->ffi, rnp_cfg_getstr(cfg, CFG_KG_PRIMARY_ALG))) {
+        (void) fprintf(stderr, "Failed to initialize key generation.\n");
+        return false;
+    }
+    if (username && rnp_op_generate_set_userid(genkey, username)) {
+        (void) fprintf(stderr, "Failed to set userid.\n");
+        goto done;
+    }
+    if (rnp_cfg_hasval(cfg, CFG_KG_PRIMARY_BITS) &&
+        rnp_op_generate_set_bits(genkey, rnp_cfg_getint(cfg, CFG_KG_PRIMARY_BITS))) {
+        (void) fprintf(stderr, "Failed to set key bits.\n");
+        goto done;
+    }
+    if (rnp_cfg_hasval(cfg, CFG_KG_PRIMARY_CURVE) &&
+        rnp_op_generate_set_curve(genkey, rnp_cfg_getstr(cfg, CFG_KG_PRIMARY_CURVE))) {
+        (void) fprintf(stderr, "Failed to set key curve.\n");
+        goto done;
+    }
+    // TODO : set DSA qbits
+    if (rnp_op_generate_set_hash(genkey, rnp_cfg_getstr(cfg, CFG_KG_HASH))) {
+        (void) fprintf(stderr, "Failed to set hash algorithm.\n");
+        goto done;
+    }
+    if (rnp_op_generate_set_protection_cipher(genkey, rnp_cfg_getstr(cfg, CFG_KG_PROT_ALG))) {
+        (void) fprintf(stderr, "Failed to set protection algorithm.\n");
+        goto done;
+    }
+    if (rnp_op_generate_set_protection_hash(genkey, rnp_cfg_getstr(cfg, CFG_KG_PROT_HASH))) {
+        (void) fprintf(stderr, "Failed to set protection hash algorithm.\n");
+        goto done;
+    }
+    if (rnp_op_generate_set_protection_iterations(
+          genkey, rnp_cfg_getint(cfg, CFG_KG_PROT_ITERATIONS))) {
+        (void) fprintf(stderr, "Failed to set protection iterations.\n");
+        goto done;
+    }
+
+    fprintf(stdout, "Generating a new key...\n");
+    if (rnp_op_generate_execute(genkey) || rnp_op_generate_get_key(genkey, &primary)) {
+        (void) fprintf(stderr, "Primary key generation failed.\n");
+        goto done;
+    }
+
+    if (!rnp_cfg_getstr(cfg, CFG_KG_SUBKEY_ALG)) {
+        res = true;
+        goto done;
+    }
+
+    rnp_op_generate_destroy(genkey);
+    genkey = NULL;
+    if (rnp_op_generate_subkey_create(
+          &genkey, rnp->ffi, primary, rnp_cfg_getstr(cfg, CFG_KG_SUBKEY_ALG))) {
+        (void) fprintf(stderr, "Failed to initialize subkey generation.\n");
+        goto done;
+    }
+    if (rnp_cfg_hasval(cfg, CFG_KG_SUBKEY_BITS) &&
+        rnp_op_generate_set_bits(genkey, rnp_cfg_getint(cfg, CFG_KG_SUBKEY_BITS))) {
+        (void) fprintf(stderr, "Failed to set subkey bits.\n");
+        goto done;
+    }
+    if (rnp_cfg_hasval(cfg, CFG_KG_SUBKEY_CURVE) &&
+        rnp_op_generate_set_curve(genkey, rnp_cfg_getstr(cfg, CFG_KG_SUBKEY_CURVE))) {
+        (void) fprintf(stderr, "Failed to set subkey curve.\n");
+        goto done;
+    }
+    // TODO : set DSA qbits
+    if (rnp_op_generate_set_hash(genkey, rnp_cfg_getstr(cfg, CFG_KG_HASH))) {
+        (void) fprintf(stderr, "Failed to set hash algorithm.\n");
+        goto done;
+    }
+    if (rnp_op_generate_set_protection_cipher(genkey, rnp_cfg_getstr(cfg, CFG_KG_PROT_ALG))) {
+        (void) fprintf(stderr, "Failed to set protection algorithm.\n");
+        goto done;
+    }
+    if (rnp_op_generate_set_protection_hash(genkey, rnp_cfg_getstr(cfg, CFG_KG_PROT_HASH))) {
+        (void) fprintf(stderr, "Failed to set protection hash algorithm.\n");
+        goto done;
+    }
+    if (rnp_op_generate_set_protection_iterations(
+          genkey, rnp_cfg_getint(cfg, CFG_KG_PROT_ITERATIONS))) {
+        (void) fprintf(stderr, "Failed to set protection iterations.\n");
+        goto done;
+    }
+    if (rnp_op_generate_execute(genkey) || rnp_op_generate_get_key(genkey, &subkey)) {
+        (void) fprintf(stderr, "Subkey generation failed.\n");
+        goto done;
+    }
+
+    res = cli_rnp_save_keyrings(rnp);
+done:
+    if (res) {
+        cli_rnp_print_key_info(stdout, rnp->ffi, primary, true, false);
+        if (subkey) {
+            cli_rnp_print_key_info(stdout, rnp->ffi, subkey, true, false);
+        }
+    }
+    rnp_op_generate_destroy(genkey);
+    rnp_key_handle_destroy(primary);
+    rnp_key_handle_destroy(subkey);
+    return res;
+}
+
+static bool
+str_is_hex(const char *hexid, size_t hexlen)
+{
+    /* todo: this function duplicates ishex from rnp_sdk.h. Should we add it to FFI? */
+    if ((hexlen >= 2) && (hexid[0] == '0') && ((hexid[1] == 'x') || (hexid[1] == 'X'))) {
+        hexid += 2;
+        hexlen -= 2;
+    }
+
+    for (size_t i = 0; i < hexlen; i++) {
+        if ((hexid[i] >= '0') && (hexid[i] <= '9')) {
+            continue;
+        }
+        if ((hexid[i] >= 'a') && (hexid[i] <= 'f')) {
+            continue;
+        }
+        if ((hexid[i] >= 'A') && (hexid[i] <= 'F')) {
+            continue;
+        }
+        if ((hexid[i] == ' ') || (hexid[i] == '\t')) {
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+static bool
+key_matches_string(rnp_key_handle_t handle, const char *str, bool secret)
+{
+    bool    matches = false;
+    char *  id = NULL;
+    size_t  idlen = 0;
+    size_t  len = str ? strlen(str) : 0;
+    regex_t r = {};
+    size_t  uid_count = 0;
+    bool    boolres = false;
+
+    if (rnp_key_have_secret(handle, &boolres)) {
+        goto done;
+    }
+
+    if (secret && !boolres) {
+        goto done;
+    }
+
+    if (!str) {
+        matches = true;
+        goto done;
+    }
+
+    if (str_is_hex(str, len) && (len >= RNP_KEYID_SIZE)) {
+        const char *hexstr = str;
+
+        if ((str[0] == '0') && ((str[1] == 'x') || (str[1] == 'X'))) {
+            hexstr += 2;
+            len -= 2;
+        }
+
+        /* check whether it's key id */
+        if ((len == RNP_KEYID_SIZE * 2) || (len == RNP_KEYID_SIZE)) {
+            if (rnp_key_get_keyid(handle, &id)) {
+                goto done;
+            }
+
+            if ((idlen = strlen(id)) < len) {
+                goto done;
+            }
+
+            if (strncasecmp(hexstr, id + idlen - len, len) == 0) {
+                matches = true;
+                goto done;
+            }
+            rnp_buffer_destroy(id);
+            id = NULL;
+        }
+
+        /* check fingerprint */
+        if (len == RNP_FP_SIZE * 2) {
+            if (rnp_key_get_fprint(handle, &id)) {
+                goto done;
+            }
+
+            if (strlen(id) != len) {
+                goto done;
+            }
+
+            if (strncasecmp(hexstr, id, len) == 0) {
+                matches = true;
+                goto done;
+            }
+            rnp_buffer_destroy(id);
+            id = NULL;
+        }
+
+        /* check grip */
+        if (len == RNP_GRIP_SIZE * 2) {
+            if (rnp_key_get_grip(handle, &id)) {
+                goto done;
+            }
+
+            if (strlen(id) != len) {
+                goto done;
+            }
+
+            if (strncasecmp(hexstr, id, len) == 0) {
+                matches = true;
+                goto done;
+            }
+            rnp_buffer_destroy(id);
+            id = NULL;
+        }
+        /* let then search for hex userid */
+    }
+
+    /* no need to check for userid over the subkey */
+    if (rnp_key_is_sub(handle, &boolres) || boolres) {
+        goto done;
+    }
+
+    if (rnp_key_get_uid_count(handle, &uid_count) || (uid_count == 0)) {
+        goto done;
+    }
+
+    /* match on full name or email address as a NOSUB, ICASE regexp */
+    if (regcomp(&r, str, REG_EXTENDED | REG_ICASE) != 0) {
+        goto done;
+    }
+
+    for (size_t idx = 0; idx < uid_count; idx++) {
+        if (rnp_key_get_uid_at(handle, idx, &id)) {
+            goto regdone;
+        }
+
+        if (regexec(&r, id, 0, NULL, 0) == 0) {
+            matches = true;
+            goto regdone;
+        }
+
+        rnp_buffer_destroy(id);
+        id = NULL;
+    }
+
+regdone:
+    regfree(&r);
+done:
+    rnp_buffer_destroy(id);
+    return matches;
+}
+
+void
+cli_rnp_keylist_destroy(list *keys)
+{
+    for (list_item *kh = list_front(*keys); kh; kh = list_next(kh)) {
+        rnp_key_handle_destroy(*((rnp_key_handle_t *) kh));
+    }
+    list_destroy(keys);
+}
+
+list
+cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret)
+{
+    list                      result = NULL;
+    rnp_identifier_iterator_t it = NULL;
+    rnp_key_handle_t          handle = NULL;
+    const char *              grip = NULL;
+    rnp_ffi_t                 ffi = rnp->ffi;
+
+    if (rnp_identifier_iterator_create(ffi, &it, "grip")) {
+        return NULL;
+    }
+
+    while (rnp_identifier_iterator_next(it, &grip) == RNP_SUCCESS) {
+        size_t sub_count = 0;
+        bool   is_subkey = false;
+        char * primary_grip = NULL;
+
+        if (!grip) {
+            goto done;
+        }
+
+        if (rnp_locate_key(ffi, "grip", grip, &handle)) {
+            goto error;
+        }
+        if (!key_matches_string(handle, filter, secret)) {
+            rnp_key_handle_destroy(handle);
+            continue;
+        }
+        /* check whether key is subkey */
+        if (rnp_key_is_sub(handle, &is_subkey)) {
+            goto error;
+        }
+        if (is_subkey && rnp_key_get_primary_grip(handle, &primary_grip)) {
+            goto error;
+        }
+        /* if we have primary key then subkey will be printed together with primary */
+        if (is_subkey && primary_grip) {
+            rnp_buffer_destroy(primary_grip);
+            continue;
+        }
+
+        if (!list_append(&result, &handle, sizeof(handle))) {
+            rnp_key_handle_destroy(handle);
+            goto error;
+        }
+
+        /* add subkeys as well, if key is primary */
+        if (is_subkey) {
+            continue;
+        }
+        if (rnp_key_get_subkey_count(handle, &sub_count)) {
+            goto error;
+        }
+        for (size_t i = 0; i < sub_count; i++) {
+            rnp_key_handle_t sub_handle = NULL;
+            if (rnp_key_get_subkey_at(handle, i, &sub_handle)) {
+                goto error;
+            }
+            if (!list_append(&result, &sub_handle, sizeof(sub_handle))) {
+                rnp_key_handle_destroy(sub_handle);
+                goto error;
+            }
+        }
+    }
+
+error:
+    cli_rnp_keylist_destroy(&result);
+done:
+    rnp_identifier_iterator_destroy(it);
+    return result;
+}
+
+static bool
+stdout_write(void *app_ctx, const void *buf, size_t len)
+{
+    return write(STDOUT_FILENO, buf, len) >= 0;
+}
+
+bool
+cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter)
+{
+    bool secret = rnp_cfg_getbool(cfg, CFG_SECRET);
+    list keys = cli_rnp_get_keylist(rnp, filter, secret);
+    if (!keys) {
+        fprintf(stdout, "Key(s) matching '%s' not found.\n", filter);
+        return false;
+    }
+
+    rnp_output_t output = NULL;
+    rnp_output_t armor = NULL;
+    const char * file = rnp_cfg_getstr(cfg, CFG_OUTFILE);
+    rnp_result_t ret;
+
+    if (file) {
+        uint32_t flags = rnp_cfg_getbool(cfg, CFG_FORCE) ? RNP_OUTPUT_FILE_OVERWRITE : 0;
+        ret = rnp_output_to_file(&output, file, flags);
+    } else {
+        ret = rnp_output_to_callback(&output, stdout_write, NULL, NULL);
+    }
+    if (ret) {
+        return false;
+    }
+
+    uint32_t base_flags = secret ? RNP_KEY_EXPORT_SECRET : RNP_KEY_EXPORT_PUBLIC;
+    bool     result = false;
+    if (rnp_output_to_armor(output, &armor, secret ? "secret key" : "public key")) {
+        goto done;
+    }
+
+    for (list_item *ki = list_front(keys); ki; ki = list_next(ki)) {
+        uint32_t         flags = base_flags;
+        rnp_key_handle_t key = *((rnp_key_handle_t *) ki);
+        bool             primary = false;
+        char *           grip = NULL;
+
+        if (rnp_key_is_primary(key, &primary)) {
+            goto done;
+        }
+
+        /* skip subkeys which have primary key */
+        if (!primary && rnp_key_get_primary_grip(key, &grip)) {
+            if (grip) {
+                rnp_buffer_destroy(grip);
+                continue;
+            }
+        }
+
+        if (primary) {
+            flags = flags | RNP_KEY_EXPORT_SUBKEYS;
+        }
+
+        if (rnp_key_export(key, armor, flags)) {
+            goto done;
+        }
+    }
+    result = !rnp_output_finish(armor);
+done:
+    rnp_output_destroy(armor);
+    rnp_output_destroy(output);
+    cli_rnp_keylist_destroy(&keys);
+    return result;
+}

--- a/src/rnp/fficli.h
+++ b/src/rnp/fficli.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ * 2.  Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FFICLI_H_
+#define FFICLI_H_
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <time.h>
+#include "rnp/rnp.h"
+#include "rnpcfg.h"
+#include "json.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef struct cli_rnp_t {
+    rnp_ffi_t ffi;
+    FILE *    resfp;     /* where to put result messages, defaults to stdout */
+    FILE *    passfp;    /* file pointer for password input */
+    int       pswdtries; /* number of password tries, -1 for unlimited */
+    char *    pubpath;   /* path to the public keyring */
+    char *    pubformat; /* format of the public keyring */
+    char *    secpath;   /* path to the secret keyring */
+    char *    secformat; /* format of the secret keyring */
+    char *    defkey;    /* default key id */
+} cli_rnp_t;
+
+bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
+bool cli_rnp_init(cli_rnp_t *, rnp_cfg_t *);
+void cli_rnp_end(cli_rnp_t *);
+bool cli_rnp_load_keyrings(cli_rnp_t *rnp, bool loadsecret);
+bool cli_rnp_save_keyrings(cli_rnp_t *rnp);
+void cli_rnp_set_default_key(cli_rnp_t *rnp);
+void cli_rnp_print_key_info(
+  FILE *fp, rnp_ffi_t ffi, rnp_key_handle_t key, bool psecret, bool psigs);
+bool cli_rnp_set_generate_params(rnp_cfg_t *cfg);
+bool cli_rnp_generate_key(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *username);
+list cli_rnp_get_keylist(cli_rnp_t *rnp, const char *filter, bool secret);
+void cli_rnp_keylist_destroy(list *keys);
+bool cli_rnp_export_keys(rnp_cfg_t *cfg, cli_rnp_t *rnp, const char *filter);
+
+const char *json_obj_get_str(json_object *obj, const char *key);
+int64_t     json_obj_get_int64(json_object *obj, const char *key);
+bool        set_pass_fd(FILE **file, int passfd);
+char *      ptimestr(char *dest, size_t size, time_t t);
+
+/* TODO: we should decide what to do with functions/constants/defines below */
+#define RNP_KEYID_SIZE 8
+#define RNP_FP_SIZE 20
+#define RNP_GRIP_SIZE 20
+#define RNP_SUCCESS 0
+
+#define MAX_PASSWORD_LENGTH 256
+#define MAX_PASSWORD_ATTEMPTS 3
+
+#define ERR_MSG(...)                           \
+    do {                                       \
+        (void) fprintf((stderr), __VA_ARGS__); \
+        (void) fprintf((stderr), "\n");        \
+    } while (0)
+
+rnp_result_t disable_core_dumps(void);
+char *       rnp_strip_eol(char *s);
+void         pgp_forget(void *vp, size_t size);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/src/rnp/rnp.cpp
+++ b/src/rnp/rnp.cpp
@@ -944,7 +944,7 @@ rnp_main(int argc, char **argv)
     default:;
     }
 
-    if (!rnp_cfg_set_keystore_info(&cfg)) {
+    if (!cli_cfg_set_keystore_info(&cfg)) {
         fputs("fatal: cannot set keystore info\n", stderr);
         ret = EXIT_ERROR;
         goto finish;

--- a/src/rnp/rnpcfg.h
+++ b/src/rnp/rnpcfg.h
@@ -86,6 +86,18 @@
 #define CFG_KR_SEC_PATH "kr-sec-path"
 #define CFG_KR_DEF_KEY "kr-def-key"
 
+/* key generation variables */
+#define CFG_KG_PRIMARY_ALG "kg-primary-alg"
+#define CFG_KG_PRIMARY_BITS "kg-primary-bits"
+#define CFG_KG_PRIMARY_CURVE "kg-primary-curve"
+#define CFG_KG_SUBKEY_ALG "kg-subkey-alg"
+#define CFG_KG_SUBKEY_BITS "kg-subkey-bits"
+#define CFG_KG_SUBKEY_CURVE "kg-subkey-curve"
+#define CFG_KG_HASH "kg-hash"
+#define CFG_KG_PROT_HASH "kg-prot-hash"
+#define CFG_KG_PROT_ALG "kg-prot-alg"
+#define CFG_KG_PROT_ITERATIONS "kg-prot-iterations"
+
 /* rnp CLI config : contains all the system-dependent and specified by the user configuration
  * options */
 typedef struct rnp_cfg_t {

--- a/src/rnp/rnpcli.cpp
+++ b/src/rnp/rnpcli.cpp
@@ -298,42 +298,6 @@ rnp_load_keyrings(rnp_t *rnp, bool loadsecret)
     return true;
 }
 
-/* resolve the userid */
-pgp_key_t *
-resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid)
-{
-    pgp_key_t *key;
-
-    if (userid == NULL) {
-        return NULL;
-    }
-    key = rnp_key_store_get_key_by_name(keyring, userid, NULL);
-    if (!key) {
-        (void) fprintf(stderr, "cannot find key '%s'\n", userid);
-        return NULL;
-    }
-    return key;
-}
-
-/* export a given key */
-char *
-rnp_export_key(rnp_t *rnp, const char *name, bool secret_key)
-{
-    const pgp_key_t *      key;
-    const rnp_key_store_t *keyring;
-
-    if (!rnp) {
-        return NULL;
-    }
-
-    keyring = secret_key ? rnp->secring : rnp->pubring;
-    key = resolve_userid(rnp, keyring, name);
-    if (!key) {
-        return NULL;
-    }
-    return pgp_export_key(keyring, key);
-}
-
 bool
 rnp_add_key(rnp_t *rnp, const char *path, bool print)
 {

--- a/src/rnp/rnpcli.cpp
+++ b/src/rnp/rnpcli.cpp
@@ -456,23 +456,6 @@ done:
     return ret;
 }
 
-/* import a key into our keyring */
-bool
-rnp_import_key(rnp_t *rnp, const char *f)
-{
-    if (!rnp_add_key(rnp, f, true)) {
-        return false;
-    }
-
-    if (!rnp_key_store_write_to_path(rnp->secring) ||
-        !rnp_key_store_write_to_path(rnp->pubring)) {
-        RNP_LOG("failed to write keyring");
-        return false;
-    }
-
-    return true;
-}
-
 /* return the time as a string */
 char *
 ptimestr(char *dest, size_t size, time_t t)

--- a/src/rnp/rnpcli.cpp
+++ b/src/rnp/rnpcli.cpp
@@ -84,7 +84,7 @@
  * will be set to the result from setrlimit in the event of
  * failure.
  */
-static rnp_result_t
+rnp_result_t
 disable_core_dumps(void)
 {
     struct rlimit limit;
@@ -110,7 +110,7 @@ disable_core_dumps(void)
 
 #endif
 
-static bool
+bool
 set_pass_fd(FILE **file, int passfd)
 {
     if (!file) {
@@ -474,7 +474,7 @@ rnp_import_key(rnp_t *rnp, const char *f)
 }
 
 /* return the time as a string */
-static char *
+char *
 ptimestr(char *dest, size_t size, time_t t)
 {
     struct tm *tm;
@@ -1524,7 +1524,7 @@ rnp_cfg_set_defkey(rnp_cfg_t *cfg)
 }
 
 bool
-rnp_cfg_set_keystore_info(rnp_cfg_t *cfg)
+cli_cfg_set_keystore_info(rnp_cfg_t *cfg)
 {
     /* detecting keystore pathes and format */
     if (!rnp_cfg_set_ks_info(cfg)) {

--- a/src/rnp/rnpcli.cpp
+++ b/src/rnp/rnpcli.cpp
@@ -566,18 +566,6 @@ rnp_print_key_info(FILE *fp, rnp_key_store_t *keyring, const pgp_key_t *key, boo
     }
 }
 
-size_t
-rnp_secret_count(rnp_t *rnp)
-{
-    return rnp->secring ? rnp_key_store_get_key_count(rnp->secring) : 0;
-}
-
-size_t
-rnp_public_count(rnp_t *rnp)
-{
-    return rnp->pubring ? rnp_key_store_get_key_count(rnp->pubring) : 0;
-}
-
 typedef struct pgp_parse_handler_param_t {
     char         in[PATH_MAX];
     char         out[PATH_MAX];

--- a/src/rnp/rnpcli.cpp
+++ b/src/rnp/rnpcli.cpp
@@ -315,23 +315,6 @@ resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid)
     return key;
 }
 
-/* find a key in a keyring */
-bool
-rnp_find_key(rnp_t *rnp, const char *id)
-{
-    pgp_key_t *key;
-
-    if (id == NULL) {
-        RNP_LOG("NULL id to search for");
-        return false;
-    }
-    key = rnp_key_store_get_key_by_name(rnp->pubring, id, NULL);
-    if (!key) {
-        return false;
-    }
-    return key != NULL;
-}
-
 /* export a given key */
 char *
 rnp_export_key(rnp_t *rnp, const char *name, bool secret_key)

--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -77,7 +77,6 @@ bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
 
 /* key management */
 void       rnp_print_key_info(FILE *, rnp_key_store_t *, const pgp_key_t *, bool);
-bool       rnp_find_key(rnp_t *, const char *);
 char *     rnp_export_key(rnp_t *, const char *, bool);
 bool       rnp_add_key(rnp_t *rnp, const char *path, bool print);
 pgp_key_t *resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid);

--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -82,9 +82,6 @@ char *     rnp_export_key(rnp_t *, const char *, bool);
 bool       rnp_add_key(rnp_t *rnp, const char *path, bool print);
 pgp_key_t *resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid);
 
-size_t     rnp_secret_count(rnp_t *);
-size_t     rnp_public_count(rnp_t *);
-
 /* file management */
 rnp_result_t rnp_process_file(rnp_t *, rnp_ctx_t *, const char *, const char *);
 rnp_result_t rnp_protect_file(rnp_t *, rnp_ctx_t *, const char *, const char *);

--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -53,11 +53,6 @@ typedef struct rnp_t {
     FILE *           passfp;        /* file pointer for password input */
     char *           defkey;        /* default key id */
     int              pswdtries;     /* number of password tries, -1 for unlimited */
-
-    union {
-        rnp_action_keygen_t generate_key_ctx;
-    } action;
-
     pgp_password_provider_t password_provider;
     pgp_key_provider_t      key_provider;
     rng_t                   rng; /* handle to rng_t */
@@ -87,13 +82,6 @@ char *     rnp_export_key(rnp_t *, const char *, bool);
 bool       rnp_add_key(rnp_t *rnp, const char *path, bool print);
 pgp_key_t *resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid);
 
-/**
- * @brief Generate key, based on information passed in rnp->action.generate_key_ctx
- *
- * @param rnp initialized and filled rnp_t structure.
- * @return generated secret key or NULL in case of generation error.
- */
-pgp_key_t *rnp_generate_key(rnp_t *rnp);
 size_t     rnp_secret_count(rnp_t *);
 size_t     rnp_public_count(rnp_t *);
 

--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -78,10 +78,7 @@ bool rnp_load_keyrings(rnp_t *rnp, bool loadsecret);
  * @return true on success or false otherwise.
  * @return false
  */
-bool rnp_cfg_set_keystore_info(rnp_cfg_t *cfg);
-
-/* set key store format information */
-int rnp_set_key_store_format(rnp_t *, const char *);
+bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
 
 /* key management */
 void       rnp_print_key_info(FILE *, rnp_key_store_t *, const pgp_key_t *, bool);
@@ -127,6 +124,12 @@ rnp_result_t rnp_armor_stream(rnp_ctx_t *ctx, bool armor, const char *in, const 
 rnp_result_t rnp_validate_keys_signatures(rnp_t *rnp);
 
 rnp_result_t rnp_encrypt_add_password(rnp_t *rnp, rnp_ctx_t *ctx);
+
+rnp_result_t disable_core_dumps(void);
+
+bool set_pass_fd(FILE **file, int passfd);
+
+char *ptimestr(char *dest, size_t size, time_t t);
 
 #if defined(__cplusplus)
 }

--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -77,9 +77,7 @@ bool cli_cfg_set_keystore_info(rnp_cfg_t *cfg);
 
 /* key management */
 void       rnp_print_key_info(FILE *, rnp_key_store_t *, const pgp_key_t *, bool);
-char *     rnp_export_key(rnp_t *, const char *, bool);
 bool       rnp_add_key(rnp_t *rnp, const char *path, bool print);
-pgp_key_t *resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid);
 
 /* file management */
 rnp_result_t rnp_process_file(rnp_t *, rnp_ctx_t *, const char *, const char *);

--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -85,7 +85,6 @@ void       rnp_print_key_info(FILE *, rnp_key_store_t *, const pgp_key_t *, bool
 bool       rnp_find_key(rnp_t *, const char *);
 char *     rnp_export_key(rnp_t *, const char *, bool);
 bool       rnp_add_key(rnp_t *rnp, const char *path, bool print);
-bool       rnp_import_key(rnp_t *, const char *);
 pgp_key_t *resolve_userid(rnp_t *rnp, const rnp_key_store_t *keyring, const char *userid);
 
 /**

--- a/src/rnpkeys/CMakeLists.txt
+++ b/src/rnpkeys/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(rnpkeys
   tui.cpp
   main.cpp
   ../rnp/rnpcfg.cpp
+  ../rnp/fficli.cpp
   ../rnp/rnpcli.cpp
 )
 
@@ -43,6 +44,7 @@ target_include_directories(rnpkeys
 target_link_libraries(rnpkeys
   PRIVATE
     librnp
+    JSON-C::JSON-C
 )
 
 include(GNUInstallDirs)
@@ -51,4 +53,3 @@ install(TARGETS rnpkeys
     DESTINATION "${CMAKE_INSTALL_BINDIR}"
     COMPONENT cli
 )
-

--- a/src/rnpkeys/main.cpp
+++ b/src/rnpkeys/main.cpp
@@ -48,7 +48,7 @@ int
 rnpkeys_main(int argc, char **argv)
 #endif
 {
-    rnp_t     rnp = {};
+    cli_rnp_t rnp = {};
     rnp_cfg_t opt_cfg = {};
     rnp_cfg_t cfg = {};
     optdefs_t cmd = (optdefs_t) 0;
@@ -117,6 +117,6 @@ rnpkeys_main(int argc, char **argv)
 end:
     rnp_cfg_free(&cfg);
     rnp_cfg_free(&opt_cfg);
-    rnp_end(&rnp);
+    cli_rnp_end(&rnp);
     return ret;
 }

--- a/src/rnpkeys/rnpkeys.h
+++ b/src/rnpkeys/rnpkeys.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 #include <sys/param.h>
-#include "../rnp/rnpcli.h"
+#include "../rnp/fficli.h"
 
 #define DEFAULT_RSA_NUMBITS 2048
 
@@ -40,29 +40,25 @@ typedef enum {
     OPT_DEBUG
 } optdefs_t;
 
-rnp_result_t rnp_generate_key_expert_mode(rnp_t *rnp, rnp_cfg_t *cfg);
-bool         rnp_cmd(rnp_cfg_t *cfg, rnp_t *rnp, optdefs_t cmd, const char *f);
-bool         setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg);
-void         print_praise(void);
-void         print_usage(const char *usagemsg);
-bool         parse_option(rnp_cfg_t *cfg, optdefs_t *cmd, const char *s);
+bool rnp_cmd(rnp_cfg_t *cfg, cli_rnp_t *rnp, optdefs_t cmd, const char *f);
+bool setoption(rnp_cfg_t *cfg, optdefs_t *cmd, int val, char *arg);
+void print_praise(void);
+void print_usage(const char *usagemsg);
+bool parse_option(rnp_cfg_t *cfg, optdefs_t *cmd, const char *s);
 
-/* -----------------------------------------------------------------------------
- * @brief   Initializes rnpkeys. Function allocates memory dynamically for
- *          cfg and rnp arguments, which must be freed by the caller.
+/**
+ * @brief Initializes rnpkeys. Function allocates memory dynamically for
+ *        cfg and rnp arguments, which must be freed by the caller.
  *
- * @param   [out] cfg configuration to be used by rnd_cmd
- * @param   [out[ rnp initialized rnp context
- * @param   [in]  opt_cfg configuration with settings from command line
- * @param   [in]  load_keys wether rnpkeys should be configured to
- *                run key generation
- *
- * @pre     cfg and rnp must be not NULL
- *
- * @returns true if on success, otherwise false. If false returned, no
- *          memory allocation was done.
- *
--------------------------------------------------------------------------------- */
-bool rnpkeys_init(rnp_cfg_t *cfg, rnp_t *rnp, const rnp_cfg_t *opt_cfg, bool is_generate_key);
+ * @param cfg configuration to be used by rnd_cmd
+ * @param rnp initialized rnp context
+ * @param opt_cfg configuration with settings from command line
+ * @param is_generate_key wether rnpkeys should be configured to run key generation
+ * @return true on success, or false otherwise.
+ */
+bool rnpkeys_init(rnp_cfg_t *      cfg,
+                  cli_rnp_t *      rnp,
+                  const rnp_cfg_t *opt_cfg,
+                  bool             is_generate_key);
 
 #endif /* _rnpkeys_ */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(JSON-C 0.11 REQUIRED)
 add_executable(rnp_tests
   ../rnp/rnpcfg.cpp
   ../rnp/rnpcli.cpp
+  ../rnp/fficli.cpp
   ../rnp/rnp.cpp
   ../rnpkeys/rnpkeys.cpp
   ../rnpkeys/main.cpp

--- a/src/tests/data/test_cli_rnpkeys/getkey_2fcadf05ffa501bb_sec
+++ b/src/tests/data/test_cli_rnpkeys/getkey_2fcadf05ffa501bb_sec
@@ -3,8 +3,8 @@
 sec   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
 uid           key1-uid0
-uid           key1-uid1
 uid           key1-uid2
+uid           key1-uid1
 ssb   1024/Elgamal (Encrypt-Only) 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e
 ssb   1024/Elgamal (Encrypt-Only) 326ef111425d14a5 2017-07-20 [E]

--- a/src/tests/data/test_cli_rnpkeys/keyring_1_list_keys_sec
+++ b/src/tests/data/test_cli_rnpkeys/keyring_1_list_keys_sec
@@ -15,8 +15,8 @@ ssb   1024/RSA (Encrypt or Sign) 8a05b89fad5aded1 2017-07-20 [E]
 sec   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
 uid           key1-uid0
-uid           key1-uid1
 uid           key1-uid2
+uid           key1-uid1
 ssb   1024/Elgamal (Encrypt-Only) 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e
 ssb   1024/Elgamal (Encrypt-Only) 326ef111425d14a5 2017-07-20 [E]

--- a/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_sec
+++ b/src/tests/data/test_cli_rnpkeys/keyring_1_list_sigs_sec
@@ -18,10 +18,10 @@ ssb   1024/RSA (Encrypt or Sign) 8a05b89fad5aded1 2017-07-20 [E]
 sec   1024/DSA 2fcadf05ffa501bb 2017-07-20 [SC] [EXPIRES 2083-05-11]
       be1c4ab951f4c2f6b604c7f82fcadf05ffa501bb
 uid           key1-uid0
+sig           2fcadf05ffa501bb 2017-07-29 key1-uid0
+uid           key1-uid2
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 uid           key1-uid1
-sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
-uid           key1-uid2
 sig           2fcadf05ffa501bb 2017-07-20 key1-uid0
 ssb   1024/Elgamal (Encrypt-Only) 54505a936a4a970e 2017-07-20 [E] [EXPIRES 2083-05-11]
       a3e94de61a8cb229413d348e54505a936a4a970e

--- a/src/tests/exportkey.cpp
+++ b/src/tests/exportkey.cpp
@@ -57,6 +57,7 @@ rnpkeys_exportkey_verifyUserId(void **state)
 
     list keys = cli_rnp_get_keylist(&rnp, getenv("LOGNAME"), false);
     assert_int_equal(list_length(keys), 2);
+    cli_rnp_keylist_destroy(&keys);
 
     /* Try to export the key with specified userid parameter from the env */
     assert_true(cli_rnp_export_keys(&cfg, &rnp, getenv("LOGNAME")));

--- a/src/tests/exportkey.cpp
+++ b/src/tests/exportkey.cpp
@@ -34,38 +34,37 @@ void
 rnpkeys_exportkey_verifyUserId(void **state)
 {
     /* Generate the key and export it */
-    rnp_test_state_t *rstate = (rnp_test_state_t *) *state;
-    ;
-    rnp_t rnp;
-    int   pipefd[2];
-    char *exportedkey = NULL;
+    cli_rnp_t rnp = {};
+    rnp_cfg_t cfg = {};
+    int       pipefd[2];
 
     /* Initialize the rnp structure. */
-    rnp_assert_ok(rstate, setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
+    assert_true(setup_cli_rnp_common(&rnp, RNP_KEYSTORE_GPG, NULL, pipefd));
+    rnp_cfg_init(&cfg);
 
     /* Generate the key */
-    set_default_rsa_key_desc(&rnp.action.generate_key_ctx, PGP_HASH_SHA256);
-    rnp_assert_non_null(rstate, rnp_generate_key(&rnp));
+    cli_set_default_rsa_key_desc(&cfg, "SHA256");
+
+    assert_true(cli_rnp_generate_key(&cfg, &rnp, NULL));
 
     /* Loading keyrings and checking whether they have correct key */
-    rnp_assert_ok(rstate, rnp_load_keyrings(&rnp, 1));
-    rnp_assert_int_not_equal(rstate, 0, rnp_secret_count(&rnp));
-    rnp_assert_int_not_equal(rstate, 0, rnp_public_count(&rnp));
-    rnp_assert_true(rstate, rnp_find_key(&rnp, getenv("LOGNAME")));
+    assert_true(cli_rnp_load_keyrings(&rnp, true));
+    size_t keycount = 0;
+    assert_rnp_success(rnp_get_public_key_count(rnp.ffi, &keycount));
+    assert_int_equal(keycount, 2);
+    assert_rnp_success(rnp_get_secret_key_count(rnp.ffi, &keycount));
+    assert_int_equal(keycount, 2);
 
-    /* Try to export the key without passing userid from the interface : this should fail*/
-    exportedkey = rnp_export_key(&rnp, NULL, false);
-    rnp_assert_null(rstate, exportedkey);
-    free(exportedkey);
+    list keys = cli_rnp_get_keylist(&rnp, getenv("LOGNAME"), false);
+    assert_int_equal(list_length(keys), 2);
 
     /* Try to export the key with specified userid parameter from the env */
-    exportedkey = rnp_export_key(&rnp, getenv("LOGNAME"), false);
-    rnp_assert_non_null(rstate, exportedkey);
-    free(exportedkey);
+    assert_true(cli_rnp_export_keys(&cfg, &rnp, getenv("LOGNAME")));
 
     /* try to export the key with specified userid parameter (which is wrong) */
-    exportedkey = rnp_export_key(&rnp, "LOGNAME", false);
-    rnp_assert_null(rstate, exportedkey);
-    free(exportedkey);
-    rnp_end(&rnp); // Free memory and other allocated resources.
+    assert_false(cli_rnp_export_keys(&cfg, &rnp, "LOGNAME"));
+
+    close(pipefd[0]);
+    cli_rnp_end(&rnp); // Free memory and other allocated resources.
+    rnp_cfg_free(&cfg);
 }

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -130,7 +130,7 @@ rnpkeys_generatekey_testSignature(void **state)
 
                 /* Load keyring */
                 rnp_assert_ok(rstate, rnp_load_keyrings(&rnp, true));
-                rnp_assert_true(rstate, rnp_secret_count(&rnp) > 0);
+                rnp_assert_true(rstate, rnp_key_store_get_key_count(rnp.secring) > 0);
 
                 /* Setup signing context */
                 rnp_ctx_init(&ctx, &rnp.rng);
@@ -228,7 +228,7 @@ rnpkeys_generatekey_testEncryption(void **state)
 
             /* Load keyring */
             rnp_assert_ok(rstate, rnp_load_keyrings(&rnp, false));
-            rnp_assert_int_equal(rstate, 0, rnp_secret_count(&rnp));
+            rnp_assert_int_equal(rstate, 0, rnp_key_store_get_key_count(rnp.secring));
 
             /* setting the cipher and armored flags */
             rnp_ctx_init(&ctx, &rnp.rng);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -825,8 +825,8 @@ test_key_import(void **state)
 
     /* import just the public key */
     assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-just-key.pgp"));
-    assert_int_equal(rnp_public_count(&rnp), 1);
-    assert_int_equal(rnp_secret_count(&rnp), 0);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 1);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 0);
@@ -837,8 +837,8 @@ test_key_import(void **state)
 
     /* import public key + 1 userid */
     assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-uid-1-no-sigs.pgp"));
-    assert_int_equal(rnp_public_count(&rnp), 1);
-    assert_int_equal(rnp_secret_count(&rnp), 0);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 1);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 0);
@@ -853,8 +853,8 @@ test_key_import(void **state)
 
     /* import public key + 1 userid + signature */
     assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-uid-1.pgp"));
-    assert_int_equal(rnp_public_count(&rnp), 1);
-    assert_int_equal(rnp_secret_count(&rnp), 0);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 1);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 0);
@@ -869,8 +869,8 @@ test_key_import(void **state)
 
     /* import public key + 1 subkey */
     assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-subkey-1.pgp"));
-    assert_int_equal(rnp_public_count(&rnp), 2);
-    assert_int_equal(rnp_secret_count(&rnp), 0);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 2);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 1);
@@ -889,8 +889,8 @@ test_key_import(void **state)
 
     /* import secret key with 1 uid and 1 subkey */
     assert_true(rnp_import_key(&rnp, MERGE_PATH "key-sec-uid-1-subkey-1.pgp"));
-    assert_int_equal(rnp_public_count(&rnp), 2);
-    assert_int_equal(rnp_secret_count(&rnp), 2);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 2);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 2);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 1);
@@ -924,8 +924,8 @@ test_key_import(void **state)
 
     /* import secret key with 2 uids and 2 subkeys */
     assert_true(rnp_import_key(&rnp, MERGE_PATH "key-sec.pgp"));
-    assert_int_equal(rnp_public_count(&rnp), 3);
-    assert_int_equal(rnp_secret_count(&rnp), 3);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 3);
+    assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 3);
 
     assert_true(load_transferable_key(&tkey, ".rnp/pubring.gpg"));
     assert_int_equal(list_length(tkey.subkeys), 2);

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -824,7 +824,8 @@ test_key_import(void **state)
     assert_true(setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, ".rnp", NULL));
 
     /* import just the public key */
-    assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-just-key.pgp"));
+    assert_true(rnp_add_key(&rnp, MERGE_PATH "key-pub-just-key.pgp", false));
+    assert_true(rnp_key_store_write_to_path(rnp.pubring));
     assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 1);
     assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
@@ -836,7 +837,8 @@ test_key_import(void **state)
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 userid */
-    assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-uid-1-no-sigs.pgp"));
+    assert_true(rnp_add_key(&rnp, MERGE_PATH "key-pub-uid-1-no-sigs.pgp", false));
+    assert_true(rnp_key_store_write_to_path(rnp.pubring));
     assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 1);
     assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
@@ -852,7 +854,8 @@ test_key_import(void **state)
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 userid + signature */
-    assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-uid-1.pgp"));
+    assert_true(rnp_add_key(&rnp, MERGE_PATH "key-pub-uid-1.pgp", false));
+    assert_true(rnp_key_store_write_to_path(rnp.pubring));
     assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 1);
     assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
@@ -868,7 +871,8 @@ test_key_import(void **state)
     transferable_key_destroy(&tkey);
 
     /* import public key + 1 subkey */
-    assert_true(rnp_import_key(&rnp, MERGE_PATH "key-pub-subkey-1.pgp"));
+    assert_true(rnp_add_key(&rnp, MERGE_PATH "key-pub-subkey-1.pgp", false));
+    assert_true(rnp_key_store_write_to_path(rnp.pubring));
     assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 2);
     assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 0);
 
@@ -888,7 +892,9 @@ test_key_import(void **state)
     transferable_key_destroy(&tkey);
 
     /* import secret key with 1 uid and 1 subkey */
-    assert_true(rnp_import_key(&rnp, MERGE_PATH "key-sec-uid-1-subkey-1.pgp"));
+    assert_true(rnp_add_key(&rnp, MERGE_PATH "key-sec-uid-1-subkey-1.pgp", false));
+    assert_true(rnp_key_store_write_to_path(rnp.pubring));
+    assert_true(rnp_key_store_write_to_path(rnp.secring));
     assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 2);
     assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 2);
 
@@ -923,7 +929,9 @@ test_key_import(void **state)
     transferable_key_destroy(&tkey);
 
     /* import secret key with 2 uids and 2 subkeys */
-    assert_true(rnp_import_key(&rnp, MERGE_PATH "key-sec.pgp"));
+    assert_true(rnp_add_key(&rnp, MERGE_PATH "key-sec.pgp", false));
+    assert_true(rnp_key_store_write_to_path(rnp.pubring));
+    assert_true(rnp_key_store_write_to_path(rnp.secring));
     assert_int_equal(rnp_key_store_get_key_count(rnp.pubring), 3);
     assert_int_equal(rnp_key_store_get_key_count(rnp.secring), 3);
 

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -519,26 +519,6 @@ setup_cli_rnp_common(cli_rnp_t *rnp, const char *ks_format, const char *homedir,
 }
 
 void
-set_default_rsa_key_desc(rnp_action_keygen_t *action, pgp_hash_alg_t hashalg)
-{
-    rnp_keygen_primary_desc_t *primary = &action->primary.keygen;
-    rnp_keygen_subkey_desc_t * subkey = &action->subkey.keygen;
-
-    primary->crypto.key_alg = PGP_PKA_RSA;
-    primary->crypto.rsa.modulus_bit_len = 1024;
-    primary->crypto.hash_alg = hashalg;
-    primary->crypto.rng = &global_rng;
-
-    action->primary.protection.iterations = 1;
-    action->subkey.protection.iterations = 1;
-
-    subkey->crypto.key_alg = PGP_PKA_RSA;
-    subkey->crypto.rsa.modulus_bit_len = 1024;
-    subkey->crypto.hash_alg = hashalg;
-    subkey->crypto.rng = &global_rng;
-}
-
-void
 cli_set_default_rsa_key_desc(rnp_cfg_t *cfg, const char *hashalg)
 {
     rnp_cfg_setint(cfg, CFG_NUMBITS, 1024);

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -43,6 +43,7 @@ extern "C" {
 
 #include "rnp.h"
 #include "../rnp/rnpcli.h"
+#include "../rnp/fficli.h"
 
 /* Check if a file exists.
  * Use with assert_true and rnp_assert_false(rstate, .
@@ -140,9 +141,14 @@ bool setupPasswordfd(int *pipefd);
 /* Common initialization of rnp structure : home path, keystore format and pointer to store
  * password fd */
 bool setup_rnp_common(rnp_t *rnp, const char *ks_format, const char *homedir, int *pipefd);
+bool setup_cli_rnp_common(cli_rnp_t * rnp,
+                          const char *ks_format,
+                          const char *homedir,
+                          int *       pipefd);
 
 /* Initialize key generation params with default values and specified hash algorithm */
 void set_default_rsa_key_desc(rnp_action_keygen_t *action, pgp_hash_alg_t hashalg);
+void cli_set_default_rsa_key_desc(rnp_cfg_t *cfg, const char *hash);
 
 // this is a password callback that will always fail
 bool failing_password_callback(const pgp_password_ctx_t *ctx,

--- a/src/tests/support.h
+++ b/src/tests/support.h
@@ -147,7 +147,6 @@ bool setup_cli_rnp_common(cli_rnp_t * rnp,
                           int *       pipefd);
 
 /* Initialize key generation params with default values and specified hash algorithm */
-void set_default_rsa_key_desc(rnp_action_keygen_t *action, pgp_hash_alg_t hashalg);
 void cli_set_default_rsa_key_desc(rnp_cfg_t *cfg, const char *hash);
 
 // this is a password callback that will always fail

--- a/src/tests/user-prefs.cpp
+++ b/src/tests/user-prefs.cpp
@@ -67,7 +67,8 @@ test_load_user_prefs(void **state)
 
     rnp_assert_ok(rstate, setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, homedir, pipefd));
     rnp_assert_ok(rstate, rnp_load_keyrings(&rnp, false));
-    rnp_assert_true(rstate, rnp_secret_count(&rnp) == 0 && rnp_public_count(&rnp) == 7);
+    rnp_assert_true(rstate, rnp_key_store_get_key_count(rnp.secring) == 0);
+    rnp_assert_true(rstate, rnp_key_store_get_key_count(rnp.pubring) == 7);
 
     {
         const char *userid = "key1-uid0";


### PR DESCRIPTION
This PR makes rnpkeys to use FFI interface.
rnp will be moved later on so we'll finally be able to have single interface to rnp functions.
Also it removes no longer used code, which is replaced with FFI calls.
There are some minor usages of direct interface (see `fficli.h`), which will be adressed during `rnp` transition.

P.S. Unfortunately I don't see the good way to make compilable incremental commits for `rnpkeys` instead of single large one.