### PR TITLE
Validate key material only after generation or key import.

### DIFF
--- a/src/lib/crypto/ecdsa.cpp
+++ b/src/lib/crypto/ecdsa.cpp
@@ -91,7 +91,7 @@ ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
 
     if (!ecdsa_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 1)) {
+        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
         goto done;
     }
     if (!secret) {
@@ -100,7 +100,7 @@ ecdsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!ecdsa_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 1)) {
+        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;

--- a/src/lib/crypto/eddsa.cpp
+++ b/src/lib/crypto/eddsa.cpp
@@ -77,7 +77,7 @@ eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
 
     if (!eddsa_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 1)) {
+        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
         goto done;
     }
 
@@ -87,7 +87,7 @@ eddsa_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!eddsa_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 1)) {
+        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;

--- a/src/lib/crypto/elgamal.cpp
+++ b/src/lib/crypto/elgamal.cpp
@@ -158,7 +158,7 @@ elgamal_validate_key(rng_t *rng, const pgp_eg_key_t *key, bool secret)
         goto done;
     }
 
-    if (elgamal_load_secret_key(&bskey, key) ||
+    if (!elgamal_load_secret_key(&bskey, key) ||
         botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
         goto done;
     }

--- a/src/lib/crypto/rsa.cpp
+++ b/src/lib/crypto/rsa.cpp
@@ -105,7 +105,7 @@ rsa_validate_key(rng_t *rng, const pgp_rsa_key_t *key, bool secret)
         goto done;
     }
 
-    if (botan_pubkey_check_key(bpkey, rng_handle(rng), 1)) {
+    if (botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
         goto done;
     }
 

--- a/src/lib/crypto/sm2.cpp
+++ b/src/lib/crypto/sm2.cpp
@@ -134,7 +134,7 @@ sm2_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     rnp_result_t    ret = RNP_ERROR_BAD_PARAMETERS;
 
     if (!sm2_load_public_key(&bpkey, key) ||
-        botan_pubkey_check_key(bpkey, rng_handle(rng), 1)) {
+        botan_pubkey_check_key(bpkey, rng_handle(rng), 0)) {
         goto done;
     }
 
@@ -144,7 +144,7 @@ sm2_validate_key(rng_t *rng, const pgp_ec_key_t *key, bool secret)
     }
 
     if (!sm2_load_secret_key(&bskey, key) ||
-        botan_privkey_check_key(bskey, rng_handle(rng), 1)) {
+        botan_privkey_check_key(bskey, rng_handle(rng), 0)) {
         goto done;
     }
     ret = RNP_SUCCESS;

--- a/src/lib/generate-key.cpp
+++ b/src/lib/generate-key.cpp
@@ -377,6 +377,12 @@ pgp_generate_primary_key(rnp_keygen_primary_desc_t *desc,
         break;
     }
 
+    /* mark it as valid */
+    primary_pub->valid = true;
+    primary_pub->validated = true;
+    primary_sec->valid = true;
+    primary_sec->validated = true;
+
     ok = true;
 end:
     // free any user preferences
@@ -509,6 +515,10 @@ pgp_generate_subkey(rnp_keygen_subkey_desc_t *     desc,
         break;
     }
 
+    subkey_pub->valid = true;
+    subkey_pub->validated = true;
+    subkey_sec->valid = true;
+    subkey_sec->validated = true;
     ok = true;
 end:
     transferable_subkey_destroy(&tskeysec);

--- a/src/lib/pgp-key.cpp
+++ b/src/lib/pgp-key.cpp
@@ -522,6 +522,7 @@ pgp_key_copy_fields(pgp_key_t *dst, const pgp_key_t *src)
 
     /* key validity */
     dst->valid = src->valid;
+    dst->validated = src->validated;
 
     return RNP_SUCCESS;
 error:

--- a/src/lib/pgp-key.h
+++ b/src/lib/pgp-key.h
@@ -79,6 +79,7 @@ struct pgp_key_t {
     pgp_revoke_t       revocation;   /* revocation reason */
     key_store_format_t format;       /* the format of the key in packets[0] */
     bool               valid;        /* this key is valid and usable */
+    bool               validated;    /* this key was validated */
 };
 
 struct pgp_key_t *pgp_key_new(void);

--- a/src/lib/rnp.cpp
+++ b/src/lib/rnp.cpp
@@ -1367,6 +1367,11 @@ rnp_import_keys(rnp_ffi_t ffi, rnp_input_t input, uint32_t flags, char **results
         if (pgp_key_is_public(key) && !pub) {
             continue;
         }
+        if (validate_pgp_key_material(pgp_key_get_material(key), &ffi->rng)) {
+            FFI_LOG(ffi, "attempt to import key with invalid material");
+            ret = RNP_ERROR_BAD_PARAMETERS;
+            goto done;
+        }
         // if we got here then we add public key itself or public part of the secret key
         if (!rnp_key_store_import_key(ffi->pubring, key, true, &pub_status)) {
             ret = RNP_ERROR_BAD_PARAMETERS;

--- a/src/librekey/rnp_key_store.cpp
+++ b/src/librekey/rnp_key_store.cpp
@@ -574,6 +574,8 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
             RNP_LOG("failed to merge key or subkey");
             return NULL;
         }
+        added_key->validated = added_key->validated && srckey->validated;
+        added_key->valid = added_key->valid && srckey->valid;
         pgp_key_free_data(srckey);
     } else {
         added_key = (pgp_key_t *) list_append(&keyring->keys, srckey, sizeof(*srckey));
@@ -592,7 +594,7 @@ rnp_key_store_add_key(rnp_key_store_t *keyring, pgp_key_t *srckey)
     RNP_DLOG("keyc %lu", rnp_key_store_get_key_count(keyring));
 
     /* validate all added keys if not disabled */
-    if (!keyring->disable_validation) {
+    if (!keyring->disable_validation && !added_key->validated) {
         added_key->valid = true; // we need to this to check key's signatures
         added_key->valid = !validate_pgp_key(added_key, keyring);
 

--- a/src/librepgp/stream-key.cpp
+++ b/src/librepgp/stream-key.cpp
@@ -1689,14 +1689,8 @@ validate_pgp_key(const pgp_key_t *key, const rnp_key_store_t *keyring)
 {
     pgp_signatures_info_t sinfo = {};
     rnp_result_t          res = RNP_ERROR_GENERIC;
-    rng_t                 rng = {};
 
-    if (!rng_init(&rng, RNG_SYSTEM)) {
-        RNP_LOG("RNG init failed");
-        return RNP_ERROR_RNG;
-    }
-
-    /* check signatures first */
+    /* check signatures */
     res = validate_pgp_key_signatures(&sinfo, key, keyring);
     if (!res) {
         bool valid = false;
@@ -1709,11 +1703,5 @@ validate_pgp_key(const pgp_key_t *key, const rnp_key_store_t *keyring)
         res = valid ? RNP_SUCCESS : RNP_ERROR_SIGNATURE_INVALID;
     }
     free_signatures_info(&sinfo);
-    /* if signatures are ok then check key material */
-    if (!res) {
-        res = validate_pgp_key_material(pgp_key_get_material(key), &rng);
-    }
-
-    rng_destroy(&rng);
     return res;
 }

--- a/src/rnp/rnpcli.cpp
+++ b/src/rnp/rnpcli.cpp
@@ -382,7 +382,6 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
     if (!tmp_keystore) {
         goto done;
     }
-
     // load the key(s)
     if (!rnp_key_store_load_from_path(tmp_keystore, &rnp->key_provider)) {
         RNP_LOG("failed to load key from file %s", path);
@@ -402,6 +401,11 @@ rnp_add_key(rnp_t *rnp, const char *path, bool print)
         size_t     expackets = 0;
         bool       changed = false;
 
+        /* validate imported key's material */
+        if (validate_pgp_key_material(pgp_key_get_material(imported), &rnp->rng)) {
+            RNP_LOG("invalid key material in added key");
+            continue;
+        }
         /* add public key */
         if (pgp_key_copy(&keycp, imported, true)) {
             RNP_LOG("failed to create key copy");


### PR DESCRIPTION
This PR addresses CI timeout issues, discussed in #873.
It disables time-expensive key material tests and disables key material validation right after the load.
Since key material cannot be changed, it is enough to validate it only after generation (to be extra-safe), and after the key import.