### PR TITLE
Fix 895

### DIFF
--- a/src/rnp/rnpcli.h
+++ b/src/rnp/rnpcli.h
@@ -49,7 +49,6 @@ typedef struct rnp_t {
     rnp_key_store_t *pubring;       /* public key ring */
     rnp_key_store_t *secring;       /* s3kr1t key ring */
     FILE *           resfp;         /* where to put result messages, defaults to stdout */
-    FILE *           user_input_fp; /* file pointer for user input */
     FILE *           passfp;        /* file pointer for password input */
     char *           defkey;        /* default key id */
     int              pswdtries;     /* number of password tries, -1 for unlimited */


### PR DESCRIPTION
This was a little tricky to track down. I can think of 3 or 4 different ways to fix this, so I'm certainly open to other options.

1. In `ask_expert_details` we create a pipe and set the read side as the `CFG_USERINPUTFD` option, then execute an rnp command:
https://github.com/riboseinc/rnp/blob/b309f51c92eb4a1e2b39eb421a8377d423509ca6/src/tests/generatekey.cpp#L585-L587

2. That leads us to:
https://github.com/riboseinc/rnp/blob/b309f51c92eb4a1e2b39eb421a8377d423509ca6/src/rnpkeys/rnpkeys.cpp#L255-L259

3. Which calls `cli_rnp_set_generate_params`:
https://github.com/riboseinc/rnp/blob/b309f51c92eb4a1e2b39eb421a8377d423509ca6/src/rnp/fficli.cpp#L622

4. In which we finally use this fd via `fdopen`:
https://github.com/riboseinc/rnp/blob/b309f51c92eb4a1e2b39eb421a8377d423509ca6/src/rnpkeys/tui.cpp#L225

5. And where we also close this fd (note that `fdopen` does not dupe the descriptor, so this effectively calls `close` on the fd too):
https://github.com/riboseinc/rnp/blob/b309f51c92eb4a1e2b39eb421a8377d423509ca6/src/rnpkeys/tui.cpp#L229

6. After which, we finally actually generate a key. During this time, we instantiate Botan's `System_RNG`. Depending on how botan was configured, this may use the implementation that opens `/dev/urandom`. This will likely reuse the same fd that we just closed above, since it's now free.

7. But then we close it again:
https://github.com/riboseinc/rnp/blob/b309f51c92eb4a1e2b39eb421a8377d423509ca6/src/tests/generatekey.cpp#L597

After this point, the botan RNG in `rnp->ffi->rng` holds an invalid fd. Later on, it may even point to some other file, etc.

Now it's clear why configuring botan with `--with-os-feature=getrandom` makes the issue go away. With a bit more work you can also see why re-enabling certain other tests would make the issue go away too (because another test was instantiating Botan's global `g_system_rng` before we were in that special window between 5 & 7 above). Either way we were always double closing some fds here.