### PR TITLE
Allow cross-compiling of tests with MinGW (and add TODOs)

### DIFF
--- a/src/tests/cli.cpp
+++ b/src/tests/cli.cpp
@@ -24,7 +24,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef _WIN32
 #include <sys/wait.h>
+#endif
+
 #include "rnp_tests.h"
 #include "support.h"
 #include "utils.h"
@@ -486,19 +489,26 @@ test_cli_redumper(void **state)
     chnum = snprintf(cmd, sizeof(cmd), "%s -h", redumper_path);
     assert_true(chnum < (int) sizeof(cmd));
     status = system(cmd);
+    // there are no equivalents for WIFEXITED and WEXITSTATUS on Windows
+#ifndef _WIN32
     assert_true(WIFEXITED(status));
     assert_int_equal(WEXITSTATUS(status), 1);
+#endif
     /* run redumper on some data */
     chnum = snprintf(cmd, sizeof(cmd), "%s \"%s\"", redumper_path, KEYS "/1/pubring.gpg");
     assert_true(chnum < (int) sizeof(cmd));
     status = system(cmd);
+#ifndef _WIN32
     assert_true(WIFEXITED(status));
     assert_int_equal(WEXITSTATUS(status), 0);
+#endif
     /* run redumper on some data with json output */
     chnum = snprintf(cmd, sizeof(cmd), "%s -j \"%s\"", redumper_path, KEYS "/1/pubring.gpg");
     assert_true(chnum < (int) sizeof(cmd));
     status = system(cmd);
+#ifndef _WIN32
     assert_true(WIFEXITED(status));
     assert_int_equal(WEXITSTATUS(status), 0);
+#endif
     free(redumper_path);
 }

--- a/src/tests/ffi.cpp
+++ b/src/tests/ffi.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <time.h>
 
 #include <rnp/rnp.h>
 #include "rnp_tests.h"
@@ -34,8 +35,6 @@
 #include "librepgp/stream-common.h"
 #include "utils.h"
 #include <json.h>
-#include <vector>
-#include <string>
 
 void
 test_ffi_homedir(void **state)
@@ -617,7 +616,7 @@ test_ffi_save_keys(void **state)
     // save secring
     sec_path = rnp_compose_path(temp_dir, "private-keys-v1.d", NULL);
     assert_false(rnp_dir_exists(sec_path));
-    assert_int_equal(0, mkdir(sec_path, S_IRWXU));
+    assert_int_equal(0, RNP_MKDIR(sec_path, S_IRWXU));
     assert_int_equal(RNP_SUCCESS, rnp_output_to_path(&output, sec_path));
     assert_int_equal(RNP_SUCCESS,
                      rnp_save_keys(ffi, "G10", output, RNP_LOAD_SAVE_SECRET_KEYS));

--- a/src/tests/generatekey.cpp
+++ b/src/tests/generatekey.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "rnp.h"
+#include <time.h>
 #include <rekey/rnp_key_store.h>
 #include <rnp/rnpcfg.h>
 #include <rnpkeys/rnpkeys.h>
@@ -558,10 +559,15 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg_t *ops, const char *rsp)
     int       pipefd[2] = {0};
     int       user_input_pipefd[2] = {0};
     size_t    rsp_len;
+    int       pipe_result = -1;
 
     rsp_len = strlen(rsp);
     memset(ctx, 0, sizeof(*ctx));
-    if (pipe(pipefd) == -1) {
+#ifndef _WIN32
+    // TODO: Implement code for Windows, possibly using CreatePipe
+    pipe_result = pipe(pipefd);
+#endif
+    if (pipe_result == -1) {
         ret = false;
         goto end;
     }
@@ -572,7 +578,11 @@ ask_expert_details(cli_rnp_t *ctx, rnp_cfg_t *ops, const char *rsp)
     }
 
     /* Write response to fd */
-    if (pipe(user_input_pipefd) == -1) {
+#ifndef _WIN32
+    // TODO: Implement code for Windows, possibly using CreatePipe
+    pipe_result = pipe(user_input_pipefd);
+#endif
+    if (pipe_result == -1) {
         ret = false;
         goto end;
     }

--- a/src/tests/load-pgp.cpp
+++ b/src/tests/load-pgp.cpp
@@ -31,6 +31,7 @@
 
 #include "rnp_tests.h"
 #include "support.h"
+#include "utils.h"
 
 /* This test loads a .gpg pubring with a single V3 key,
  * and confirms that appropriate key flags are set.
@@ -820,7 +821,7 @@ test_key_import(void **state)
     pgp_transferable_subkey_t *tskey = NULL;
     pgp_transferable_userid_t *tuid = NULL;
 
-    assert_int_equal(mkdir(".rnp", S_IRWXU), 0);
+    assert_int_equal(RNP_MKDIR(".rnp", S_IRWXU), 0);
     assert_true(setup_rnp_common(&rnp, RNP_KEYSTORE_GPG, ".rnp", NULL));
 
     /* import just the public key */

--- a/src/tests/rnp_tests.cpp
+++ b/src/tests/rnp_tests.cpp
@@ -42,9 +42,14 @@ rng_t global_rng;
 static char *
 get_data_dir(void)
 {
+#ifdef _WIN32
+    // TODO: realpath unavailable on Windows, maybe use GetFullPathName?
+    return NULL;
+#else
     char data_dir[PATH_MAX];
     paths_concat(data_dir, sizeof(data_dir), original_dir, "data", NULL);
     return realpath(data_dir, NULL);
+#endif
 }
 
 static int
@@ -93,7 +98,12 @@ setup_test(void **state)
     } else {
         rstate->not_fatal = 0;
     }
+#ifndef _WIN32
     assert_int_equal(0, setenv("HOME", rstate->home, 1));
+#else
+    // TODO: use alternative for setenv on Windows
+    assert_int_equal(0, 1);
+#endif
     assert_int_equal(0, chdir(rstate->home));
     char *src_data = get_data_dir();
     if (!src_data) {
@@ -126,7 +136,12 @@ main(int argc, char *argv[])
      * and it isn't always set in every environment.
      */
     if (!getenv("LOGNAME")) {
+#ifndef _WIN32
         setenv("LOGNAME", "test-user", 1);
+#else
+    // TODO: use alternative for setenv on Windows
+    return -1;
+#endif
     }
     int iteration = 1;
     if (getenv("RNP_TEST_ITERATIONS")) {

--- a/src/tests/streams.cpp
+++ b/src/tests/streams.cpp
@@ -131,7 +131,7 @@ test_stream_file(void **state)
     assert_rnp_failure(init_file_src(&src, filename));
     assert_rnp_failure(init_file_src(&src, dirname));
     /* create dir */
-    assert_int_equal(mkdir(dirname, S_IRWXU), 0);
+    assert_int_equal(RNP_MKDIR(dirname, S_IRWXU), 0);
     /* attempt to read or create file in place of directory */
     assert_rnp_failure(init_file_src(&src, dirname));
     assert_rnp_failure(init_file_dest(&dst, dirname, false));
@@ -140,7 +140,7 @@ test_stream_file(void **state)
     assert_int_equal(file_size(dirname), 0);
     dst_close(&dst, true);
     /* create dir back */
-    assert_int_equal(mkdir(dirname, S_IRWXU), 0);
+    assert_int_equal(RNP_MKDIR(dirname, S_IRWXU), 0);
 
     /* write some data to the file and the discard it */
     assert_rnp_success(init_file_dest(&dst, filename, false));

--- a/src/tests/support.cpp
+++ b/src/tests/support.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "support.h"
+#include "utils.h"
 
 #include <sys/types.h>
 #include <sys/param.h>
@@ -187,7 +188,7 @@ path_mkdir(mode_t mode, const char *first, ...)
     vpaths_concat(buffer, sizeof(buffer), first, ap);
     va_end(ap);
 
-    assert_int_equal(0, mkdir(buffer, mode));
+    assert_int_equal(0, RNP_MKDIR(buffer, mode));
 }
 
 static int
@@ -232,6 +233,7 @@ copy_recursively(const char *src, const char *dst)
 char *
 make_temp_dir()
 {
+#ifndef _WIN32
     const char *tmplate = "/tmp/rnp-cmocka-XXXXXX";
     char *      buffer = (char *) calloc(1, strlen(tmplate) + 1);
     if (buffer == NULL) {
@@ -239,11 +241,16 @@ make_temp_dir()
     }
     strncpy(buffer, tmplate, strlen(tmplate));
     return mkdtemp(buffer);
+#else
+    // TODO: Use alternative for mkdtemp on Windows
+    return NULL;
+#endif
 }
 
 static char *
 directory_from_absolute_file_path(const char *file_path)
 {
+#ifndef _WIN32
     const char *last_sep = strrchr(file_path, '/');
     if (!last_sep) {
         return NULL;
@@ -261,11 +268,16 @@ directory_from_absolute_file_path(const char *file_path)
     free(dir);
     dir = NULL;
     return full_dir;
+#else
+    // TODO: realpath unavailable on Windows, maybe use GetFullPathName?
+    return NULL;
+#endif
 }
 
 static char *
 directory_from_relative_file_path(const char *file_path, const char *reldir)
 {
+#ifndef _WIN32
     const char *last_sep = strrchr(file_path, '/');
     if (!last_sep) {
         return NULL;
@@ -286,6 +298,10 @@ directory_from_relative_file_path(const char *file_path, const char *reldir)
     free(dir);
     dir = NULL;
     return full_dir;
+#else
+    // TODO: realpath unavailable on Windows, maybe use GetFullPathName?
+    return NULL;
+#endif
 }
 
 char *
@@ -411,8 +427,14 @@ bool
 setupPasswordfd(int *pipefd)
 {
     bool ok = false;
+    int result = -1;
 
-    if (pipe(pipefd) == -1) {
+#ifndef _WIN32
+    // TODO: Implement code for Windows, possibly using CreatePipe
+    result = pipe(pipefd);
+#endif
+
+    if (result == -1) {
         perror("pipe");
         goto end;
     }


### PR DESCRIPTION
I haven't yet tried to run the tests on Windows. As seen in TODO comments (see also #ifdef) there are several places that use code that isn't available on Windows, and need some new platform specific code.
This is just a starting point.
