### PR TITLE
FFI: add function rnp_op_generate_set_request_password().

### DIFF
--- a/include/rnp/rnp.h
+++ b/include/rnp/rnp.h
@@ -574,6 +574,19 @@ rnp_result_t rnp_op_generate_set_curve(rnp_op_generate_t op, const char *curve);
 rnp_result_t rnp_op_generate_set_protection_password(rnp_op_generate_t op,
                                                      const char *      password);
 
+/**
+ * @brief Enable or disable password requesting via ffi's password provider. This password
+ *        then will be used for key encryption.
+ *        Note: this will be ignored if password was set via
+ *        rnp_op_generate_set_protection_password().
+ *
+ * @param op pointer to opaque key generation context.
+ * @param request true to enable password requesting or false otherwise. Default value is false
+ *                (i.e. key will be generated unencrypted).
+ * @return RNP_SUCCESS or error code if failed.
+ */
+rnp_result_t rnp_op_generate_set_request_password(rnp_op_generate_t op, bool request);
+
 /** Set cipher used to encrypt secret key data. If not called then default one will be used.
  *
  * @param op pointer to opaque key generation context.

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -114,6 +114,8 @@ struct rnp_op_generate_st {
     pgp_key_t *gen_pub;
     /* password used to encrypt the key, if specified */
     char *password;
+    /* request password for key encryption via ffi's password provider */
+    bool request_password;
     /* we don't use top-level keygen action here for easier fields access */
     rnp_keygen_crypto_params_t  crypto;
     rnp_key_protection_params_t protection;
@@ -4071,6 +4073,16 @@ rnp_op_generate_set_protection_password(rnp_op_generate_t op, const char *passwo
 }
 
 rnp_result_t
+rnp_op_generate_set_request_password(rnp_op_generate_t op, bool request)
+{
+    if (!op || !request) {
+        return RNP_ERROR_NULL_POINTER;
+    }
+    op->request_password = request;
+    return RNP_SUCCESS;
+}
+
+rnp_result_t
 rnp_op_generate_set_protection_cipher(rnp_op_generate_t op, const char *cipher)
 {
     if (!op || !cipher) {
@@ -4311,9 +4323,10 @@ rnp_op_generate_execute(rnp_op_generate_t op)
         return RNP_ERROR_NULL_POINTER;
     }
 
-    rnp_result_t ret = RNP_ERROR_GENERIC;
-    pgp_key_t    pub = {};
-    pgp_key_t    sec = {};
+    rnp_result_t            ret = RNP_ERROR_GENERIC;
+    pgp_key_t               pub = {};
+    pgp_key_t               sec = {};
+    pgp_password_provider_t prov = {.callback = NULL};
 
     if (op->primary) {
         rnp_keygen_primary_desc_t keygen = {};
@@ -4350,12 +4363,15 @@ rnp_op_generate_execute(rnp_op_generate_t op)
 
     /* encrypt secret key if requested */
     if (op->password) {
-        pgp_password_provider_t prov = {.callback = rnp_password_provider_string,
-                                        .userdata = (void *) op->password};
-        if (!rnp_key_add_protection(&sec, op->ffi->secring->format, &op->protection, &prov)) {
-            ret = RNP_ERROR_BAD_PARAMETERS;
-            goto done;
-        }
+        prov = {.callback = rnp_password_provider_string, .userdata = (void *) op->password};
+    } else if (op->request_password) {
+        prov = {.callback = rnp_password_cb_bounce, .userdata = op->ffi};
+    }
+    if (prov.callback &&
+        !rnp_key_add_protection(&sec, op->ffi->secring->format, &op->protection, &prov)) {
+        FFI_LOG(op->ffi, "failed to encrypt the key");
+        ret = RNP_ERROR_BAD_PARAMETERS;
+        goto done;
     }
 
     /* add secret key to the keyring */

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -214,6 +214,7 @@ main(int argc, char *argv[])
       cmocka_unit_test(test_ffi_key_generate_eddsa),
       cmocka_unit_test(test_ffi_key_generate_sm2),
       cmocka_unit_test(test_ffi_key_generate_ex),
+      cmocka_unit_test(test_ffi_key_generate_protection),
       cmocka_unit_test(test_ffi_add_userid),
       cmocka_unit_test(test_ffi_detect_key_format),
       cmocka_unit_test(test_ffi_encrypt_pass),

--- a/src/tests/rnp_tests.h
+++ b/src/tests/rnp_tests.h
@@ -160,6 +160,8 @@ void test_ffi_key_generate_sm2(void **state);
 
 void test_ffi_key_generate_ex(void **state);
 
+void test_ffi_key_generate_protection(void **state);
+
 void test_ffi_add_userid(void **state);
 
 void test_ffi_detect_key_format(void **state);


### PR DESCRIPTION
This PR adds a way to request key encryption password via FFI's password provider and then use it to encrypt generated key.
While it is already possible to encrypt key via rnp_op_generate_set_password(), this method could be handy in some situations (in rnpkeys for instance :)).

I'm not sure about the function name, so if you have better suggestions - you are welcome to share :)